### PR TITLE
Integrate CADIS track branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format follows Keep a Changelog style, and the project will use Semantic Ver
 - Desktop MVP runtime with `cadisd`, `cadis`, Unix socket NDJSON frames, status/chat/doctor commands, optional Ollama model adapter, local fallback responses, JSONL event logs, and redaction.
 - Native `cadis-hud` prototype with orbital HUD shell, status bar, chat command panel, config tabs, theme controls, model controls, voice preview hooks, rename dialog, and approval stack UI.
 - Example desktop MVP config at `config/cadis.example.toml`.
+- Agent Runtime baseline with daemon-owned `AgentSession` lifecycle events, per-route timeout and step-budget metadata, cancellation metadata, and explicit `/worker` or `/spawn` orchestration through core spawn limits.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format follows Keep a Changelog style, and the project will use Semantic Ver
 - Desktop MVP runtime with `cadisd`, `cadis`, Unix socket NDJSON frames, status/chat/doctor commands, optional Ollama model adapter, local fallback responses, JSONL event logs, and redaction.
 - Native `cadis-hud` prototype with orbital HUD shell, status bar, chat command panel, config tabs, theme controls, model controls, voice preview hooks, rename dialog, and approval stack UI.
 - Example desktop MVP config at `config/cadis.example.toml`.
+- Daemon Unix socket integration coverage for live `session.subscribe` fan-out to
+  two clients while status and agent-list requests remain responsive during
+  paused message generation.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ The repository already includes a meaningful desktop MVP foundation:
 - `cadisd`: local daemon and protocol authority
 - `cadis`: CLI client for status, models, agents, spawn, chat, tools, and doctor checks
 - `apps/cadis-hud`: Tauri + React HUD prototype
-- `crates/cadis-avatar`: renderer-neutral Wulan avatar state engine contract
+- `crates/cadis-avatar`: renderer-neutral Wulan avatar state engine contract,
+  with a feature-gated adapter-ready wgpu render-plan spike
 - typed protocol events for messages, models, agents, approvals, workspaces, orchestrator routing, and workers
 - JSONL event persistence with redaction boundaries
 - profile-local workspace registry and grants for safe-read tools

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The repository already includes a meaningful desktop MVP foundation:
 - `crates/cadis-avatar`: renderer-neutral Wulan avatar state engine contract
 - typed protocol events for messages, models, agents, approvals, workspaces, orchestrator routing, and workers
 - JSONL event persistence with redaction boundaries
-- profile-local workspace registry and grants for safe-read tools
+- profile-local agent homes, workspace registry, and grants for safe-read tools
 - optional Ollama, OpenAI API, and Codex CLI model adapters
 - official Codex CLI adapter for ChatGPT Plus/Pro login flows
 - HUD-local Edge TTS playback, `whisper-cli` voice input, and voice doctor preflight
@@ -81,8 +81,9 @@ The repository already includes a meaningful desktop MVP foundation:
 Planned work still includes production-grade mutating tool execution, full
 policy coverage, richer worker isolation, Telegram/mobile clients,
 daemon-owned production voice, and code work windows. The workspace
-architecture is partially implemented; persistent agent homes, real worker
-worktree creation, checkpoint rollback, and project media manifests remain next.
+architecture is partially implemented; real worker worktree creation,
+checkpoint rollback, dedicated profile/agent doctor commands, and project media
+manifests remain next.
 
 ## Core capabilities
 

--- a/apps/cadis-hud/README.md
+++ b/apps/cadis-hud/README.md
@@ -76,6 +76,12 @@ pnpm build
 cargo check --manifest-path src-tauri/Cargo.toml --locked
 ```
 
+The Track A live-progress acceptance fixture is
+`src/ui/hudLiveProgress.acceptance.test.tsx`. It renders the chat panel and
+orbital HUD from mock daemon frames and verifies that `session.started`,
+`orchestrator.route`, `agent.status.changed`, and `message.delta` are visible
+before `message.completed`.
+
 No credentials are stored in this app. ChatGPT Plus/Pro access is delegated to
 the official Codex CLI login used by `cadisd` when the model provider is
 `codex-cli`. OpenAI API access uses environment variables handled by the daemon.

--- a/apps/cadis-hud/src/styles/globals.css
+++ b/apps/cadis-hud/src/styles/globals.css
@@ -1734,16 +1734,43 @@ html, body, #root {
 .worker-tree__list { list-style: none; padding: 4px 0 0 14px; margin: 0; }
 .worker-tree__item {
   display: grid;
-  grid-template-columns: 8px auto auto 1fr;
+  grid-template-columns: 8px minmax(68px, auto) auto minmax(0, 1fr) 42px;
   gap: 6px;
   align-items: center;
   padding: 2px 0;
   color: var(--dim);
 }
 .worker-tree__dot { width: 6px; height: 6px; border-radius: 50%; }
-.worker-tree__id { color: var(--text); }
+.worker-tree__id { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .worker-tree__status { color: var(--faint); text-transform: uppercase; font-size: 9px; }
 .worker-tree__text { color: var(--faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.worker-tree__item--session .worker-tree__id { color: var(--accent); }
+.worker-tree__progress {
+  position: relative;
+  display: block;
+  width: 42px;
+  height: 4px;
+  overflow: hidden;
+  border-radius: 2px;
+  background: oklch(0.12 0.025 var(--hue) / 0.72);
+  border: 1px solid oklch(0.32 0.06 var(--hue) / 0.38);
+}
+.worker-tree__progress span {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--accent);
+  opacity: 0.82;
+  transition: width 160ms ease;
+}
+.worker-tree__progress--active span {
+  background: linear-gradient(90deg, var(--accent-d), var(--ok), var(--accent-d));
+  animation: worker-progress-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes worker-progress-pulse {
+  0%, 100% { opacity: 0.46; }
+  50% { opacity: 0.95; }
+}
 
 /* ─── Theme picker (P5.6) ─── */
 

--- a/apps/cadis-hud/src/ui/cadisActions.test.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.test.ts
@@ -1,4 +1,7 @@
+import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createElement } from "react";
 import {
   _resetCadisActionsForTest,
   _emitCadisSubscriptionFrameForTest,
@@ -8,6 +11,8 @@ import {
   sendUserMessage,
 } from "./cadisActions.js";
 import { useHud } from "./hudState.js";
+import { WorkerTree } from "./orbital/WorkerTree.js";
+import { mockCadisDaemonWorkerStream } from "./fixtures/mockCadisDaemonEventStream.js";
 
 const invokeMock = vi.hoisted(() => vi.fn());
 const listenMock = vi.hoisted(() => vi.fn());
@@ -36,6 +41,7 @@ beforeEach(() => {
     agentModels: INITIAL_AGENT_MODELS,
     availableModels: INITIAL_AVAILABLE_MODELS,
     defaultModel: INITIAL_DEFAULT_MODEL,
+    agentSessions: [],
     chat: [],
     approvals: [],
     workers: [],
@@ -267,8 +273,53 @@ describe("cadisActions", () => {
         status: "completed",
         lastText: "tests passed",
         summary: "tests passed",
+        logLineCount: 1,
+        logTail: ["running tests"],
       },
     ]);
+  });
+
+  it("renders worker progress from a mock daemon event stream", () => {
+    for (const frame of mockCadisDaemonWorkerStream) {
+      handleCadisFrameForTest(frame);
+    }
+
+    const state = useHud.getState();
+    expect(state.agentSessions).toMatchObject([
+      {
+        id: "ags_mock_001",
+        agentId: "codex",
+        status: "completed",
+        stepsUsed: 3,
+        budgetSteps: 3,
+        result: "focused HUD worker tests passed",
+      },
+    ]);
+    expect(state.workers).toMatchObject([
+      {
+        id: "worker_mock_001",
+        agentId: "codex",
+        parentAgentId: "main",
+        status: "completed",
+        summary: "completed: focused HUD worker tests passed",
+        logLineCount: 1,
+        worktree: {
+          state: "planned",
+          branchName: "cadis/worker_mock_001/hud-worker-progress",
+        },
+        artifacts: {
+          summary: "/home/user/.cadis/artifacts/workers/worker_mock_001/summary.md",
+          testReport: "/home/user/.cadis/artifacts/workers/worker_mock_001/test-report.json",
+        },
+      },
+    ]);
+
+    render(createElement(WorkerTree, { agentId: "codex" }));
+
+    expect(screen.getByText(/workers · 1/)).toBeInTheDocument();
+    expect(screen.getByText("ags_mock_001")).toBeInTheDocument();
+    expect(screen.getByText("worker_mock_001")).toBeInTheDocument();
+    expect(screen.getByText(/focused HUD worker tests passed/)).toBeInTheDocument();
   });
 
   it("computes bounded reconnect backoff", () => {

--- a/apps/cadis-hud/src/ui/cadisActions.test.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.test.ts
@@ -6,6 +6,7 @@ import {
   connect,
   handleCadisFrameForTest,
   sendUserMessage,
+  sendVoicePreflight,
 } from "./cadisActions.js";
 import { useHud } from "./hudState.js";
 
@@ -39,6 +40,8 @@ beforeEach(() => {
     chat: [],
     approvals: [],
     workers: [],
+    voiceStatus: null,
+    voiceDoctor: null,
     gateway: "disconnected",
   });
 });
@@ -102,7 +105,7 @@ describe("cadisActions", () => {
       },
     });
     connect();
-    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(4));
     invokeMock.mockClear();
 
     expect(sendUserMessage("@Builder run tests")).toBe(true);
@@ -118,7 +121,7 @@ describe("cadisActions", () => {
 
   it("resolves leading @mentions by agent role before sending target_agent_id", async () => {
     connect();
-    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(4));
     useHud.setState({
       agents: [
         ...useHud.getState().agents,
@@ -269,6 +272,73 @@ describe("cadisActions", () => {
         summary: "tests passed",
       },
     ]);
+  });
+
+  it("records daemon-visible voice status and doctor checks", () => {
+    handleCadisFrameForTest({
+      frame: "event",
+      payload: {
+        type: "voice.doctor.response",
+        payload: {
+          status: {
+            enabled: true,
+            state: "degraded",
+            provider: "edge",
+            voice_id: "id-ID-GadisNeural",
+            stt_language: "auto",
+            max_spoken_chars: 800,
+            bridge: "hud-local",
+            last_preflight: {
+              surface: "cadis-hud",
+              status: "warn",
+              summary: "1 warning",
+              checked_at: "2026-04-26T00:00:00Z",
+            },
+          },
+          checks: [
+            { name: "voice.provider", status: "ok", message: "configured provider edge" },
+            { name: "microphone", status: "warn", message: "permission pending" },
+          ],
+        },
+      },
+    });
+
+    expect(useHud.getState().voiceStatus).toMatchObject({
+      enabled: true,
+      state: "degraded",
+      provider: "edge",
+      lastPreflight: { surface: "cadis-hud", summary: "1 warning" },
+    });
+    expect(useHud.getState().voiceDoctor).toMatchObject({
+      summary: "1 warning",
+      checks: [
+        { name: "voice.provider", status: "pass", detail: "configured provider edge" },
+        { name: "microphone", status: "warn", detail: "permission pending" },
+      ],
+    });
+  });
+
+  it("publishes HUD bridge preflight checks to the daemon", async () => {
+    connect();
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(4));
+    invokeMock.mockClear();
+
+    expect(
+      sendVoicePreflight({
+        summary: "ready",
+        checks: [{ name: "microphone", status: "pass", detail: "1 input visible" }],
+      }),
+    ).toBe(true);
+
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(1));
+    expect(sentRequest()).toMatchObject({
+      type: "voice.preflight",
+      payload: {
+        surface: "cadis-hud",
+        summary: "ready",
+        checks: [{ name: "microphone", status: "ok", message: "1 input visible" }],
+      },
+    });
   });
 
   it("computes bounded reconnect backoff", () => {

--- a/apps/cadis-hud/src/ui/cadisActions.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.ts
@@ -7,8 +7,13 @@ import {
   useHud,
   type AvatarStyle,
   type AgentLive,
+  type AgentSessionRecord,
+  type AgentSessionStatus,
   type ThemeKey,
+  type WorkerArtifactInfo,
+  type WorkerRecord,
   type WorkerStatus,
+  type WorkerWorktreeInfo,
 } from "./hudState.js";
 import { AGENT_ROSTER } from "../lib/agents-roster.js";
 import type { VoicePrefs } from "../lib/voice/voices.js";
@@ -342,7 +347,7 @@ function handleMessage(type: string, payload: unknown, sessionId?: string): void
     handleRequestRejected(payload);
     return;
   }
-  if (type === "daemon.status.response") {
+  if (type === "daemon.status.response" || type === "daemon.status") {
     handleDaemonStatus(payload);
     return;
   }
@@ -382,6 +387,16 @@ function handleMessage(type: string, payload: unknown, sessionId?: string): void
     handleAgentStatusChanged(payload);
     return;
   }
+  if (
+    type === "agent.session.started" ||
+    type === "agent.session.updated" ||
+    type === "agent.session.completed" ||
+    type === "agent.session.failed" ||
+    type === "agent.session.cancelled"
+  ) {
+    handleAgentSessionEvent(type, payload, sessionId);
+    return;
+  }
   if (type === "approval.requested") {
     handleApprovalRequested(payload);
     return;
@@ -398,6 +413,8 @@ function handleMessage(type: string, payload: unknown, sessionId?: string): void
     type === "worker.started" ||
     type === "worker.log.delta" ||
     type === "worker.completed" ||
+    type === "worker.failed" ||
+    type === "worker.cancelled" ||
     type === "worker.event"
   ) {
     handleWorkerEvent(type, payload);
@@ -553,6 +570,49 @@ function handleAgentStatusChanged(payload: unknown): void {
   }
 }
 
+function handleAgentSessionEvent(type: string, payload: unknown, sessionId?: string): void {
+  const p = asRecord(payload);
+  const sessionRecordId = stringFrom(p.agent_session_id) ?? stringFrom(p.id);
+  const agentId = stringFrom(p.agent_id);
+  if (!sessionRecordId || !agentId) return;
+
+  const existing = useHud
+    .getState()
+    .agentSessions.find((candidate) => candidate.id === sessionRecordId);
+  const status =
+    normalizeAgentSessionStatus(stringFrom(p.status)) ?? defaultAgentSessionStatus(type);
+  const task = stringFrom(p.task) ?? existing?.task ?? "agent session";
+  const budgetSteps = numberFrom(p.budget_steps) ?? existing?.budgetSteps ?? 0;
+  const stepsUsed = numberFrom(p.steps_used) ?? existing?.stepsUsed ?? 0;
+  const result = stringFrom(p.result);
+  const error = stringFrom(p.error) ?? stringFrom(p.error_code);
+  const parentAgentId = stringFrom(p.parent_agent_id) ?? existing?.parentAgentId;
+
+  ensureKnownAgent(agentId);
+  useHud.getState().upsertAgentSession({
+    id: sessionRecordId,
+    sessionId: stringFrom(p.session_id) ?? sessionId ?? existing?.sessionId ?? "main",
+    routeId: stringFrom(p.route_id) ?? existing?.routeId ?? "",
+    agentId,
+    parentAgentId,
+    task,
+    status,
+    timeoutAt: stringFrom(p.timeout_at) ?? existing?.timeoutAt,
+    budgetSteps,
+    stepsUsed,
+    result,
+    error,
+    updatedAt: Date.now(),
+  });
+
+  useHud.getState().setAgentStatus(agentId, agentStatusFromSession(status));
+  useHud.getState().setAgentTask(agentId, {
+    verb: agentTaskVerbFromSession(status),
+    target: task,
+    detail: agentSessionDetail({ status, budgetSteps, stepsUsed, result, error }),
+  });
+}
+
 function handleApprovalRequested(payload: unknown): void {
   const p = asRecord(payload);
   const approvalId = stringFrom(p.approval_id) ?? stringFrom(p.id);
@@ -605,15 +665,23 @@ function handleWorkerEvent(type: string, payload: unknown): void {
   const status = normalizeWorkerStatus(stringFrom(p.status)) ?? defaultWorkerStatus(type);
   const summary = stringFrom(p.summary);
   const delta = stringFrom(p.delta);
+  const text = delta ?? summary ?? stringFrom(p.text) ?? existing?.lastText;
+  const logTail = nextWorkerLogTail(existing, delta);
+  const logLineCount = existing ? existing.logLineCount + (delta ? 1 : 0) : delta ? 1 : 0;
+  ensureKnownAgent(parentAgentId);
   useHud.getState().upsertWorker({
     id: workerId,
-    agentId,
+    agentId: agentId ?? existing?.agentId,
     parentAgentId,
-    cli: stringFrom(p.cli),
-    cwd: stringFrom(p.cwd),
+    cli: stringFrom(p.cli) ?? existing?.cli,
+    cwd: stringFrom(p.cwd) ?? existing?.cwd,
     status,
-    lastText: delta ?? summary ?? stringFrom(p.text),
-    summary,
+    lastText: text,
+    summary: summary ?? existing?.summary,
+    logLineCount,
+    logTail,
+    worktree: readWorkerWorktree(p.worktree) ?? existing?.worktree,
+    artifacts: readWorkerArtifacts(p.artifacts) ?? existing?.artifacts,
     startedAt: numberFrom(p.started_at) ?? existing?.startedAt ?? Date.now(),
     updatedAt: numberFrom(p.updated_at) ?? Date.now(),
   });
@@ -747,14 +815,36 @@ function joinModel(provider: string, model: string): string {
   return cleanModel.includes("/") ? cleanModel : `${cleanProvider}/${cleanModel}`;
 }
 
-function normalizeAgentStatus(status: string | undefined): "working" | "idle" | "waiting" | null {
+function normalizeAgentStatus(status: string | undefined): AgentLive["status"] | null {
   if (!status) return null;
   const normalized = status.toLowerCase();
+  if (normalized === "spawning" || normalized === "starting" || normalized === "started") {
+    return "waiting";
+  }
   if (normalized === "running" || normalized === "working") return "working";
   if (normalized === "waitingapproval" || normalized === "waiting_approval" || normalized === "waiting") {
     return "waiting";
   }
-  if (normalized === "idle" || normalized === "completed" || normalized === "failed") return "idle";
+  if (normalized === "idle" || normalized === "completed") return "idle";
+  if (normalized === "failed" || normalized === "error" || normalized === "timed_out") return "idle";
+  if (normalized === "cancelled" || normalized === "canceled") return "idle";
+  return null;
+}
+
+function normalizeAgentSessionStatus(status: string | undefined): AgentSessionStatus | null {
+  if (!status) return null;
+  const normalized = status.toLowerCase();
+  if (normalized === "started" || normalized === "starting") return "started";
+  if (normalized === "running" || normalized === "working") return "running";
+  if (normalized === "completed" || normalized === "complete" || normalized === "succeeded") {
+    return "completed";
+  }
+  if (normalized === "failed" || normalized === "error") return "failed";
+  if (normalized === "cancelled" || normalized === "canceled") return "cancelled";
+  if (normalized === "timed_out" || normalized === "timeout") return "timed_out";
+  if (normalized === "budget_exceeded" || normalized === "budgetexceeded") {
+    return "budget_exceeded";
+  }
   return null;
 }
 
@@ -776,7 +866,70 @@ function normalizeWorkerStatus(status: string | undefined): WorkerStatus | null 
 function defaultWorkerStatus(type: string): WorkerStatus {
   if (type === "worker.started") return "spawning";
   if (type === "worker.completed") return "completed";
+  if (type === "worker.failed") return "failed";
+  if (type === "worker.cancelled") return "cancelled";
   return "running";
+}
+
+function defaultAgentSessionStatus(type: string): AgentSessionStatus {
+  if (type === "agent.session.started") return "started";
+  if (type === "agent.session.completed") return "completed";
+  if (type === "agent.session.failed") return "failed";
+  if (type === "agent.session.cancelled") return "cancelled";
+  return "running";
+}
+
+function agentStatusFromSession(status: AgentSessionStatus): AgentLive["status"] {
+  if (status === "started" || status === "running") return "working";
+  if (status === "failed" || status === "timed_out" || status === "budget_exceeded") return "idle";
+  if (status === "cancelled") return "idle";
+  return "idle";
+}
+
+function agentTaskVerbFromSession(status: AgentSessionStatus): string {
+  if (status === "completed") return "completed";
+  if (status === "failed" || status === "timed_out" || status === "budget_exceeded") return "failed";
+  if (status === "cancelled") return "cancelled";
+  return "working";
+}
+
+function agentSessionDetail({
+  status,
+  budgetSteps,
+  stepsUsed,
+  result,
+  error,
+}: Pick<AgentSessionRecord, "status" | "budgetSteps" | "stepsUsed" | "result" | "error">): string {
+  if (status === "completed" && result) return result;
+  if ((status === "failed" || status === "timed_out" || status === "budget_exceeded") && error) {
+    return error;
+  }
+  if (budgetSteps > 0) return `step ${Math.min(stepsUsed, budgetSteps)}/${budgetSteps}`;
+  return status.replace("_", " ");
+}
+
+function nextWorkerLogTail(existing: WorkerRecord | undefined, delta: string | undefined): string[] {
+  if (!delta) return existing?.logTail ?? [];
+  return [...(existing?.logTail ?? []), delta].slice(-3);
+}
+
+function readWorkerWorktree(value: unknown): WorkerWorktreeInfo | undefined {
+  const worktree = asRecord(value);
+  const state = stringFrom(worktree.state);
+  const branchName = stringFrom(worktree.branch_name);
+  const worktreePath = stringFrom(worktree.worktree_path);
+  const cleanupPolicy = stringFrom(worktree.cleanup_policy);
+  if (!state && !branchName && !worktreePath && !cleanupPolicy) return undefined;
+  return { state, branchName, worktreePath, cleanupPolicy };
+}
+
+function readWorkerArtifacts(value: unknown): WorkerArtifactInfo | undefined {
+  const artifacts = asRecord(value);
+  const summary = stringFrom(artifacts.summary);
+  const patch = stringFrom(artifacts.patch);
+  const testReport = stringFrom(artifacts.test_report);
+  if (!summary && !patch && !testReport) return undefined;
+  return { summary, patch, testReport };
 }
 
 function readSessionId(envelope: CadisEnvelope): string | undefined {

--- a/apps/cadis-hud/src/ui/cadisActions.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.ts
@@ -8,6 +8,9 @@ import {
   type AvatarStyle,
   type AgentLive,
   type ThemeKey,
+  type VoiceDaemonStatus,
+  type VoiceDiagnosticCheck,
+  type VoiceDoctorReport,
   type WorkerStatus,
 } from "./hudState.js";
 import { AGENT_ROSTER } from "../lib/agents-roster.js";
@@ -84,6 +87,7 @@ export function connect(): void {
     await Promise.all([
       callCadis("models.list", {}, activeGeneration),
       callCadis("daemon.status", {}, activeGeneration),
+      callCadis("voice.status", {}, activeGeneration),
     ]);
   })();
 }
@@ -189,6 +193,30 @@ export function persistVoicePreferences(prefs: VoicePrefs): void {
 
 export function persistChatPreferences(prefs: { thinking: boolean; fast: boolean }): void {
   sendUiPreferencesPatch({ chat: prefs });
+}
+
+export function requestVoiceDoctor(): boolean {
+  if (!connected) return false;
+  void callCadis("voice.doctor", { include_bridge: true }).then((ok) => {
+    if (!ok) scheduleReconnect();
+  });
+  return true;
+}
+
+export function sendVoicePreflight(report: VoiceDoctorReport, surface = "cadis-hud"): boolean {
+  if (!connected) return false;
+  void callCadis("voice.preflight", {
+    surface,
+    summary: report.summary,
+    checks: report.checks.map((check) => ({
+      name: check.name,
+      status: protocolVoiceCheckStatus(check.status),
+      message: check.detail,
+    })),
+  }).then((ok) => {
+    if (!ok) scheduleReconnect();
+  });
+  return true;
 }
 
 export function _resetCadisActionsForTest(): void {
@@ -354,6 +382,14 @@ function handleMessage(type: string, payload: unknown, sessionId?: string): void
     handlePreferences(payload);
     return;
   }
+  if (type === "voice.status.updated") {
+    handleVoiceStatus(payload);
+    return;
+  }
+  if (type === "voice.doctor.response" || type === "voice.preflight.response") {
+    handleVoiceDoctor(payload);
+    return;
+  }
   if (type === "message.delta") {
     handleMessageDelta(payload, sessionId);
     return;
@@ -460,6 +496,27 @@ function handlePreferences(payload: unknown): void {
   if (typeof chat.thinking === "boolean") chatPatch.thinking = chat.thinking;
   if (typeof chat.fast === "boolean") chatPatch.fast = chat.fast;
   if (Object.keys(chatPatch).length) useHud.getState().setChatPreferences(chatPatch);
+}
+
+function handleVoiceStatus(payload: unknown): void {
+  const status = normalizeVoiceStatus(payload);
+  if (status) useHud.getState().setVoiceStatus(status);
+}
+
+function handleVoiceDoctor(payload: unknown): void {
+  const p = asRecord(payload);
+  const status = normalizeVoiceStatus(p.status);
+  if (status) useHud.getState().setVoiceStatus(status);
+
+  const checks = Array.isArray(p.checks)
+    ? p.checks
+        .map(normalizeVoiceCheck)
+        .filter((check): check is VoiceDiagnosticCheck => Boolean(check))
+    : [];
+  useHud.getState().setVoiceDoctor({
+    summary: voiceDoctorSummary(checks),
+    checks,
+  });
 }
 
 function handleMessageDelta(payload: unknown, sessionId?: string): void {
@@ -771,6 +828,86 @@ function normalizeWorkerStatus(status: string | undefined): WorkerStatus | null 
   if (normalized === "failed" || normalized === "error") return "failed";
   if (normalized === "cancelled" || normalized === "canceled") return "cancelled";
   return null;
+}
+
+function normalizeVoiceStatus(payload: unknown): VoiceDaemonStatus | null {
+  const p = asRecord(payload);
+  const provider = stringFrom(p.provider) ?? "edge";
+  const voiceId = stringFrom(p.voice_id) ?? "id-ID-GadisNeural";
+  const sttLanguage = stringFrom(p.stt_language) ?? "auto";
+  const maxSpokenChars = numberFrom(p.max_spoken_chars) ?? 800;
+  const bridge = stringFrom(p.bridge) ?? "hud-local";
+  const state = normalizeVoiceState(stringFrom(p.state));
+  const lastPreflight = asRecord(p.last_preflight);
+  const surface = stringFrom(lastPreflight.surface);
+  const checkedAt = stringFrom(lastPreflight.checked_at);
+  const summary = stringFrom(lastPreflight.summary);
+  const preflightStatus = stringFrom(lastPreflight.status);
+
+  return {
+    enabled: p.enabled === true,
+    state,
+    provider,
+    voiceId,
+    sttLanguage,
+    maxSpokenChars,
+    bridge,
+    ...(surface && checkedAt && summary && preflightStatus
+      ? {
+          lastPreflight: {
+            surface,
+            checkedAt,
+            summary,
+            status: preflightStatus,
+          },
+        }
+      : {}),
+  };
+}
+
+function normalizeVoiceState(state: string | undefined): VoiceDaemonStatus["state"] {
+  if (
+    state === "disabled" ||
+    state === "ready" ||
+    state === "degraded" ||
+    state === "blocked" ||
+    state === "unknown"
+  ) {
+    return state;
+  }
+  return "unknown";
+}
+
+function normalizeVoiceCheck(value: unknown): VoiceDiagnosticCheck | null {
+  const p = asRecord(value);
+  const name = stringFrom(p.name);
+  if (!name) return null;
+  return {
+    name,
+    status: hudVoiceCheckStatus(stringFrom(p.status)),
+    detail: stringFrom(p.message) ?? stringFrom(p.detail) ?? "",
+  };
+}
+
+function hudVoiceCheckStatus(status: string | undefined): VoiceDiagnosticCheck["status"] {
+  const normalized = status?.toLowerCase();
+  if (normalized === "ok" || normalized === "pass" || normalized === "ready") return "pass";
+  if (normalized === "error" || normalized === "fail" || normalized === "blocked") return "fail";
+  return "warn";
+}
+
+function protocolVoiceCheckStatus(status: VoiceDiagnosticCheck["status"]): string {
+  if (status === "pass") return "ok";
+  if (status === "fail") return "error";
+  return "warn";
+}
+
+function voiceDoctorSummary(checks: VoiceDiagnosticCheck[]): string {
+  const failures = checks.filter((check) => check.status === "fail").length;
+  const warnings = checks.filter((check) => check.status === "warn").length;
+  if (failures) return `${failures} blocking issue${failures === 1 ? "" : "s"}`;
+  if (warnings) return `${warnings} warning${warnings === 1 ? "" : "s"}`;
+  return checks.length ? "ready" : "not run";
 }
 
 function defaultWorkerStatus(type: string): WorkerStatus {

--- a/apps/cadis-hud/src/ui/cadisActions.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.ts
@@ -354,6 +354,10 @@ function handleMessage(type: string, payload: unknown, sessionId?: string): void
     handlePreferences(payload);
     return;
   }
+  if (type === "session.started") {
+    handleSessionStarted(payload, sessionId);
+    return;
+  }
   if (type === "message.delta") {
     handleMessageDelta(payload, sessionId);
     return;
@@ -460,6 +464,21 @@ function handlePreferences(payload: unknown): void {
   if (typeof chat.thinking === "boolean") chatPatch.thinking = chat.thinking;
   if (typeof chat.fast === "boolean") chatPatch.fast = chat.fast;
   if (Object.keys(chatPatch).length) useHud.getState().setChatPreferences(chatPatch);
+}
+
+function handleSessionStarted(payload: unknown, sessionId?: string): void {
+  const p = asRecord(payload);
+  const sid = stringFrom(p.session_id) ?? sessionId;
+  const title = stringFrom(p.title);
+  const label = title ?? sid;
+  if (!label) return;
+  useHud.getState().upsertChat({
+    id: `session-${sid ?? label}`,
+    who: "system",
+    text: `(session started: ${label})`,
+    ts: Date.now(),
+    final: true,
+  });
 }
 
 function handleMessageDelta(payload: unknown, sessionId?: string): void {

--- a/apps/cadis-hud/src/ui/fixtures/mockCadisDaemonEventStream.ts
+++ b/apps/cadis-hud/src/ui/fixtures/mockCadisDaemonEventStream.ts
@@ -1,0 +1,183 @@
+export type MockCadisFrame = {
+  frame: "event";
+  payload: {
+    protocol_version?: string;
+    event_id: string;
+    timestamp: string;
+    source: "cadisd";
+    session_id?: string;
+    type: string;
+    payload: Record<string, unknown>;
+  };
+};
+
+export const mockCadisDaemonWorkerStream: MockCadisFrame[] = [
+  {
+    frame: "event",
+    payload: {
+      protocol_version: "0.1",
+      event_id: "evt_mock_001",
+      timestamp: "2026-04-26T00:00:00Z",
+      source: "cadisd",
+      type: "daemon.status",
+      payload: { state: "connected", version: "0.1.0", model_provider: "echo", uptime_seconds: 4 },
+    },
+  },
+  {
+    frame: "event",
+    payload: {
+      protocol_version: "0.1",
+      event_id: "evt_mock_002",
+      timestamp: "2026-04-26T00:00:01Z",
+      source: "cadisd",
+      session_id: "ses_mock_1",
+      type: "agent.spawned",
+      payload: {
+        agent_id: "codex",
+        display_name: "Codex",
+        role: "Coding",
+        parent_agent_id: "main",
+        model: "codex-cli/chatgpt-plan",
+        status: "running",
+      },
+    },
+  },
+  {
+    frame: "event",
+    payload: {
+      protocol_version: "0.1",
+      event_id: "evt_mock_003",
+      timestamp: "2026-04-26T00:00:02Z",
+      source: "cadisd",
+      session_id: "ses_mock_1",
+      type: "agent.session.started",
+      payload: {
+        agent_session_id: "ags_mock_001",
+        session_id: "ses_mock_1",
+        route_id: "route_mock_001",
+        agent_id: "codex",
+        parent_agent_id: "main",
+        task: "run focused HUD worker tests",
+        status: "running",
+        timeout_at: "2026-04-26T00:15:00Z",
+        budget_steps: 3,
+        steps_used: 0,
+      },
+    },
+  },
+  {
+    frame: "event",
+    payload: {
+      protocol_version: "0.1",
+      event_id: "evt_mock_004",
+      timestamp: "2026-04-26T00:00:03Z",
+      source: "cadisd",
+      session_id: "ses_mock_1",
+      type: "worker.started",
+      payload: {
+        worker_id: "worker_mock_001",
+        agent_id: "codex",
+        parent_agent_id: "main",
+        status: "running",
+        summary: "Worker Coding: run focused HUD worker tests",
+        worktree: {
+          worktree_root: ".cadis/worktrees",
+          worktree_path: ".cadis/worktrees/worker_mock_001",
+          branch_name: "cadis/worker_mock_001/hud-worker-progress",
+          state: "planned",
+          cleanup_policy: "explicit",
+        },
+        artifacts: {
+          root: "/home/user/.cadis/artifacts/workers/worker_mock_001",
+          patch: "/home/user/.cadis/artifacts/workers/worker_mock_001/patch.diff",
+          test_report: "/home/user/.cadis/artifacts/workers/worker_mock_001/test-report.json",
+          summary: "/home/user/.cadis/artifacts/workers/worker_mock_001/summary.md",
+          changed_files: "/home/user/.cadis/artifacts/workers/worker_mock_001/changed-files.json",
+          memory_candidates: "/home/user/.cadis/artifacts/workers/worker_mock_001/memory-candidates.jsonl",
+        },
+      },
+    },
+  },
+  {
+    frame: "event",
+    payload: {
+      protocol_version: "0.1",
+      event_id: "evt_mock_005",
+      timestamp: "2026-04-26T00:00:04Z",
+      source: "cadisd",
+      session_id: "ses_mock_1",
+      type: "worker.log.delta",
+      payload: {
+        worker_id: "worker_mock_001",
+        agent_id: "codex",
+        parent_agent_id: "main",
+        delta: "started: Worker Coding: run focused HUD worker tests\n",
+      },
+    },
+  },
+  {
+    frame: "event",
+    payload: {
+      protocol_version: "0.1",
+      event_id: "evt_mock_006",
+      timestamp: "2026-04-26T00:00:05Z",
+      source: "cadisd",
+      session_id: "ses_mock_1",
+      type: "agent.session.updated",
+      payload: {
+        agent_session_id: "ags_mock_001",
+        session_id: "ses_mock_1",
+        route_id: "route_mock_001",
+        agent_id: "codex",
+        parent_agent_id: "main",
+        task: "run focused HUD worker tests",
+        status: "running",
+        timeout_at: "2026-04-26T00:15:00Z",
+        budget_steps: 3,
+        steps_used: 2,
+      },
+    },
+  },
+  {
+    frame: "event",
+    payload: {
+      protocol_version: "0.1",
+      event_id: "evt_mock_007",
+      timestamp: "2026-04-26T00:00:06Z",
+      source: "cadisd",
+      session_id: "ses_mock_1",
+      type: "worker.completed",
+      payload: {
+        worker_id: "worker_mock_001",
+        agent_id: "codex",
+        parent_agent_id: "main",
+        status: "completed",
+        summary: "completed: focused HUD worker tests passed",
+      },
+    },
+  },
+  {
+    frame: "event",
+    payload: {
+      protocol_version: "0.1",
+      event_id: "evt_mock_008",
+      timestamp: "2026-04-26T00:00:07Z",
+      source: "cadisd",
+      session_id: "ses_mock_1",
+      type: "agent.session.completed",
+      payload: {
+        agent_session_id: "ags_mock_001",
+        session_id: "ses_mock_1",
+        route_id: "route_mock_001",
+        agent_id: "codex",
+        parent_agent_id: "main",
+        task: "run focused HUD worker tests",
+        status: "completed",
+        timeout_at: "2026-04-26T00:15:00Z",
+        budget_steps: 3,
+        steps_used: 3,
+        result: "focused HUD worker tests passed",
+      },
+    },
+  },
+];

--- a/apps/cadis-hud/src/ui/hudLiveProgress.acceptance.test.tsx
+++ b/apps/cadis-hud/src/ui/hudLiveProgress.acceptance.test.tsx
@@ -1,0 +1,138 @@
+import "@testing-library/jest-dom/vitest";
+import { act, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AGENT_ROSTER } from "../lib/agents-roster.js";
+import { DEFAULT_VOICE_PREFS } from "../lib/voice/voices.js";
+import { ChatPanel } from "./chat/ChatPanel.js";
+import { handleCadisFrameForTest, _resetCadisActionsForTest } from "./cadisActions.js";
+import { useHud, type AgentLive } from "./hudState.js";
+import { OrbitalHUD } from "./orbital/OrbitalHUD.js";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(() => Promise.resolve(vi.fn())),
+}));
+
+vi.mock("../lib/voice/tts.js", () => ({
+  speak: vi.fn(() => Promise.resolve()),
+  stopSpeaking: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../lib/voice/stt.js", () => ({
+  available: vi.fn(() => false),
+  startListening: vi.fn(),
+}));
+
+const INITIAL_AGENT_MODELS = Object.fromEntries(
+  AGENT_ROSTER.map((agent) => [agent.id, "openai/gpt-5.5"]),
+);
+
+const INITIAL_AGENTS: AgentLive[] = AGENT_ROSTER.map((agent) => ({
+  spec: agent,
+  status: agent.id === "main" ? "idle" : "waiting",
+  currentTask: {
+    verb: "ready",
+    target: agent.id === "main" ? "CADIS agent" : `${agent.name} agent`,
+    detail: "openai/gpt-5.5",
+  },
+  uptimeSeconds: 0,
+}));
+
+beforeEach(() => {
+  _resetCadisActionsForTest();
+  useHud.setState({
+    gateway: "connected",
+    agents: INITIAL_AGENTS,
+    agentModels: INITIAL_AGENT_MODELS,
+    availableModels: ["openai/gpt-5.5"],
+    defaultModel: "openai/gpt-5.5",
+    chat: [],
+    approvals: [],
+    workers: [],
+    avatarStyle: "orb",
+    voiceState: "idle",
+    voicePrefs: DEFAULT_VOICE_PREFS,
+  });
+});
+
+describe("HUD live progress acceptance", () => {
+  it("renders session, route, agent status, and streamed deltas before completion", () => {
+    render(
+      <>
+        <OrbitalHUD />
+        <ChatPanel />
+      </>,
+    );
+
+    emitLiveEvent("evt_001", "session.started", {
+      session_id: "ses_track_a",
+      title: "Track A HUD acceptance",
+    });
+    emitLiveEvent("evt_002", "orchestrator.route", {
+      id: "route_track_a",
+      source: "hud-chat",
+      target_agent_id: "codex",
+      target_agent_name: "Codex",
+      reason: "@codex prefix",
+    });
+    emitLiveEvent("evt_003", "agent.status.changed", {
+      agent_id: "codex",
+      status: "working",
+      task: "generating visible streamed answer",
+    });
+    emitLiveEvent("evt_004", "message.delta", {
+      session_id: "ses_track_a",
+      delta: "Reading live daemon progress",
+      content_kind: "chat",
+      agent_id: "codex",
+      agent_name: "Codex",
+    });
+
+    expect(screen.getByText("(session started: Track A HUD acceptance)")).toBeVisible();
+    expect(screen.getByText("(route: hud-chat -> Codex; @codex prefix)")).toBeVisible();
+    expect(screen.getByText("Reading live daemon progress")).toBeVisible();
+    expect(screen.queryByText("Final answer after provider completion.")).not.toBeInTheDocument();
+
+    const codexWidget = screen.getByText("Codex").closest(".agent-widget");
+    expect(codexWidget).not.toBeNull();
+    expect(within(codexWidget as HTMLElement).getAllByText("working")[0]).toBeVisible();
+    expect(within(codexWidget as HTMLElement).getByText("generating visible streamed answer")).toBeVisible();
+    expect(useHud.getState().chat.find((message) => message.who === "cadis")).toMatchObject({
+      text: "Reading live daemon progress",
+      final: false,
+      agentId: "codex",
+      agentName: "Codex",
+    });
+
+    emitLiveEvent("evt_005", "message.completed", {
+      session_id: "ses_track_a",
+      content_kind: "chat",
+      content: "Final answer after provider completion.",
+      agent_id: "codex",
+      agent_name: "Codex",
+    });
+
+    expect(screen.getByText("Final answer after provider completion.")).toBeVisible();
+    expect(useHud.getState().chat.find((message) => message.who === "cadis")).toMatchObject({
+      text: "Final answer after provider completion.",
+      final: true,
+    });
+  });
+});
+
+function emitLiveEvent(eventId: string, type: string, payload: Record<string, unknown>): void {
+  act(() => {
+    handleCadisFrameForTest({
+      frame: "event",
+      payload: {
+        event_id: eventId,
+        session_id: payload.session_id,
+        type,
+        payload,
+      },
+    });
+  });
+}

--- a/apps/cadis-hud/src/ui/hudState.ts
+++ b/apps/cadis-hud/src/ui/hudState.ts
@@ -42,7 +42,45 @@ export type ApprovalRecord = {
   timeoutMs?: number;
 };
 
+export type AgentSessionStatus =
+  | "started"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "timed_out"
+  | "budget_exceeded";
+
+export type AgentSessionRecord = {
+  id: string;
+  sessionId: string;
+  routeId: string;
+  agentId: string;
+  parentAgentId?: string;
+  task: string;
+  status: AgentSessionStatus;
+  timeoutAt?: string;
+  budgetSteps: number;
+  stepsUsed: number;
+  result?: string;
+  error?: string;
+  updatedAt: number;
+};
+
 export type WorkerStatus = "spawning" | "running" | "completed" | "failed" | "cancelled";
+
+export type WorkerWorktreeInfo = {
+  state?: string;
+  branchName?: string;
+  worktreePath?: string;
+  cleanupPolicy?: string;
+};
+
+export type WorkerArtifactInfo = {
+  summary?: string;
+  patch?: string;
+  testReport?: string;
+};
 
 export type WorkerRecord = {
   id: string;
@@ -54,6 +92,10 @@ export type WorkerRecord = {
   lastText?: string;
   reason?: string;
   summary?: string;
+  logLineCount: number;
+  logTail: string[];
+  worktree?: WorkerWorktreeInfo;
+  artifacts?: WorkerArtifactInfo;
   startedAt: number;
   updatedAt: number;
 };
@@ -66,6 +108,7 @@ export type ChatPreferences = {
 export type HudStore = {
   gateway: GatewayState;
   agents: AgentLive[];
+  agentSessions: AgentSessionRecord[];
   chat: ChatMessage[];
   approvals: ApprovalRecord[];
   workers: WorkerRecord[];
@@ -104,6 +147,7 @@ export type HudStore = {
   setChatPreferences: (patch: Partial<ChatPreferences>) => void;
   pushApproval: (a: ApprovalRecord) => void;
   removeApproval: (id: string) => void;
+  upsertAgentSession: (session: AgentSessionRecord) => void;
   upsertWorker: (w: WorkerRecord) => void;
   removeWorker: (id: string) => void;
 };
@@ -170,6 +214,7 @@ const INITIAL_AGENTS = AGENT_ROSTER.map((agent) => buildSeedAgent(agent, INITIAL
 export const useHud = create<HudStore>((set) => ({
   gateway: "disconnected",
   agents: INITIAL_AGENTS,
+  agentSessions: [],
   chat: [],
   approvals: [],
   workers: [],
@@ -263,6 +308,17 @@ export const useHud = create<HudStore>((set) => ({
       return { approvals: next };
     }),
   removeApproval: (id) => set((s) => ({ approvals: s.approvals.filter((a) => a.id !== id) })),
+  upsertAgentSession: (session) =>
+    set((s) => {
+      const idx = s.agentSessions.findIndex((candidate) => candidate.id === session.id);
+      if (idx === -1) return { agentSessions: [...s.agentSessions, session] };
+      const next = [...s.agentSessions];
+      const definedSession = Object.fromEntries(
+        Object.entries(session).filter(([, value]) => value !== undefined),
+      ) as AgentSessionRecord;
+      next[idx] = { ...next[idx]!, ...definedSession };
+      return { agentSessions: next };
+    }),
   upsertWorker: (worker) =>
     set((s) => {
       const idx = s.workers.findIndex((candidate) => candidate.id === worker.id);
@@ -278,4 +334,5 @@ export const useHud = create<HudStore>((set) => ({
 }));
 
 export const selectApprovals = (s: HudStore): ApprovalRecord[] => s.approvals;
+export const selectAgentSessions = (s: HudStore): AgentSessionRecord[] => s.agentSessions;
 export const selectWorkers = (s: HudStore): WorkerRecord[] => s.workers;

--- a/apps/cadis-hud/src/ui/hudState.ts
+++ b/apps/cadis-hud/src/ui/hudState.ts
@@ -58,6 +58,33 @@ export type WorkerRecord = {
   updatedAt: number;
 };
 
+export type VoiceDiagnosticCheck = {
+  name: string;
+  status: "pass" | "warn" | "fail";
+  detail: string;
+};
+
+export type VoiceDaemonStatus = {
+  enabled: boolean;
+  state: "disabled" | "ready" | "degraded" | "blocked" | "unknown";
+  provider: string;
+  voiceId: string;
+  sttLanguage: string;
+  maxSpokenChars: number;
+  bridge: string;
+  lastPreflight?: {
+    surface: string;
+    status: string;
+    summary: string;
+    checkedAt: string;
+  };
+};
+
+export type VoiceDoctorReport = {
+  summary: string;
+  checks: VoiceDiagnosticCheck[];
+};
+
 export type ChatPreferences = {
   thinking: boolean;
   fast: boolean;
@@ -73,6 +100,8 @@ export type HudStore = {
   avatarStyle: AvatarStyle;
   voiceState: "idle" | "listening" | "thinking" | "speaking";
   voicePrefs: VoicePrefs;
+  voiceStatus: VoiceDaemonStatus | null;
+  voiceDoctor: VoiceDoctorReport | null;
   voiceConfigOpen: boolean;
   modelsConfigOpen: boolean;
   configOpen: boolean;
@@ -92,6 +121,8 @@ export type HudStore = {
   setAgentTask: (id: string, task: Partial<AgentLive["currentTask"]>) => void;
   setVoiceState: (s: HudStore["voiceState"]) => void;
   updateVoicePrefs: (patch: Partial<VoicePrefs>) => void;
+  setVoiceStatus: (status: VoiceDaemonStatus | null) => void;
+  setVoiceDoctor: (report: VoiceDoctorReport | null) => void;
   setVoiceConfigOpen: (open: boolean) => void;
   setModelsConfigOpen: (open: boolean) => void;
   setConfigOpen: (open: boolean, tab?: ConfigTab) => void;
@@ -177,6 +208,8 @@ export const useHud = create<HudStore>((set) => ({
   avatarStyle: "orb",
   voiceState: "idle",
   voicePrefs: DEFAULT_VOICE_PREFS,
+  voiceStatus: null,
+  voiceDoctor: null,
   voiceConfigOpen: false,
   modelsConfigOpen: false,
   configOpen: false,
@@ -214,6 +247,8 @@ export const useHud = create<HudStore>((set) => ({
   setVoiceState: (voiceState) => set({ voiceState }),
   updateVoicePrefs: (patch) =>
     set((s) => ({ voicePrefs: { ...s.voicePrefs, ...patch } })),
+  setVoiceStatus: (voiceStatus) => set({ voiceStatus }),
+  setVoiceDoctor: (voiceDoctor) => set({ voiceDoctor }),
   setVoiceConfigOpen: (voiceConfigOpen) =>
     set({ voiceConfigOpen, configOpen: voiceConfigOpen, configTab: "voice" }),
   setModelsConfigOpen: (modelsConfigOpen) =>

--- a/apps/cadis-hud/src/ui/orbital/WorkerTree.tsx
+++ b/apps/cadis-hud/src/ui/orbital/WorkerTree.tsx
@@ -6,7 +6,13 @@
  * worker's `cli` (so e.g. "codex" workers attach to the Codex agent).
  */
 import { useState } from "react";
-import { useHud, selectWorkers, type WorkerRecord } from "../hudState.js";
+import {
+  useHud,
+  selectAgentSessions,
+  selectWorkers,
+  type AgentSessionRecord,
+  type WorkerRecord,
+} from "../hudState.js";
 
 const STATUS_COLOR: Record<WorkerRecord["status"], string> = {
   spawning: "var(--warn)",
@@ -14,6 +20,16 @@ const STATUS_COLOR: Record<WorkerRecord["status"], string> = {
   completed: "var(--accent)",
   failed: "var(--err)",
   cancelled: "var(--faint)",
+};
+
+const SESSION_STATUS_COLOR: Record<AgentSessionRecord["status"], string> = {
+  started: "var(--warn)",
+  running: "var(--ok)",
+  completed: "var(--accent)",
+  failed: "var(--err)",
+  cancelled: "var(--faint)",
+  timed_out: "var(--err)",
+  budget_exceeded: "var(--err)",
 };
 
 export type WorkerTreeProps = {
@@ -24,16 +40,25 @@ export type WorkerTreeProps = {
 
 function workerBelongsTo(w: WorkerRecord, agentId: string): boolean {
   if (w.parentAgentId === agentId) return true;
+  if (w.agentId === agentId) return true;
   if (!w.parentAgentId && w.cli && w.cli.toLowerCase() === agentId.toLowerCase()) return true;
   return false;
 }
 
+function sessionBelongsTo(s: AgentSessionRecord, agentId: string): boolean {
+  return s.agentId === agentId || s.parentAgentId === agentId;
+}
+
 export function WorkerTree({ agentId, defaultOpen }: WorkerTreeProps) {
   const all = useHud(selectWorkers);
+  const allSessions = useHud(selectAgentSessions);
   const workers = all.filter((w) => workerBelongsTo(w, agentId));
+  const sessions = allSessions.filter((s) => sessionBelongsTo(s, agentId));
   const [open, setOpen] = useState(defaultOpen ?? true);
 
-  if (workers.length === 0) return null;
+  if (workers.length === 0 && sessions.length === 0) return null;
+
+  const runningWorkers = workers.filter((w) => w.status === "running" || w.status === "spawning").length;
 
   return (
     <div className="worker-tree" data-agent={agentId}>
@@ -44,10 +69,26 @@ export function WorkerTree({ agentId, defaultOpen }: WorkerTreeProps) {
         aria-expanded={open}
       >
         <span className="worker-tree__caret">{open ? "▾" : "▸"}</span>
-        <span className="worker-tree__label">workers · {workers.length}</span>
+        <span className="worker-tree__label">
+          workers · {workers.length}
+          {runningWorkers > 0 ? ` · ${runningWorkers} active` : ""}
+        </span>
       </button>
       {open && (
         <ul className="worker-tree__list">
+          {sessions.map((s) => (
+            <li key={s.id} className="worker-tree__item worker-tree__item--session" data-status={s.status}>
+              <span
+                className="worker-tree__dot"
+                style={{ background: SESSION_STATUS_COLOR[s.status] }}
+                aria-hidden
+              />
+              <span className="worker-tree__id" title={s.id}>{compactId(s.id)}</span>
+              <span className="worker-tree__status">{s.status.replace("_", " ")}</span>
+              <span className="worker-tree__text" title={s.task}>{sessionText(s)}</span>
+              <ProgressBar value={sessionProgress(s)} />
+            </li>
+          ))}
           {workers.map((w) => (
             <li key={w.id} className="worker-tree__item" data-status={w.status}>
               <span
@@ -55,13 +96,75 @@ export function WorkerTree({ agentId, defaultOpen }: WorkerTreeProps) {
                 style={{ background: STATUS_COLOR[w.status] }}
                 aria-hidden
               />
-              <span className="worker-tree__id">{w.id}</span>
+              <span className="worker-tree__id" title={w.id}>{compactId(w.id)}</span>
               <span className="worker-tree__status">{w.status}</span>
-              {w.lastText && <span className="worker-tree__text">{w.lastText}</span>}
+              <span className="worker-tree__text" title={workerTitle(w)}>
+                {workerText(w)}
+              </span>
+              <ProgressBar value={workerProgress(w)} indeterminate={w.status === "running"} />
             </li>
           ))}
         </ul>
       )}
     </div>
   );
+}
+
+function ProgressBar({
+  value,
+  indeterminate = false,
+}: {
+  value: number;
+  indeterminate?: boolean;
+}) {
+  return (
+    <span
+      className={`worker-tree__progress${indeterminate ? " worker-tree__progress--active" : ""}`}
+      aria-hidden
+    >
+      <span style={{ width: `${Math.max(0, Math.min(100, value))}%` }} />
+    </span>
+  );
+}
+
+function sessionProgress(session: AgentSessionRecord): number {
+  if (session.status === "completed") return 100;
+  if (session.status === "failed" || session.status === "cancelled") return 100;
+  if (session.status === "timed_out" || session.status === "budget_exceeded") return 100;
+  if (session.budgetSteps <= 0) return session.status === "started" ? 8 : 18;
+  return Math.max(8, Math.round((session.stepsUsed / session.budgetSteps) * 100));
+}
+
+function workerProgress(worker: WorkerRecord): number {
+  if (worker.status === "completed" || worker.status === "failed" || worker.status === "cancelled") {
+    return 100;
+  }
+  if (worker.status === "spawning") return 12;
+  return Math.min(92, 30 + worker.logLineCount * 12);
+}
+
+function sessionText(session: AgentSessionRecord): string {
+  const progress =
+    session.budgetSteps > 0
+      ? `step ${Math.min(session.stepsUsed, session.budgetSteps)}/${session.budgetSteps}`
+      : session.status.replace("_", " ");
+  return `${session.task} · ${progress}`;
+}
+
+function workerText(worker: WorkerRecord): string {
+  const worktree = worker.worktree?.state ? `worktree ${worker.worktree.state}` : undefined;
+  return worker.lastText ?? worker.summary ?? worktree ?? worker.cli ?? "daemon worker";
+}
+
+function workerTitle(worker: WorkerRecord): string {
+  const parts = [
+    worker.lastText ?? worker.summary,
+    worker.worktree?.branchName,
+    worker.worktree?.worktreePath,
+  ].filter(Boolean);
+  return parts.join(" · ");
+}
+
+function compactId(id: string): string {
+  return id.length > 16 ? `${id.slice(0, 13)}...` : id;
 }

--- a/apps/cadis-hud/src/ui/settings/ConfigDialog.tsx
+++ b/apps/cadis-hud/src/ui/settings/ConfigDialog.tsx
@@ -6,6 +6,8 @@ import {
   type AvatarStyle,
   type ConfigTab,
   type ThemeKey,
+  type VoiceDiagnosticCheck,
+  type VoiceDoctorReport,
 } from "../hudState.js";
 import { VOICES } from "../../lib/voice/voices.js";
 import { stopSpeaking, testAudio } from "../../lib/voice/tts.js";
@@ -15,6 +17,8 @@ import {
   persistChatPreferences,
   persistThemePreference,
   persistVoicePreferences,
+  requestVoiceDoctor,
+  sendVoicePreflight,
   sendAgentModelUpdate,
 } from "../cadisActions.js";
 
@@ -29,17 +33,6 @@ const AVATAR_STYLES: { id: AvatarStyle; label: string; detail: string }[] = [
   { id: "orb", label: "CADIS Orb", detail: "Current RamaClaw-style core" },
   { id: "wulan_arc", label: "Wulan Arc", detail: "Hologram avatar contribution" },
 ];
-
-type VoiceDoctorCheck = {
-  name: string;
-  status: "pass" | "warn" | "fail";
-  detail: string;
-};
-
-type VoiceDoctorReport = {
-  summary: string;
-  checks: VoiceDoctorCheck[];
-};
 
 export function ConfigDialog() {
   const open = useHud((s) => s.configOpen);
@@ -100,6 +93,8 @@ export function ConfigDialog() {
 
 function VoiceTab() {
   const prefs = useHud((s) => s.voicePrefs);
+  const daemonStatus = useHud((s) => s.voiceStatus);
+  const daemonDoctor = useHud((s) => s.voiceDoctor);
   const update = useHud((s) => s.updateVoicePrefs);
   const setVoiceState = useHud((s) => s.setVoiceState);
   const mainName = useHud((s) => s.agents.find((a) => a.spec.id === "main")?.spec.name ?? "CADIS");
@@ -118,10 +113,12 @@ function VoiceTab() {
   const runDoctor = async () => {
     setDoctorBusy(true);
     setDoctorError(null);
+    requestVoiceDoctor();
     try {
       const rendererMic = await rendererMicCheck();
       const report = await invoke<VoiceDoctorReport>("voice_doctor_preflight", { rendererMic });
       setDoctor(report);
+      sendVoicePreflight(report);
     } catch (e) {
       setDoctorError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -158,6 +155,13 @@ function VoiceTab() {
     setTesting(false);
     setVoiceState("idle");
   };
+  const displayedDoctor = doctor ?? daemonDoctor;
+  const displayedChecks = [
+    ...(daemonStatus
+      ? [voiceStatusCheck(daemonStatus.state, daemonStatus.provider, daemonStatus.bridge)]
+      : []),
+    ...(displayedDoctor?.checks ?? [rendererMicPendingCheck()]),
+  ];
 
   return (
     <>
@@ -218,20 +222,28 @@ function VoiceTab() {
       <section className="voice-config__row">
         <label className="voice-config__label">
           Engine
-          <span className="voice-config__value">edge-tts-universal</span>
+          <span className="voice-config__value">
+            {daemonStatus?.provider ?? "edge"} · local bridge
+          </span>
         </label>
+        {daemonStatus?.lastPreflight && (
+          <div className="voice-config__hint">
+            last preflight: {daemonStatus.lastPreflight.status} ·{" "}
+            {daemonStatus.lastPreflight.summary}
+          </div>
+        )}
       </section>
 
       <section className="voice-config__row voice-doctor">
         <label className="voice-config__label">
           Voice doctor
           <span className="voice-config__value">
-            {doctorBusy ? "checking" : doctor?.summary ?? "not run"}
+            {doctorBusy ? "checking" : displayedDoctor?.summary ?? daemonStatus?.state ?? "not run"}
           </span>
         </label>
         {doctorError && <div className="voice-config__error">{doctorError}</div>}
         <div className="voice-doctor__grid">
-          {(doctor?.checks ?? [rendererMicPendingCheck()]).map((check) => (
+          {displayedChecks.map((check) => (
             <div key={check.name} className="voice-doctor__item">
               <span className={`voice-doctor__dot voice-doctor__dot--${check.status}`} />
               <span className="voice-doctor__name">{check.name}</span>
@@ -452,7 +464,7 @@ function WindowTab() {
   );
 }
 
-function rendererMicPendingCheck(): VoiceDoctorCheck {
+function rendererMicPendingCheck(): VoiceDiagnosticCheck {
   return {
     name: "microphone",
     status: "warn",
@@ -460,7 +472,7 @@ function rendererMicPendingCheck(): VoiceDoctorCheck {
   };
 }
 
-async function rendererMicCheck(): Promise<VoiceDoctorCheck> {
+async function rendererMicCheck(): Promise<VoiceDiagnosticCheck> {
   if (typeof navigator === "undefined") {
     return {
       name: "microphone",
@@ -517,6 +529,23 @@ async function rendererMicCheck(): Promise<VoiceDoctorCheck> {
     name: "microphone",
     status: "warn",
     detail: "capture APIs exist; no audio input visible before permission",
+  };
+}
+
+function voiceStatusCheck(
+  state: string,
+  provider: string,
+  bridge: string,
+): VoiceDiagnosticCheck {
+  return {
+    name: "daemon voice",
+    status:
+      state === "blocked"
+        ? "fail"
+        : state === "ready" || state === "disabled"
+          ? "pass"
+          : "warn",
+    detail: `${state} · ${provider} · ${bridge}`,
   };
 }
 

--- a/config/README.md
+++ b/config/README.md
@@ -10,6 +10,10 @@ Runtime user configuration defaults to:
 
 Do not commit real provider keys, Telegram tokens, or local private paths.
 
+Voice config is daemon-owned. Supported visible TTS provider IDs are `edge`,
+`openai`, and `system`; `stub` is reserved for deterministic tests. Current
+provider implementations are local stubs and must not include API keys.
+
 The desktop MVP example is:
 
 - [cadis.example.toml](cadis.example.toml)

--- a/config/cadis.example.toml
+++ b/config/cadis.example.toml
@@ -38,11 +38,16 @@ always_on_top = false
 
 [voice]
 enabled = false
+# Supported daemon-visible providers: "edge", "openai", "system".
+# HUD/Tauri remains the local microphone and playback bridge for this slice.
+provider = "edge"
 voice_id = "id-ID-GadisNeural"
+stt_language = "auto"
 rate = 0
 pitch = 0
 volume = 0
 auto_speak = false
+max_spoken_chars = 800
 
 [agent_spawn]
 # Applies to client-requested agent.spawn and explicit orchestrator /worker actions.

--- a/config/cadis.example.toml
+++ b/config/cadis.example.toml
@@ -39,7 +39,10 @@ always_on_top = false
 [voice]
 enabled = false
 # Supported daemon-visible providers: "edge", "openai", "system".
-# HUD/Tauri remains the local microphone and playback bridge for this slice.
+# Tests may use the deterministic "stub" provider. The current daemon provider
+# implementations are local stubs and do not call external APIs.
+# HUD/Tauri remains the local microphone and playback bridge where platform APIs
+# require it.
 provider = "edge"
 voice_id = "id-ID-GadisNeural"
 stt_language = "auto"

--- a/config/cadis.example.toml
+++ b/config/cadis.example.toml
@@ -16,6 +16,8 @@ log_level = "info"
 # cadisd initializes this profile under ~/.cadis/profiles/<profile>/ and keeps
 # profile-local sessions, agents, workers, workspaces, event logs, and secrets
 # separated from global daemon state.
+# Daemon-known agents get non-destructive homes under agents/<agent>/ with
+# AGENT.toml, POLICY.toml, instructions, memory, and skill policy templates.
 default_profile = "default"
 
 [model]

--- a/config/cadis.example.toml
+++ b/config/cadis.example.toml
@@ -50,6 +50,11 @@ max_depth = 2
 max_children_per_parent = 4
 max_total_agents = 32
 
+[agent_runtime]
+# Applies to daemon-owned per-route AgentSession records.
+default_timeout_sec = 900
+max_steps_per_session = 1
+
 [orchestrator]
 # Enables explicit /worker, /spawn, /route, and /delegate message actions.
 worker_delegation_enabled = true

--- a/crates/README.md
+++ b/crates/README.md
@@ -5,7 +5,7 @@ Rust workspace crates will live here.
 Planned first crates:
 
 - `cadis-protocol` - typed requests, responses, events, versioning, serialization
-- `cadis-avatar` - renderer-independent Wulan avatar state engine, gesture model, face-tracking privacy config, and wgpu-first renderer contract
+- `cadis-avatar` - renderer-independent Wulan avatar state engine, gesture model, face-tracking privacy config, wgpu-first renderer contract, and feature-gated adapter-ready wgpu render-plan spike
 - `cadis-core`
 - `cadis-daemon`
 - `cadis-cli`

--- a/crates/cadis-avatar/README.md
+++ b/crates/cadis-avatar/README.md
@@ -11,7 +11,12 @@ normalizes daemon/HUD state into renderable avatar frames:
 - face expression state
 - optional local-only face tracking input
 - direct wgpu-first renderer contract data without linking the `wgpu` crate
+- renderer-failure fallback state for the default CADIS orb or a static Wulan texture
 - deferred Bevy contract metadata behind the future `bevy-renderer` feature
+
+`AvatarRendererContract` now includes an `AvatarFallbackContract` so native
+renderer adapters can turn render failures into serializable HUD fallback state
+without blocking HUD launch. The default fallback target is the CADIS orb.
 
 The current `apps/cadis-hud` Wulan Arc scene remains the visual prototype. This
 crate is the migration target for a future CADIS-native avatar renderer.

--- a/crates/cadis-avatar/README.md
+++ b/crates/cadis-avatar/README.md
@@ -12,11 +12,20 @@ normalizes daemon/HUD state into renderable avatar frames:
 - optional local-only face tracking input
 - direct wgpu-first renderer contract data without linking the `wgpu` crate
 - renderer-failure fallback state for the default CADIS orb or a static Wulan texture
+- feature-gated `wgpu_renderer` spike that builds deterministic direct-wgpu
+  render plans without linking `wgpu`
 - deferred Bevy contract metadata behind the future `bevy-renderer` feature
 
 `AvatarRendererContract` now includes an `AvatarFallbackContract` so native
 renderer adapters can turn render failures into serializable HUD fallback state
 without blocking HUD launch. The default fallback target is the CADIS orb.
+
+Enable `--features wgpu-renderer` to compile
+`wgpu_renderer::WgpuAvatarSpikeRenderer`. The spike consumes `AvatarFrame`,
+checks the direct-wgpu contract, records an adapter-ready `WgpuAvatarRenderPlan`,
+and preserves fallback behavior when the native surface or portrait texture is
+not ready. It is still renderer-neutral at the HUD/daemon boundary and does not
+execute tools, policies, model calls, microphone capture, or camera access.
 
 The current `apps/cadis-hud` Wulan Arc scene remains the visual prototype. This
 crate is the migration target for a future CADIS-native avatar renderer.

--- a/crates/cadis-avatar/src/lib.rs
+++ b/crates/cadis-avatar/src/lib.rs
@@ -11,6 +11,9 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "wgpu-renderer")]
+pub mod wgpu_renderer;
+
 /// Identifier used by the Wulan avatar prototype and native engine.
 pub const WULAN_AVATAR_ID: &str = "wulan_arc";
 

--- a/crates/cadis-avatar/src/lib.rs
+++ b/crates/cadis-avatar/src/lib.rs
@@ -14,6 +14,9 @@ use serde::{Deserialize, Serialize};
 /// Identifier used by the Wulan avatar prototype and native engine.
 pub const WULAN_AVATAR_ID: &str = "wulan_arc";
 
+/// Avatar style used when native Wulan rendering cannot produce a frame.
+pub const CADIS_ORB_AVATAR_ID: &str = "orb";
+
 /// Supported avatar renderer backend targets.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -25,6 +28,85 @@ pub enum RendererBackend {
     WgpuNative,
     /// Bevy scene renderer target for richer body and scene orchestration.
     BevyScene,
+}
+
+/// HUD avatar target used when a native renderer fails or is unavailable.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AvatarFallbackTarget {
+    /// Stable default CADIS orb path.
+    #[default]
+    #[serde(rename = "orb")]
+    CadisOrb,
+    /// Static Wulan portrait texture without native animation.
+    StaticWulanTexture,
+}
+
+impl AvatarFallbackTarget {
+    /// Returns the daemon/HUD avatar style identifier for this fallback target.
+    pub fn avatar_id(self) -> &'static str {
+        match self {
+            Self::CadisOrb => CADIS_ORB_AVATAR_ID,
+            Self::StaticWulanTexture => WULAN_AVATAR_ID,
+        }
+    }
+}
+
+/// Renderer fallback behavior promised by native avatar adapters.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AvatarFallbackContract {
+    /// HUD avatar target to show when native rendering fails.
+    pub target: AvatarFallbackTarget,
+    /// Whether renderer failure must leave the HUD launch path available.
+    pub preserves_hud_launch: bool,
+    /// Whether fallback events should carry a coarse reason code.
+    pub reason_code_required: bool,
+    /// Whether reduced-motion state should be preserved through fallback.
+    pub reduced_motion_passthrough: bool,
+}
+
+impl Default for AvatarFallbackContract {
+    fn default() -> Self {
+        Self {
+            target: AvatarFallbackTarget::CadisOrb,
+            preserves_hud_launch: true,
+            reason_code_required: true,
+            reduced_motion_passthrough: true,
+        }
+    }
+}
+
+/// Coarse reason a renderer adapter fell back instead of drawing Wulan.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AvatarFallbackReason {
+    /// Renderer implementation was not available.
+    #[default]
+    RendererUnavailable,
+    /// Renderer lost or could not acquire its target surface.
+    SurfaceLost,
+    /// Renderer returned an error while drawing a frame.
+    RenderError,
+    /// Requested backend is not supported by the adapter.
+    UnsupportedBackend,
+}
+
+/// Minimal state a HUD adapter needs to show a fallback avatar.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct AvatarFallbackState {
+    /// Fallback avatar style to show.
+    pub target: AvatarFallbackTarget,
+    /// Coarse fallback reason suitable for HUD state and tests.
+    pub reason: AvatarFallbackReason,
+    /// Renderer backend that failed or was unavailable.
+    pub failed_backend: RendererBackend,
+    /// Runtime mode being rendered when fallback was selected.
+    pub mode: AvatarMode,
+    /// Whether reduced-motion state remains active in fallback.
+    pub reduced_motion: bool,
+    /// Monotonic timestamp in milliseconds from the source frame.
+    pub time_ms: u64,
 }
 
 impl RendererBackend {
@@ -213,6 +295,8 @@ pub struct AvatarEngineConfig {
     pub avatar_id: String,
     /// Preferred native renderer backend.
     pub renderer: RendererBackend,
+    /// Fallback avatar target when the native renderer fails.
+    pub renderer_fallback: AvatarFallbackTarget,
     /// Face tracking config.
     pub face_tracking: FaceTrackingConfig,
     /// Privacy policy for any face tracking data.
@@ -228,6 +312,7 @@ impl Default for AvatarEngineConfig {
         Self {
             avatar_id: WULAN_AVATAR_ID.to_owned(),
             renderer: RendererBackend::WgpuNative,
+            renderer_fallback: AvatarFallbackTarget::CadisOrb,
             face_tracking: FaceTrackingConfig::default(),
             privacy: AvatarPrivacy::default(),
             reduced_motion: false,
@@ -267,7 +352,7 @@ impl AvatarEngineConfig {
 
     /// Returns the renderer contract implied by this configuration.
     pub fn renderer_contract(&self) -> AvatarRendererContract {
-        AvatarRendererContract::for_backend(self.renderer)
+        AvatarRendererContract::for_backend(self.renderer).with_fallback(self.renderer_fallback)
     }
 }
 
@@ -487,6 +572,25 @@ impl AvatarFrame {
     }
 }
 
+impl AvatarFallbackContract {
+    /// Converts a failed render attempt into minimal fallback state for the HUD.
+    pub fn state_for_frame(
+        self,
+        failed_backend: RendererBackend,
+        frame: &AvatarFrame,
+        reason: AvatarFallbackReason,
+    ) -> AvatarFallbackState {
+        AvatarFallbackState {
+            target: self.target,
+            reason,
+            failed_backend,
+            mode: frame.mode,
+            reduced_motion: self.reduced_motion_passthrough && frame.body_state.reduced_motion,
+            time_ms: frame.time_ms,
+        }
+    }
+}
+
 /// Version of the direct-wgpu avatar uniform payload.
 pub const WGPU_AVATAR_UNIFORM_VERSION: u16 = 1;
 
@@ -621,6 +725,8 @@ pub struct AvatarRendererContract {
     pub wgpu: WgpuRendererContract,
     /// Deferred Bevy renderer contract.
     pub bevy: BevyRendererContract,
+    /// Required fallback behavior when native rendering fails.
+    pub fallback: AvatarFallbackContract,
 }
 
 impl AvatarRendererContract {
@@ -630,7 +736,24 @@ impl AvatarRendererContract {
             preferred_backend,
             wgpu: WgpuRendererContract::default(),
             bevy: BevyRendererContract::default(),
+            fallback: AvatarFallbackContract::default(),
         }
+    }
+
+    /// Overrides the fallback target while preserving fallback safety rules.
+    pub fn with_fallback(mut self, target: AvatarFallbackTarget) -> Self {
+        self.fallback.target = target;
+        self
+    }
+
+    /// Builds the HUD fallback state for a frame that could not be rendered.
+    pub fn fallback_for_frame(
+        &self,
+        failed_backend: RendererBackend,
+        frame: &AvatarFrame,
+        reason: AvatarFallbackReason,
+    ) -> AvatarFallbackState {
+        self.fallback.state_for_frame(failed_backend, frame, reason)
     }
 }
 
@@ -696,6 +819,35 @@ pub trait AvatarRenderer {
 pub trait WgpuAvatarRenderer: AvatarRenderer {
     /// Returns the no-dependency `wgpu` contract this renderer implements.
     fn wgpu_contract(&self) -> WgpuRendererContract;
+}
+
+/// Result of attempting to render a frame with fallback handling.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AvatarRenderAttempt {
+    /// The renderer accepted the frame.
+    Rendered(AvatarRenderReceipt),
+    /// The renderer failed and the HUD should show fallback state.
+    Fallback(AvatarFallbackState),
+}
+
+/// Renders one frame or returns fallback state without blocking the HUD path.
+pub fn render_or_fallback<R>(
+    renderer: &mut R,
+    frame: &AvatarFrame,
+    contract: &AvatarRendererContract,
+) -> AvatarRenderAttempt
+where
+    R: AvatarRenderer + ?Sized,
+{
+    let backend = renderer.backend();
+    match renderer.render(frame) {
+        Ok(receipt) => AvatarRenderAttempt::Rendered(receipt),
+        Err(_) => AvatarRenderAttempt::Fallback(contract.fallback_for_frame(
+            backend,
+            frame,
+            AvatarFallbackReason::RenderError,
+        )),
+    }
 }
 
 /// Renderer error.
@@ -1010,16 +1162,21 @@ mod tests {
 
         assert_eq!(config.avatar_id, WULAN_AVATAR_ID);
         assert_eq!(config.renderer, RendererBackend::WgpuNative);
+        assert_eq!(config.renderer_fallback, AvatarFallbackTarget::CadisOrb);
         assert_eq!(config.face_tracking.mode, FaceTrackingMode::Off);
         assert!(config.privacy.local_only_face_tracking);
         assert!(!config.privacy.persist_raw_face_frames);
         assert!(!config.privacy.persist_face_landmarks);
         assert!(!config.privacy.allow_remote_face_tracking);
         assert!(!config.privacy.allow_face_identity);
-        assert_eq!(
-            config.renderer_contract().wgpu.uniform_version,
-            WGPU_AVATAR_UNIFORM_VERSION
-        );
+
+        let contract = config.renderer_contract();
+        assert_eq!(contract.wgpu.uniform_version, WGPU_AVATAR_UNIFORM_VERSION);
+        assert_eq!(contract.fallback.target, AvatarFallbackTarget::CadisOrb);
+        assert_eq!(contract.fallback.target.avatar_id(), CADIS_ORB_AVATAR_ID);
+        assert!(contract.fallback.preserves_hud_launch);
+        assert!(contract.fallback.reason_code_required);
+        assert!(contract.fallback.reduced_motion_passthrough);
     }
 
     #[test]
@@ -1042,6 +1199,61 @@ mod tests {
         assert!(frame.body.intensity > 0.8);
         assert!(frame.face.mouth_open > 0.5);
         assert!(frame.material.glow > 0.8);
+    }
+
+    #[test]
+    fn modes_export_expected_body_gestures_and_priorities() {
+        let mut engine = AvatarEngine::new(AvatarEngineConfig::default());
+        let cases = [
+            (
+                AvatarMode::Idle,
+                BodyGesture::IdleBreath,
+                BodyGesturePriority::Ambient,
+            ),
+            (
+                AvatarMode::Listening,
+                BodyGesture::AttentiveLean,
+                BodyGesturePriority::Activity,
+            ),
+            (
+                AvatarMode::Thinking,
+                BodyGesture::ThinkingOrbit,
+                BodyGesturePriority::Activity,
+            ),
+            (
+                AvatarMode::Speaking,
+                BodyGesture::SpeakingPulse,
+                BodyGesturePriority::Activity,
+            ),
+            (
+                AvatarMode::Coding,
+                BodyGesture::CodingFocus,
+                BodyGesturePriority::Activity,
+            ),
+            (
+                AvatarMode::Approval,
+                BodyGesture::ApprovalHold,
+                BodyGesturePriority::Interaction,
+            ),
+            (
+                AvatarMode::Error,
+                BodyGesture::ErrorAlert,
+                BodyGesturePriority::Safety,
+            ),
+        ];
+
+        for (index, (mode, gesture, priority)) in cases.into_iter().enumerate() {
+            let frame = engine.update(AvatarInput {
+                mode,
+                audio_level: 0.65,
+                now_ms: ((index + 1) * 100) as u64,
+                ..AvatarInput::default()
+            });
+
+            assert_eq!(frame.body_state.gesture, gesture);
+            assert_eq!(frame.body.gesture, gesture);
+            assert_eq!(frame.body_state.priority, priority);
+        }
     }
 
     #[test]
@@ -1162,6 +1374,78 @@ mod tests {
         assert_eq!(receipt.backend, RendererBackend::Headless);
         assert_eq!(receipt.time_ms, 42);
         assert_eq!(renderer.frames(), &[frame]);
+    }
+
+    #[derive(Debug, Default)]
+    struct FailingWgpuRenderer;
+
+    impl AvatarRenderer for FailingWgpuRenderer {
+        fn backend(&self) -> RendererBackend {
+            RendererBackend::WgpuNative
+        }
+
+        fn render(
+            &mut self,
+            _frame: &AvatarFrame,
+        ) -> Result<AvatarRenderReceipt, AvatarRenderError> {
+            Err(AvatarRenderError::new("native surface unavailable"))
+        }
+    }
+
+    #[test]
+    fn renderer_error_returns_cadis_orb_fallback_state() {
+        let mut engine = AvatarEngine::new(AvatarEngineConfig {
+            reduced_motion: true,
+            ..AvatarEngineConfig::default()
+        });
+        let frame = engine.update(AvatarInput {
+            mode: AvatarMode::Approval,
+            now_ms: 777,
+            ..AvatarInput::default()
+        });
+        let contract = engine.config().renderer_contract();
+        let mut renderer = FailingWgpuRenderer;
+
+        let attempt = render_or_fallback(&mut renderer, &frame, &contract);
+
+        assert_eq!(
+            attempt,
+            AvatarRenderAttempt::Fallback(AvatarFallbackState {
+                target: AvatarFallbackTarget::CadisOrb,
+                reason: AvatarFallbackReason::RenderError,
+                failed_backend: RendererBackend::WgpuNative,
+                mode: AvatarMode::Approval,
+                reduced_motion: true,
+                time_ms: 777,
+            })
+        );
+    }
+
+    #[test]
+    fn fallback_state_serializes_for_hud_boundaries() {
+        let mut engine = AvatarEngine::new(AvatarEngineConfig {
+            renderer_fallback: AvatarFallbackTarget::StaticWulanTexture,
+            reduced_motion: true,
+            ..AvatarEngineConfig::default()
+        });
+        let frame = engine.update(AvatarInput {
+            mode: AvatarMode::Error,
+            now_ms: 900,
+            ..AvatarInput::default()
+        });
+        let fallback = engine.config().renderer_contract().fallback_for_frame(
+            RendererBackend::WgpuNative,
+            &frame,
+            AvatarFallbackReason::SurfaceLost,
+        );
+
+        let json = serde_json::to_string(&fallback).expect("fallback should serialize");
+
+        assert!(json.contains("\"target\":\"static_wulan_texture\""));
+        assert!(json.contains("\"reason\":\"surface_lost\""));
+        assert!(json.contains("\"failed_backend\":\"wgpu_native\""));
+        assert!(json.contains("\"mode\":\"error\""));
+        assert!(json.contains("\"reduced_motion\":true"));
     }
 
     #[test]

--- a/crates/cadis-avatar/src/wgpu_renderer.rs
+++ b/crates/cadis-avatar/src/wgpu_renderer.rs
@@ -1,0 +1,413 @@
+//! Adapter-ready Rust/wgpu avatar renderer spike.
+//!
+//! This module is compiled only with the `wgpu-renderer` feature. It deliberately
+//! keeps the crate free of a hard `wgpu` dependency: the public shape is a
+//! deterministic render plan that a concrete GPU adapter can translate into
+//! pipelines, bind groups, buffers, and draw calls.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AvatarFrame, AvatarRenderError, AvatarRenderReceipt, AvatarRenderer, RendererBackend,
+    WgpuAlphaModeHint, WgpuAvatarPrimitive, WgpuAvatarRenderer, WgpuAvatarUniforms,
+    WgpuRendererContract, WgpuSurfaceTarget, WgpuTextureFormatHint, WGPU_AVATAR_UNIFORM_VERSION,
+};
+
+/// Feature-gated renderer identifier for diagnostics and fixtures.
+pub const WGPU_SPIKE_RENDERER_ID: &str = "cadis-wulan-wgpu-spike";
+
+/// First shader contract label expected by a concrete direct-wgpu adapter.
+pub const WGPU_SPIKE_SHADER_LABEL: &str = "wulan-avatar-spike-v1";
+
+/// CPU-side readiness and budget config for the wgpu renderer spike.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+pub struct WgpuAvatarRendererConfig {
+    /// Target viewport size in physical pixels.
+    pub target_size: [u32; 2],
+    /// Whether the HUD/native adapter has an available surface or texture.
+    pub surface_available: bool,
+    /// Whether the Wulan portrait texture has been uploaded or otherwise bound.
+    pub portrait_texture_ready: bool,
+    /// Alpha cutoff used by the portrait plane.
+    pub alpha_cutoff: f32,
+    /// Upper particle count budget before reduced-motion handling.
+    pub max_particles: u16,
+}
+
+impl Default for WgpuAvatarRendererConfig {
+    fn default() -> Self {
+        Self {
+            target_size: [512, 512],
+            surface_available: true,
+            portrait_texture_ready: true,
+            alpha_cutoff: 0.08,
+            max_particles: 96,
+        }
+    }
+}
+
+/// Primitive-specific portrait plane state.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+pub struct WgpuPortraitPlane {
+    /// Center position in normalized device coordinates.
+    pub center: [f32; 2],
+    /// Plane size in normalized device coordinates.
+    pub size: [f32; 2],
+    /// Alpha cutoff for transparent portrait pixels.
+    pub alpha_cutoff: f32,
+    /// Tint derived from the avatar material state.
+    pub tint_rgb: [f32; 3],
+}
+
+/// Primitive-specific reticle and ring state.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+pub struct WgpuReticleRings {
+    /// Number of rings the adapter should draw.
+    pub ring_count: u8,
+    /// Outer radius in normalized device coordinates.
+    pub outer_radius: f32,
+    /// Rotation rate in radians per second.
+    pub rotation_rate: f32,
+    /// Ring opacity after reduced-motion handling.
+    pub opacity: f32,
+}
+
+/// Primitive-specific particle state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct WgpuParticleField {
+    /// Particle budget for this frame.
+    pub count: u16,
+    /// Stable seed derived from frame time and mode.
+    pub seed: u32,
+}
+
+/// Primitive-specific face overlay state.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+pub struct WgpuFaceOverlay {
+    /// Gaze x/y, blink left/right, mouth open, and brow raise.
+    pub face: [f32; 6],
+    /// Whether face values came from local-only tracking.
+    pub tracked_face: bool,
+}
+
+/// Primitive-specific body gesture rig state.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+pub struct WgpuBodyGestureRig {
+    /// Head yaw and pitch.
+    pub head: [f32; 2],
+    /// Left and right hand emphasis.
+    pub hands: [f32; 2],
+    /// Current gesture intensity after accessibility handling.
+    pub intensity: f32,
+}
+
+/// Deterministic render plan consumed by a concrete direct-wgpu adapter.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct WgpuAvatarRenderPlan {
+    /// Renderer spike identifier.
+    pub renderer_id: String,
+    /// Shader contract label.
+    pub shader_label: String,
+    /// Uniform payload copied from the renderer-neutral frame.
+    pub uniforms: WgpuAvatarUniforms,
+    /// Surface target shape.
+    pub surface_target: WgpuSurfaceTarget,
+    /// Texture format hint.
+    pub texture_format: WgpuTextureFormatHint,
+    /// Alpha mode hint.
+    pub alpha_mode: WgpuAlphaModeHint,
+    /// Target viewport size in physical pixels.
+    pub target_size: [u32; 2],
+    /// Primitive families expected by the adapter.
+    pub primitives: Vec<WgpuAvatarPrimitive>,
+    /// Portrait plane draw state.
+    pub portrait: WgpuPortraitPlane,
+    /// Reticle ring draw state.
+    pub reticles: WgpuReticleRings,
+    /// Particle field draw state.
+    pub particles: WgpuParticleField,
+    /// Face overlay draw state.
+    pub face_overlay: WgpuFaceOverlay,
+    /// Body gesture draw state.
+    pub body_rig: WgpuBodyGestureRig,
+    /// Whether reduced-motion rules were applied to this plan.
+    pub reduced_motion: bool,
+}
+
+impl WgpuAvatarRenderPlan {
+    /// Builds a deterministic adapter plan from a renderer-neutral frame.
+    pub fn from_frame(
+        frame: &AvatarFrame,
+        contract: &WgpuRendererContract,
+        config: WgpuAvatarRendererConfig,
+    ) -> Result<Self, AvatarRenderError> {
+        validate_contract(contract, config)?;
+
+        let uniforms = frame.wgpu_uniforms();
+        let reduced_motion = uniforms.flags.reduced_motion;
+        let motion_scale = if reduced_motion { 0.25 } else { 1.0 };
+        let intensity = uniforms.gesture_intensity;
+        let portrait_width = 1.08 + (intensity * 0.06 * motion_scale);
+        let portrait_height = 1.42 + (intensity * 0.08 * motion_scale);
+
+        Ok(Self {
+            renderer_id: WGPU_SPIKE_RENDERER_ID.to_owned(),
+            shader_label: WGPU_SPIKE_SHADER_LABEL.to_owned(),
+            uniforms,
+            surface_target: contract.target,
+            texture_format: contract.texture_format,
+            alpha_mode: contract.alpha_mode,
+            target_size: config.target_size,
+            primitives: contract.primitives.clone(),
+            portrait: WgpuPortraitPlane {
+                center: [uniforms.head[0] * 0.035 * motion_scale, -0.03],
+                size: [portrait_width, portrait_height],
+                alpha_cutoff: config.alpha_cutoff.clamp(0.0, 1.0),
+                tint_rgb: frame.material.primary_rgb,
+            },
+            reticles: WgpuReticleRings {
+                ring_count: 2,
+                outer_radius: 0.73,
+                rotation_rate: reticle_rotation_rate(uniforms.mode_id, intensity, reduced_motion),
+                opacity: if reduced_motion {
+                    0.28
+                } else {
+                    0.52 + intensity * 0.20
+                },
+            },
+            particles: WgpuParticleField {
+                count: particle_count(uniforms.mode_id, config.max_particles, reduced_motion),
+                seed: particle_seed(frame.time_ms, uniforms.mode_id),
+            },
+            face_overlay: WgpuFaceOverlay {
+                face: uniforms.face,
+                tracked_face: uniforms.flags.tracked_face,
+            },
+            body_rig: WgpuBodyGestureRig {
+                head: uniforms.head,
+                hands: if reduced_motion {
+                    [uniforms.hands[0] * 0.35, uniforms.hands[1] * 0.35]
+                } else {
+                    uniforms.hands
+                },
+                intensity,
+            },
+            reduced_motion,
+        })
+    }
+}
+
+/// Feature-gated native wgpu renderer spike.
+#[derive(Clone, Debug)]
+pub struct WgpuAvatarSpikeRenderer {
+    contract: WgpuRendererContract,
+    config: WgpuAvatarRendererConfig,
+    last_plan: Option<WgpuAvatarRenderPlan>,
+}
+
+impl WgpuAvatarSpikeRenderer {
+    /// Creates a renderer spike using the default direct-wgpu contract.
+    pub fn new(config: WgpuAvatarRendererConfig) -> Self {
+        Self::with_contract(WgpuRendererContract::default(), config)
+    }
+
+    /// Creates a renderer spike with an explicit contract.
+    pub fn with_contract(contract: WgpuRendererContract, config: WgpuAvatarRendererConfig) -> Self {
+        Self {
+            contract,
+            config,
+            last_plan: None,
+        }
+    }
+
+    /// Returns the last adapter plan accepted by this renderer.
+    pub fn last_plan(&self) -> Option<&WgpuAvatarRenderPlan> {
+        self.last_plan.as_ref()
+    }
+}
+
+impl Default for WgpuAvatarSpikeRenderer {
+    fn default() -> Self {
+        Self::new(WgpuAvatarRendererConfig::default())
+    }
+}
+
+impl AvatarRenderer for WgpuAvatarSpikeRenderer {
+    fn backend(&self) -> RendererBackend {
+        RendererBackend::WgpuNative
+    }
+
+    fn render(&mut self, frame: &AvatarFrame) -> Result<AvatarRenderReceipt, AvatarRenderError> {
+        let plan = WgpuAvatarRenderPlan::from_frame(frame, &self.contract, self.config)?;
+        self.last_plan = Some(plan);
+        Ok(AvatarRenderReceipt {
+            backend: self.backend(),
+            time_ms: frame.time_ms,
+        })
+    }
+}
+
+impl WgpuAvatarRenderer for WgpuAvatarSpikeRenderer {
+    fn wgpu_contract(&self) -> WgpuRendererContract {
+        self.contract.clone()
+    }
+}
+
+fn validate_contract(
+    contract: &WgpuRendererContract,
+    config: WgpuAvatarRendererConfig,
+) -> Result<(), AvatarRenderError> {
+    if contract.uniform_version != WGPU_AVATAR_UNIFORM_VERSION {
+        return Err(AvatarRenderError::new(
+            "wgpu avatar uniform contract version mismatch",
+        ));
+    }
+    if contract.requires_camera {
+        return Err(AvatarRenderError::new(
+            "wgpu avatar renderer must not require camera access",
+        ));
+    }
+    if config.target_size[0] == 0 || config.target_size[1] == 0 {
+        return Err(AvatarRenderError::new(
+            "wgpu avatar target size must be non-zero",
+        ));
+    }
+    if !config.surface_available {
+        return Err(AvatarRenderError::new("wgpu avatar surface lost"));
+    }
+    if !config.portrait_texture_ready {
+        return Err(AvatarRenderError::new(
+            "wulan portrait texture is not ready",
+        ));
+    }
+    Ok(())
+}
+
+fn reticle_rotation_rate(mode_id: u32, intensity: f32, reduced_motion: bool) -> f32 {
+    if reduced_motion {
+        return 0.0;
+    }
+
+    match mode_id {
+        2 => 0.90 + intensity * 0.45,
+        3 => 0.55 + intensity * 0.30,
+        4 => 0.36,
+        5 => 0.18,
+        6 => 1.25,
+        _ => 0.24,
+    }
+}
+
+fn particle_count(mode_id: u32, max_particles: u16, reduced_motion: bool) -> u16 {
+    let desired = match mode_id {
+        1 => 72,
+        2 => 96,
+        3 => 88,
+        4 => 80,
+        5 => 64,
+        6 => 48,
+        _ => 44,
+    };
+    let capped = desired.min(max_particles);
+    if reduced_motion {
+        capped.min(24)
+    } else {
+        capped
+    }
+}
+
+fn particle_seed(time_ms: u64, mode_id: u32) -> u32 {
+    let low = time_ms as u32;
+    low.rotate_left(7) ^ mode_id.wrapping_mul(0x9e37)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        render_or_fallback, AvatarEngine, AvatarEngineConfig, AvatarFallbackReason,
+        AvatarFallbackState, AvatarFallbackTarget, AvatarInput, AvatarMode, AvatarRenderAttempt,
+        BodyGesturePriority,
+    };
+
+    #[test]
+    fn spike_renderer_accepts_wgpu_frames_and_records_plan() {
+        let mut engine = AvatarEngine::new(AvatarEngineConfig::default());
+        let frame = engine.update(AvatarInput {
+            mode: AvatarMode::Thinking,
+            now_ms: 2_000,
+            ..AvatarInput::default()
+        });
+        let mut renderer = WgpuAvatarSpikeRenderer::default();
+
+        let receipt = renderer.render(&frame).expect("wgpu plan should render");
+        let plan = renderer.last_plan().expect("render should store plan");
+
+        assert_eq!(receipt.backend, RendererBackend::WgpuNative);
+        assert_eq!(receipt.time_ms, 2_000);
+        assert_eq!(plan.renderer_id, WGPU_SPIKE_RENDERER_ID);
+        assert_eq!(plan.uniforms.mode_id, 2);
+        assert_eq!(plan.reticles.ring_count, 2);
+        assert!(plan.reticles.rotation_rate > 0.0);
+        assert!(plan.particles.count > 24);
+    }
+
+    #[test]
+    fn reduced_motion_limits_dynamic_wgpu_primitives() {
+        let mut engine = AvatarEngine::new(AvatarEngineConfig {
+            reduced_motion: true,
+            ..AvatarEngineConfig::default()
+        });
+        let frame = engine.update(AvatarInput {
+            mode: AvatarMode::Error,
+            now_ms: 333,
+            ..AvatarInput::default()
+        });
+        let plan = WgpuAvatarRenderPlan::from_frame(
+            &frame,
+            &WgpuRendererContract::default(),
+            WgpuAvatarRendererConfig::default(),
+        )
+        .expect("reduced motion frame should plan");
+
+        assert!(plan.reduced_motion);
+        assert_eq!(plan.reticles.rotation_rate, 0.0);
+        assert!(plan.reticles.opacity <= 0.28);
+        assert!(plan.particles.count <= 24);
+        assert!(plan.body_rig.hands[0] < frame.body.left_hand);
+        assert_eq!(frame.body_state.priority, BodyGesturePriority::Safety);
+    }
+
+    #[test]
+    fn unavailable_surface_uses_cadis_orb_fallback() {
+        let mut engine = AvatarEngine::new(AvatarEngineConfig {
+            reduced_motion: true,
+            ..AvatarEngineConfig::default()
+        });
+        let frame = engine.update(AvatarInput {
+            mode: AvatarMode::Approval,
+            now_ms: 444,
+            ..AvatarInput::default()
+        });
+        let contract = engine.config().renderer_contract();
+        let mut renderer = WgpuAvatarSpikeRenderer::new(WgpuAvatarRendererConfig {
+            surface_available: false,
+            ..WgpuAvatarRendererConfig::default()
+        });
+
+        let attempt = render_or_fallback(&mut renderer, &frame, &contract);
+
+        assert_eq!(
+            attempt,
+            AvatarRenderAttempt::Fallback(AvatarFallbackState {
+                target: AvatarFallbackTarget::CadisOrb,
+                reason: AvatarFallbackReason::RenderError,
+                failed_backend: RendererBackend::WgpuNative,
+                mode: AvatarMode::Approval,
+                reduced_motion: true,
+                time_ms: 444,
+            })
+        );
+        assert!(renderer.last_plan().is_none());
+    }
+}

--- a/crates/cadis-cli/src/main.rs
+++ b/crates/cadis-cli/src/main.rs
@@ -11,9 +11,9 @@ use cadis_protocol::{
     ApprovalResponseRequest, ClientId, ClientRequest, ContentKind, DaemonResponse, EmptyPayload,
     ErrorPayload, EventId, EventSubscriptionRequest, EventsSnapshotRequest, MessageSendRequest,
     ModelsListPayload, RequestEnvelope, RequestId, ServerFrame, SessionId, ToolCallRequest,
-    WorkspaceAccess, WorkspaceDoctorPayload, WorkspaceDoctorRequest, WorkspaceGrantPayload,
-    WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest,
-    WorkspaceRecordPayload, WorkspaceRegisterRequest, WorkspaceRevokeRequest,
+    WorkerTailRequest, WorkspaceAccess, WorkspaceDoctorPayload, WorkspaceDoctorRequest,
+    WorkspaceGrantPayload, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceListPayload,
+    WorkspaceListRequest, WorkspaceRecordPayload, WorkspaceRegisterRequest, WorkspaceRevokeRequest,
 };
 use cadis_store::load_config;
 
@@ -51,6 +51,7 @@ fn run() -> Result<(), Box<dyn Error>> {
             let frames = send_request(&cli, ClientRequest::AgentList(EmptyPayload::default()))?;
             render_agents(&frames, cli.json)
         }
+        Command::Worker(command) => run_worker(&cli, command),
         Command::Workspace(command) => run_workspace(&cli, command),
         Command::Events {
             replay_limit,
@@ -271,6 +272,20 @@ fn run_workspace(cli: &Cli, command: &WorkspaceCommand) -> Result<(), Box<dyn Er
     };
 
     render_workspace(&frames, cli.json)
+}
+
+fn run_worker(cli: &Cli, command: &WorkerCommand) -> Result<(), Box<dyn Error>> {
+    let frames = match command {
+        WorkerCommand::Tail { worker_id, lines } => send_request(
+            cli,
+            ClientRequest::WorkerTail(WorkerTailRequest {
+                worker_id: worker_id.clone(),
+                lines: *lines,
+            }),
+        )?,
+    };
+
+    render_worker_tail(&frames, cli.json)
 }
 
 fn send_request(cli: &Cli, request: ClientRequest) -> Result<Vec<ServerFrame>, Box<dyn Error>> {
@@ -640,6 +655,26 @@ fn render_tool(frames: &[ServerFrame], json: bool) -> Result<(), Box<dyn Error>>
     Ok(())
 }
 
+fn render_worker_tail(frames: &[ServerFrame], json: bool) -> Result<(), Box<dyn Error>> {
+    if json {
+        return print_json_frames(frames);
+    }
+
+    render_rejections(frames)?;
+    for frame in frames {
+        let ServerFrame::Event(event) = frame else {
+            continue;
+        };
+        if let cadis_protocol::CadisEvent::WorkerLogDelta(payload) = &event.event {
+            print!("{}", payload.delta);
+            if !payload.delta.ends_with('\n') {
+                println!();
+            }
+        }
+    }
+    Ok(())
+}
+
 fn render_rejections_or_json(frames: &[ServerFrame], json: bool) -> Result<(), Box<dyn Error>> {
     if json {
         return print_json_frames(frames);
@@ -762,6 +797,7 @@ impl Cli {
             Some("doctor") => Command::Doctor,
             Some("models") => Command::Models,
             Some("agents") => Command::Agents,
+            Some("worker") => Command::Worker(parse_worker(args.collect())?),
             Some("workspace") => Command::Workspace(parse_workspace(args.collect())?),
             Some("events") => parse_events(args.collect())?,
             Some("spawn") => parse_spawn(args.collect())?,
@@ -806,6 +842,7 @@ enum Command {
     Doctor,
     Models,
     Agents,
+    Worker(WorkerCommand),
     Workspace(WorkspaceCommand),
     Events {
         replay_limit: Option<u32>,
@@ -834,6 +871,14 @@ enum Command {
     },
     Approve(String),
     Deny(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum WorkerCommand {
+    Tail {
+        worker_id: String,
+        lines: Option<u32>,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -866,6 +911,46 @@ enum WorkspaceCommand {
         workspace_id: Option<String>,
         root: Option<PathBuf>,
     },
+}
+
+fn parse_worker(args: Vec<String>) -> Result<WorkerCommand, Box<dyn Error>> {
+    let mut args = args.into_iter();
+    match args.next().as_deref() {
+        Some("tail") => parse_worker_tail(args.collect()),
+        Some(other) => Err(invalid_input(format!("unknown worker command: {other}")).into()),
+        None => Err(invalid_input("worker requires a subcommand").into()),
+    }
+}
+
+fn parse_worker_tail(args: Vec<String>) -> Result<WorkerCommand, Box<dyn Error>> {
+    let mut lines = None;
+    let mut positionals = Vec::new();
+    let mut args = args.into_iter();
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--lines" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| invalid_input("--lines requires a count"))?;
+                lines = Some(value.parse::<u32>().map_err(|error| {
+                    invalid_input(format!("--lines requires a non-negative integer: {error}"))
+                })?);
+            }
+            value if value.starts_with("--") => {
+                return Err(invalid_input(format!("unknown worker tail option: {value}")).into());
+            }
+            value => positionals.push(value.to_owned()),
+        }
+    }
+
+    Ok(WorkerCommand::Tail {
+        worker_id: positionals
+            .first()
+            .cloned()
+            .ok_or_else(|| invalid_input("worker tail requires a worker ID"))?,
+        lines,
+    })
 }
 
 fn parse_workspace(args: Vec<String>) -> Result<WorkspaceCommand, Box<dyn Error>> {
@@ -1330,7 +1415,7 @@ fn invalid_data(message: impl Into<String>) -> io::Error {
 
 fn print_help() {
     println!(
-        "cadis {}\n\nUSAGE:\n  cadis [--socket PATH] [--json] <COMMAND>\n\nCOMMANDS:\n  daemon [ARGS...]       Launch cadisd from PATH or sibling target directory\n  status                 Show daemon status\n  doctor                 Check local config and daemon connectivity\n  models                 List model provider options\n  agents                 List daemon-owned agents\n  workspace <COMMAND>    Manage registered workspaces and grants\n  events [OPTIONS]       Subscribe to daemon runtime events\n  spawn <ROLE> [OPTIONS] Spawn a child/subagent\n  chat <MESSAGE>         Send a one-shot chat message\n  run [--cwd PATH] <TASK> Send a desktop MVP task as a chat request\n  tool [OPTIONS] <NAME>  Request a daemon-owned tool call\n  approve <ID>           Respond to an approval request\n  deny <ID>              Deny an approval request\n\nWORKSPACE COMMANDS:\n  workspace list [--grants]\n  workspace register <ID> <ROOT> [--kind project|documents|sandbox|worktree]\n  workspace grant <ID> [--access read,write,exec,admin] [--agent AGENT]\n  workspace revoke (--grant ID | --workspace ID)\n  workspace doctor [--workspace ID] [--root PATH]\n\nEVENT OPTIONS:\n  --snapshot             Print one daemon-owned state snapshot and exit\n  --replay <COUNT>       Replay up to COUNT buffered events before live events\n  --since <EVENT_ID>     Replay retained events after EVENT_ID\n  --no-snapshot          Subscribe without initial state snapshot\n\nSPAWN OPTIONS:\n  --name <NAME>          Display name for the new agent\n  --parent <AGENT>       Parent agent ID, default main\n  --model <MODEL>        Provider/model identifier\n\nTOOL OPTIONS:\n  --cwd <PATH>           Workspace root for file and git tools\n  --workspace <ID>       Registered workspace ID for file and git tools\n  --session <ID>         Attach the tool call to a session\n  --agent <ID>           Use an agent context for scoped workspace grants\n  --input <JSON>         Structured tool input\n\nGLOBAL OPTIONS:\n  --socket <PATH>        Unix socket path\n  --json                 Print NDJSON server frames\n  --version, -V          Print version\n  --help, -h             Print help",
+        "cadis {}\n\nUSAGE:\n  cadis [--socket PATH] [--json] <COMMAND>\n\nCOMMANDS:\n  daemon [ARGS...]       Launch cadisd from PATH or sibling target directory\n  status                 Show daemon status\n  doctor                 Check local config and daemon connectivity\n  models                 List model provider options\n  agents                 List daemon-owned agents\n  worker <COMMAND>       Inspect daemon-owned workers\n  workspace <COMMAND>    Manage registered workspaces and grants\n  events [OPTIONS]       Subscribe to daemon runtime events\n  spawn <ROLE> [OPTIONS] Spawn a child/subagent\n  chat <MESSAGE>         Send a one-shot chat message\n  run [--cwd PATH] <TASK> Send a desktop MVP task as a chat request\n  tool [OPTIONS] <NAME>  Request a daemon-owned tool call\n  approve <ID>           Respond to an approval request\n  deny <ID>              Deny an approval request\n\nWORKER COMMANDS:\n  worker tail <ID> [--lines COUNT]\n\nWORKSPACE COMMANDS:\n  workspace list [--grants]\n  workspace register <ID> <ROOT> [--kind project|documents|sandbox|worktree]\n  workspace grant <ID> [--access read,write,exec,admin] [--agent AGENT]\n  workspace revoke (--grant ID | --workspace ID)\n  workspace doctor [--workspace ID] [--root PATH]\n\nEVENT OPTIONS:\n  --snapshot             Print one daemon-owned state snapshot and exit\n  --replay <COUNT>       Replay up to COUNT buffered events before live events\n  --since <EVENT_ID>     Replay retained events after EVENT_ID\n  --no-snapshot          Subscribe without initial state snapshot\n\nSPAWN OPTIONS:\n  --name <NAME>          Display name for the new agent\n  --parent <AGENT>       Parent agent ID, default main\n  --model <MODEL>        Provider/model identifier\n\nTOOL OPTIONS:\n  --cwd <PATH>           Workspace root for file and git tools\n  --workspace <ID>       Registered workspace ID for file and git tools\n  --session <ID>         Attach the tool call to a session\n  --agent <ID>           Use an agent context for scoped workspace grants\n  --input <JSON>         Structured tool input\n\nGLOBAL OPTIONS:\n  --socket <PATH>        Unix socket path\n  --json                 Print NDJSON server frames\n  --version, -V          Print version\n  --help, -h             Print help",
         env!("CARGO_PKG_VERSION")
     );
 }

--- a/crates/cadis-cli/src/main.rs
+++ b/crates/cadis-cli/src/main.rs
@@ -10,10 +10,11 @@ use cadis_protocol::{
     AgentEventPayload, AgentId, AgentSpawnRequest, ApprovalDecision, ApprovalId,
     ApprovalResponseRequest, ClientId, ClientRequest, ContentKind, DaemonResponse, EmptyPayload,
     ErrorPayload, EventId, EventSubscriptionRequest, EventsSnapshotRequest, MessageSendRequest,
-    ModelsListPayload, RequestEnvelope, RequestId, ServerFrame, SessionId, ToolCallRequest,
-    WorkspaceAccess, WorkspaceDoctorPayload, WorkspaceDoctorRequest, WorkspaceGrantPayload,
-    WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest,
-    WorkspaceRecordPayload, WorkspaceRegisterRequest, WorkspaceRevokeRequest,
+    ModelsListPayload, RequestEnvelope, RequestId, ServerFrame, SessionId,
+    SessionSubscriptionRequest, ToolCallRequest, WorkspaceAccess, WorkspaceDoctorPayload,
+    WorkspaceDoctorRequest, WorkspaceGrantPayload, WorkspaceGrantRequest, WorkspaceId,
+    WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest, WorkspaceRecordPayload,
+    WorkspaceRegisterRequest, WorkspaceRevokeRequest,
 };
 use cadis_store::load_config;
 
@@ -52,6 +53,7 @@ fn run() -> Result<(), Box<dyn Error>> {
             render_agents(&frames, cli.json)
         }
         Command::Workspace(command) => run_workspace(&cli, command),
+        Command::Session(command) => run_session(&cli, command),
         Command::Events {
             replay_limit,
             since_event_id,
@@ -273,6 +275,27 @@ fn run_workspace(cli: &Cli, command: &WorkspaceCommand) -> Result<(), Box<dyn Er
     render_workspace(&frames, cli.json)
 }
 
+fn run_session(cli: &Cli, command: &SessionCommand) -> Result<(), Box<dyn Error>> {
+    match command {
+        SessionCommand::Subscribe {
+            session_id,
+            replay_limit,
+            since_event_id,
+            include_snapshot,
+        } => stream_subscription(
+            cli,
+            ClientRequest::SessionSubscribe(SessionSubscriptionRequest {
+                session_id: SessionId::from(session_id.clone()),
+                since_event_id: since_event_id
+                    .as_ref()
+                    .map(|value| EventId::from(value.clone())),
+                replay_limit: *replay_limit,
+                include_snapshot: *include_snapshot,
+            }),
+        ),
+    }
+}
+
 fn send_request(cli: &Cli, request: ClientRequest) -> Result<Vec<ServerFrame>, Box<dyn Error>> {
     let socket_path = cli.socket_path()?;
     let mut stream = UnixStream::connect(&socket_path).map_err(|error| {
@@ -304,6 +327,10 @@ fn send_request(cli: &Cli, request: ClientRequest) -> Result<Vec<ServerFrame>, B
 }
 
 fn stream_events(cli: &Cli, request: EventSubscriptionRequest) -> Result<(), Box<dyn Error>> {
+    stream_subscription(cli, ClientRequest::EventsSubscribe(request))
+}
+
+fn stream_subscription(cli: &Cli, request: ClientRequest) -> Result<(), Box<dyn Error>> {
     let socket_path = cli.socket_path()?;
     let mut stream = UnixStream::connect(&socket_path).map_err(|error| {
         io::Error::new(
@@ -315,11 +342,7 @@ fn stream_events(cli: &Cli, request: EventSubscriptionRequest) -> Result<(), Box
         )
     })?;
 
-    let envelope = RequestEnvelope::new(
-        next_request_id(),
-        client_id(),
-        ClientRequest::EventsSubscribe(request),
-    );
+    let envelope = RequestEnvelope::new(next_request_id(), client_id(), request);
     serde_json::to_writer(&mut stream, &envelope)?;
     stream.write_all(b"\n")?;
     stream.shutdown(std::net::Shutdown::Write)?;
@@ -763,6 +786,7 @@ impl Cli {
             Some("models") => Command::Models,
             Some("agents") => Command::Agents,
             Some("workspace") => Command::Workspace(parse_workspace(args.collect())?),
+            Some("session") => Command::Session(parse_session(args.collect())?),
             Some("events") => parse_events(args.collect())?,
             Some("spawn") => parse_spawn(args.collect())?,
             Some("chat") => {
@@ -807,6 +831,7 @@ enum Command {
     Models,
     Agents,
     Workspace(WorkspaceCommand),
+    Session(SessionCommand),
     Events {
         replay_limit: Option<u32>,
         since_event_id: Option<String>,
@@ -834,6 +859,16 @@ enum Command {
     },
     Approve(String),
     Deny(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum SessionCommand {
+    Subscribe {
+        session_id: String,
+        replay_limit: Option<u32>,
+        since_event_id: Option<String>,
+        include_snapshot: bool,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1124,6 +1159,61 @@ fn parse_workspace_access_list(value: &str) -> Result<Vec<WorkspaceAccess>, Box<
     Ok(access)
 }
 
+fn parse_session(args: Vec<String>) -> Result<SessionCommand, Box<dyn Error>> {
+    let mut args = args.into_iter();
+    match args.next().as_deref() {
+        Some("subscribe") => parse_session_subscribe(args.collect()),
+        Some(other) => Err(invalid_input(format!("unknown session command: {other}")).into()),
+        None => Err(invalid_input("session requires a subcommand").into()),
+    }
+}
+
+fn parse_session_subscribe(args: Vec<String>) -> Result<SessionCommand, Box<dyn Error>> {
+    let mut replay_limit = Some(128);
+    let mut since_event_id = None;
+    let mut include_snapshot = true;
+    let mut positionals = Vec::new();
+    let mut args = args.into_iter();
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--replay" => {
+                let value = args
+                    .next()
+                    .ok_or_else(|| invalid_input("--replay requires a count"))?;
+                replay_limit = Some(value.parse::<u32>().map_err(|error| {
+                    invalid_input(format!("--replay requires a non-negative integer: {error}"))
+                })?);
+            }
+            "--since" => {
+                since_event_id = Some(
+                    args.next()
+                        .ok_or_else(|| invalid_input("--since requires an event ID"))?,
+                );
+            }
+            "--no-snapshot" => include_snapshot = false,
+            value if value.starts_with("--") => {
+                return Err(
+                    invalid_input(format!("unknown session subscribe option: {value}")).into(),
+                );
+            }
+            value => positionals.push(value.to_owned()),
+        }
+    }
+
+    let session_id = positionals
+        .first()
+        .ok_or_else(|| invalid_input("session subscribe requires a session ID"))?
+        .clone();
+
+    Ok(SessionCommand::Subscribe {
+        session_id,
+        replay_limit,
+        since_event_id,
+        include_snapshot,
+    })
+}
+
 fn parse_events(args: Vec<String>) -> Result<Command, Box<dyn Error>> {
     let mut replay_limit = Some(128);
     let mut since_event_id = None;
@@ -1330,7 +1420,7 @@ fn invalid_data(message: impl Into<String>) -> io::Error {
 
 fn print_help() {
     println!(
-        "cadis {}\n\nUSAGE:\n  cadis [--socket PATH] [--json] <COMMAND>\n\nCOMMANDS:\n  daemon [ARGS...]       Launch cadisd from PATH or sibling target directory\n  status                 Show daemon status\n  doctor                 Check local config and daemon connectivity\n  models                 List model provider options\n  agents                 List daemon-owned agents\n  workspace <COMMAND>    Manage registered workspaces and grants\n  events [OPTIONS]       Subscribe to daemon runtime events\n  spawn <ROLE> [OPTIONS] Spawn a child/subagent\n  chat <MESSAGE>         Send a one-shot chat message\n  run [--cwd PATH] <TASK> Send a desktop MVP task as a chat request\n  tool [OPTIONS] <NAME>  Request a daemon-owned tool call\n  approve <ID>           Respond to an approval request\n  deny <ID>              Deny an approval request\n\nWORKSPACE COMMANDS:\n  workspace list [--grants]\n  workspace register <ID> <ROOT> [--kind project|documents|sandbox|worktree]\n  workspace grant <ID> [--access read,write,exec,admin] [--agent AGENT]\n  workspace revoke (--grant ID | --workspace ID)\n  workspace doctor [--workspace ID] [--root PATH]\n\nEVENT OPTIONS:\n  --snapshot             Print one daemon-owned state snapshot and exit\n  --replay <COUNT>       Replay up to COUNT buffered events before live events\n  --since <EVENT_ID>     Replay retained events after EVENT_ID\n  --no-snapshot          Subscribe without initial state snapshot\n\nSPAWN OPTIONS:\n  --name <NAME>          Display name for the new agent\n  --parent <AGENT>       Parent agent ID, default main\n  --model <MODEL>        Provider/model identifier\n\nTOOL OPTIONS:\n  --cwd <PATH>           Workspace root for file and git tools\n  --workspace <ID>       Registered workspace ID for file and git tools\n  --session <ID>         Attach the tool call to a session\n  --agent <ID>           Use an agent context for scoped workspace grants\n  --input <JSON>         Structured tool input\n\nGLOBAL OPTIONS:\n  --socket <PATH>        Unix socket path\n  --json                 Print NDJSON server frames\n  --version, -V          Print version\n  --help, -h             Print help",
+        "cadis {}\n\nUSAGE:\n  cadis [--socket PATH] [--json] <COMMAND>\n\nCOMMANDS:\n  daemon [ARGS...]       Launch cadisd from PATH or sibling target directory\n  status                 Show daemon status\n  doctor                 Check local config and daemon connectivity\n  models                 List model provider options\n  agents                 List daemon-owned agents\n  workspace <COMMAND>    Manage registered workspaces and grants\n  session <COMMAND>      Manage session event streams\n  events [OPTIONS]       Subscribe to all daemon runtime events\n  spawn <ROLE> [OPTIONS] Spawn a child/subagent\n  chat <MESSAGE>         Send a one-shot chat message\n  run [--cwd PATH] <TASK> Send a desktop MVP task as a chat request\n  tool [OPTIONS] <NAME>  Request a daemon-owned tool call\n  approve <ID>           Respond to an approval request\n  deny <ID>              Deny an approval request\n\nWORKSPACE COMMANDS:\n  workspace list [--grants]\n  workspace register <ID> <ROOT> [--kind project|documents|sandbox|worktree]\n  workspace grant <ID> [--access read,write,exec,admin] [--agent AGENT]\n  workspace revoke (--grant ID | --workspace ID)\n  workspace doctor [--workspace ID] [--root PATH]\n\nSESSION COMMANDS:\n  session subscribe <ID> [--replay COUNT] [--since EVENT_ID] [--no-snapshot]\n\nEVENT OPTIONS:\n  --snapshot             Print one daemon-owned state snapshot and exit\n  --replay <COUNT>       Replay up to COUNT buffered events before live events\n  --since <EVENT_ID>     Replay retained events after EVENT_ID\n  --no-snapshot          Subscribe without initial state snapshot\n\nSPAWN OPTIONS:\n  --name <NAME>          Display name for the new agent\n  --parent <AGENT>       Parent agent ID, default main\n  --model <MODEL>        Provider/model identifier\n\nTOOL OPTIONS:\n  --cwd <PATH>           Workspace root for file and git tools\n  --workspace <ID>       Registered workspace ID for file and git tools\n  --session <ID>         Attach the tool call to a session\n  --agent <ID>           Use an agent context for scoped workspace grants\n  --input <JSON>         Structured tool input\n\nGLOBAL OPTIONS:\n  --socket <PATH>        Unix socket path\n  --json                 Print NDJSON server frames\n  --version, -V          Print version\n  --help, -h             Print help",
         env!("CARGO_PKG_VERSION")
     );
 }

--- a/crates/cadis-cli/src/main.rs
+++ b/crates/cadis-cli/src/main.rs
@@ -11,9 +11,10 @@ use cadis_protocol::{
     ApprovalResponseRequest, ClientId, ClientRequest, ContentKind, DaemonResponse, EmptyPayload,
     ErrorPayload, EventId, EventSubscriptionRequest, EventsSnapshotRequest, MessageSendRequest,
     ModelsListPayload, RequestEnvelope, RequestId, ServerFrame, SessionId, ToolCallRequest,
-    WorkspaceAccess, WorkspaceDoctorPayload, WorkspaceDoctorRequest, WorkspaceGrantPayload,
-    WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest,
-    WorkspaceRecordPayload, WorkspaceRegisterRequest, WorkspaceRevokeRequest,
+    VoiceDoctorPayload, VoiceDoctorRequest, VoiceRuntimeState, VoiceStatusPayload, WorkspaceAccess,
+    WorkspaceDoctorPayload, WorkspaceDoctorRequest, WorkspaceGrantPayload, WorkspaceGrantRequest,
+    WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest, WorkspaceRecordPayload,
+    WorkspaceRegisterRequest, WorkspaceRevokeRequest,
 };
 use cadis_store::load_config;
 
@@ -52,6 +53,7 @@ fn run() -> Result<(), Box<dyn Error>> {
             render_agents(&frames, cli.json)
         }
         Command::Workspace(command) => run_workspace(&cli, command),
+        Command::Voice(command) => run_voice(&cli, command),
         Command::Events {
             replay_limit,
             since_event_id,
@@ -177,25 +179,50 @@ fn send_approval(
 
 fn run_doctor(cli: &Cli) -> Result<(), Box<dyn Error>> {
     let config = load_config()?;
+    let status_frames = send_request(cli, ClientRequest::DaemonStatus(EmptyPayload::default()))?;
+    let voice_frames = send_request(
+        cli,
+        ClientRequest::VoiceDoctor(VoiceDoctorRequest::default()),
+    )?;
+
+    if cli.json {
+        print_json_frames(&status_frames)?;
+        return print_json_frames(&voice_frames);
+    }
+
     println!("cadis doctor");
     println!("cadis_home: {}", config.cadis_home.display());
     println!("config: {}", config.config_path().display());
     println!("socket: {}", cli.socket_path()?.display());
 
-    let frames = send_request(cli, ClientRequest::DaemonStatus(EmptyPayload::default()))?;
     print!("daemon: ");
-    match daemon_status(&frames) {
+    match daemon_status(&status_frames) {
         Some(status) => {
             println!("{}", status.status);
             println!("model_provider: {}", status.model_provider);
             println!("sessions: {}", status.sessions);
+            render_voice(&voice_frames, false)?;
             Ok(())
         }
         None => {
             println!("unexpected response");
-            render_rejections_or_json(&frames, cli.json)
+            render_rejections_or_json(&status_frames, cli.json)
         }
     }
+}
+
+fn run_voice(cli: &Cli, command: &VoiceCommand) -> Result<(), Box<dyn Error>> {
+    let frames = match command {
+        VoiceCommand::Status => {
+            send_request(cli, ClientRequest::VoiceStatus(EmptyPayload::default()))?
+        }
+        VoiceCommand::Doctor => send_request(
+            cli,
+            ClientRequest::VoiceDoctor(VoiceDoctorRequest::default()),
+        )?,
+    };
+
+    render_voice(&frames, cli.json)
 }
 
 fn run_workspace(cli: &Cli, command: &WorkspaceCommand) -> Result<(), Box<dyn Error>> {
@@ -359,6 +386,7 @@ fn render_status(frames: &[ServerFrame], json: bool) -> Result<(), Box<dyn Error
     println!("sessions: {}", status.sessions);
     println!("model_provider: {}", status.model_provider);
     println!("uptime_seconds: {}", status.uptime_seconds);
+    print_voice_status(&status.voice);
     Ok(())
 }
 
@@ -468,6 +496,73 @@ fn render_workspace(frames: &[ServerFrame], json: bool) -> Result<(), Box<dyn Er
         println!("no workspace data returned");
     }
     Ok(())
+}
+
+fn render_voice(frames: &[ServerFrame], json: bool) -> Result<(), Box<dyn Error>> {
+    if json {
+        return print_json_frames(frames);
+    }
+
+    render_rejections(frames)?;
+    let mut rendered = false;
+    for frame in frames {
+        let ServerFrame::Event(event) = frame else {
+            continue;
+        };
+        match &event.event {
+            cadis_protocol::CadisEvent::VoiceStatusUpdated(status) => {
+                print_voice_status(status);
+                rendered = true;
+            }
+            cadis_protocol::CadisEvent::VoiceDoctorResponse(payload)
+            | cadis_protocol::CadisEvent::VoicePreflightResponse(payload) => {
+                print_voice_doctor(payload);
+                rendered = true;
+            }
+            _ => {}
+        }
+    }
+
+    if !rendered {
+        println!("no voice data returned");
+    }
+    Ok(())
+}
+
+fn print_voice_doctor(payload: &VoiceDoctorPayload) {
+    print_voice_status(&payload.status);
+    for check in &payload.checks {
+        println!("{}\t{}\t{}", check.status, check.name, check.message);
+    }
+}
+
+fn print_voice_status(status: &VoiceStatusPayload) {
+    println!(
+        "voice: {}\tenabled={}\tprovider={}\tvoice={}\tstt={}\tbridge={}\tmax_spoken_chars={}",
+        voice_state_name(status.state),
+        status.enabled,
+        status.provider,
+        status.voice_id,
+        status.stt_language,
+        status.bridge,
+        status.max_spoken_chars
+    );
+    if let Some(preflight) = &status.last_preflight {
+        println!(
+            "voice_preflight: {}\t{}\tsurface={}\tchecked_at={}",
+            preflight.status, preflight.summary, preflight.surface, preflight.checked_at
+        );
+    }
+}
+
+fn voice_state_name(state: VoiceRuntimeState) -> &'static str {
+    match state {
+        VoiceRuntimeState::Disabled => "disabled",
+        VoiceRuntimeState::Ready => "ready",
+        VoiceRuntimeState::Degraded => "degraded",
+        VoiceRuntimeState::Blocked => "blocked",
+        VoiceRuntimeState::Unknown => "unknown",
+    }
 }
 
 fn print_workspace(workspace: &WorkspaceRecordPayload) {
@@ -763,6 +858,7 @@ impl Cli {
             Some("models") => Command::Models,
             Some("agents") => Command::Agents,
             Some("workspace") => Command::Workspace(parse_workspace(args.collect())?),
+            Some("voice") => Command::Voice(parse_voice(args.collect())?),
             Some("events") => parse_events(args.collect())?,
             Some("spawn") => parse_spawn(args.collect())?,
             Some("chat") => {
@@ -807,6 +903,7 @@ enum Command {
     Models,
     Agents,
     Workspace(WorkspaceCommand),
+    Voice(VoiceCommand),
     Events {
         replay_limit: Option<u32>,
         since_event_id: Option<String>,
@@ -866,6 +963,21 @@ enum WorkspaceCommand {
         workspace_id: Option<String>,
         root: Option<PathBuf>,
     },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum VoiceCommand {
+    Status,
+    Doctor,
+}
+
+fn parse_voice(args: Vec<String>) -> Result<VoiceCommand, Box<dyn Error>> {
+    let mut args = args.into_iter();
+    match args.next().as_deref() {
+        Some("status") | None => Ok(VoiceCommand::Status),
+        Some("doctor") => Ok(VoiceCommand::Doctor),
+        Some(other) => Err(invalid_input(format!("unknown voice command: {other}")).into()),
+    }
 }
 
 fn parse_workspace(args: Vec<String>) -> Result<WorkspaceCommand, Box<dyn Error>> {
@@ -1330,7 +1442,7 @@ fn invalid_data(message: impl Into<String>) -> io::Error {
 
 fn print_help() {
     println!(
-        "cadis {}\n\nUSAGE:\n  cadis [--socket PATH] [--json] <COMMAND>\n\nCOMMANDS:\n  daemon [ARGS...]       Launch cadisd from PATH or sibling target directory\n  status                 Show daemon status\n  doctor                 Check local config and daemon connectivity\n  models                 List model provider options\n  agents                 List daemon-owned agents\n  workspace <COMMAND>    Manage registered workspaces and grants\n  events [OPTIONS]       Subscribe to daemon runtime events\n  spawn <ROLE> [OPTIONS] Spawn a child/subagent\n  chat <MESSAGE>         Send a one-shot chat message\n  run [--cwd PATH] <TASK> Send a desktop MVP task as a chat request\n  tool [OPTIONS] <NAME>  Request a daemon-owned tool call\n  approve <ID>           Respond to an approval request\n  deny <ID>              Deny an approval request\n\nWORKSPACE COMMANDS:\n  workspace list [--grants]\n  workspace register <ID> <ROOT> [--kind project|documents|sandbox|worktree]\n  workspace grant <ID> [--access read,write,exec,admin] [--agent AGENT]\n  workspace revoke (--grant ID | --workspace ID)\n  workspace doctor [--workspace ID] [--root PATH]\n\nEVENT OPTIONS:\n  --snapshot             Print one daemon-owned state snapshot and exit\n  --replay <COUNT>       Replay up to COUNT buffered events before live events\n  --since <EVENT_ID>     Replay retained events after EVENT_ID\n  --no-snapshot          Subscribe without initial state snapshot\n\nSPAWN OPTIONS:\n  --name <NAME>          Display name for the new agent\n  --parent <AGENT>       Parent agent ID, default main\n  --model <MODEL>        Provider/model identifier\n\nTOOL OPTIONS:\n  --cwd <PATH>           Workspace root for file and git tools\n  --workspace <ID>       Registered workspace ID for file and git tools\n  --session <ID>         Attach the tool call to a session\n  --agent <ID>           Use an agent context for scoped workspace grants\n  --input <JSON>         Structured tool input\n\nGLOBAL OPTIONS:\n  --socket <PATH>        Unix socket path\n  --json                 Print NDJSON server frames\n  --version, -V          Print version\n  --help, -h             Print help",
+        "cadis {}\n\nUSAGE:\n  cadis [--socket PATH] [--json] <COMMAND>\n\nCOMMANDS:\n  daemon [ARGS...]       Launch cadisd from PATH or sibling target directory\n  status                 Show daemon status\n  doctor                 Check local config and daemon connectivity\n  models                 List model provider options\n  agents                 List daemon-owned agents\n  workspace <COMMAND>    Manage registered workspaces and grants\n  voice [COMMAND]        Show daemon-visible voice status or doctor checks\n  events [OPTIONS]       Subscribe to daemon runtime events\n  spawn <ROLE> [OPTIONS] Spawn a child/subagent\n  chat <MESSAGE>         Send a one-shot chat message\n  run [--cwd PATH] <TASK> Send a desktop MVP task as a chat request\n  tool [OPTIONS] <NAME>  Request a daemon-owned tool call\n  approve <ID>           Respond to an approval request\n  deny <ID>              Deny an approval request\n\nWORKSPACE COMMANDS:\n  workspace list [--grants]\n  workspace register <ID> <ROOT> [--kind project|documents|sandbox|worktree]\n  workspace grant <ID> [--access read,write,exec,admin] [--agent AGENT]\n  workspace revoke (--grant ID | --workspace ID)\n  workspace doctor [--workspace ID] [--root PATH]\n\nVOICE COMMANDS:\n  voice status           Show daemon-visible voice status\n  voice doctor           Show voice doctor and local bridge preflight state\n\nEVENT OPTIONS:\n  --snapshot             Print one daemon-owned state snapshot and exit\n  --replay <COUNT>       Replay up to COUNT buffered events before live events\n  --since <EVENT_ID>     Replay retained events after EVENT_ID\n  --no-snapshot          Subscribe without initial state snapshot\n\nSPAWN OPTIONS:\n  --name <NAME>          Display name for the new agent\n  --parent <AGENT>       Parent agent ID, default main\n  --model <MODEL>        Provider/model identifier\n\nTOOL OPTIONS:\n  --cwd <PATH>           Workspace root for file and git tools\n  --workspace <ID>       Registered workspace ID for file and git tools\n  --session <ID>         Attach the tool call to a session\n  --agent <ID>           Use an agent context for scoped workspace grants\n  --input <JSON>         Structured tool input\n\nGLOBAL OPTIONS:\n  --socket <PATH>        Unix socket path\n  --json                 Print NDJSON server frames\n  --version, -V          Print version\n  --help, -h             Print help",
         env!("CARGO_PKG_VERSION")
     );
 }

--- a/crates/cadis-cli/src/main.rs
+++ b/crates/cadis-cli/src/main.rs
@@ -375,14 +375,41 @@ fn render_models(frames: &[ServerFrame], json: bool) -> Result<(), Box<dyn Error
             {
                 for model in models {
                     println!(
-                        "{}\t{}\t{}",
-                        model.provider, model.model, model.display_name
+                        "{}\t{}\t{}\t{}\t{}\t{}",
+                        model.provider,
+                        model.model,
+                        model_readiness_label(model.readiness),
+                        effective_model_label(
+                            model.effective_provider.as_deref(),
+                            model.effective_model.as_deref()
+                        ),
+                        if model.fallback { "fallback" } else { "real" },
+                        model.display_name
                     );
                 }
             }
         }
     }
     Ok(())
+}
+
+fn model_readiness_label(readiness: Option<cadis_protocol::ModelReadiness>) -> &'static str {
+    match readiness {
+        Some(cadis_protocol::ModelReadiness::Ready) => "ready",
+        Some(cadis_protocol::ModelReadiness::Fallback) => "fallback",
+        Some(cadis_protocol::ModelReadiness::RequiresConfiguration) => "requires_configuration",
+        Some(cadis_protocol::ModelReadiness::Unavailable) => "unavailable",
+        None => "unknown",
+    }
+}
+
+fn effective_model_label(provider: Option<&str>, model: Option<&str>) -> String {
+    match (provider, model) {
+        (Some(provider), Some(model)) => format!("{provider}/{model}"),
+        (Some(provider), None) => provider.to_owned(),
+        (None, Some(model)) => model.to_owned(),
+        (None, None) => "-".to_owned(),
+    }
 }
 
 fn render_agents(frames: &[ServerFrame], json: bool) -> Result<(), Box<dyn Error>> {

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -20,11 +20,13 @@ use cadis_protocol::{
     ModelInvocationPayload, ModelReadiness, ModelsListPayload, OrchestratorRoutePayload,
     ProtocolVersion, RequestAcceptedPayload, RequestEnvelope, RequestId, ResponseEnvelope,
     SessionEventPayload, SessionId, Timestamp, ToolCallId, ToolCallRequest, ToolEventPayload,
-    ToolFailedPayload, UiPreferencesPayload, WorkerArtifactLocations, WorkerEventPayload,
-    WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent, WorkerWorktreeState, WorkspaceAccess,
-    WorkspaceDoctorCheck, WorkspaceDoctorPayload, WorkspaceDoctorRequest, WorkspaceGrantId,
-    WorkspaceGrantPayload, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceListPayload,
-    WorkspaceListRequest, WorkspaceRecordPayload, WorkspaceRegisterRequest, WorkspaceRevokeRequest,
+    ToolFailedPayload, UiPreferencesPayload, VoiceDoctorCheck, VoiceDoctorPayload,
+    VoicePreflightRequest, VoicePreflightSummary, VoiceRuntimeState, VoiceStatusPayload,
+    WorkerArtifactLocations, WorkerEventPayload, WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent,
+    WorkerWorktreeState, WorkspaceAccess, WorkspaceDoctorCheck, WorkspaceDoctorPayload,
+    WorkspaceDoctorRequest, WorkspaceGrantId, WorkspaceGrantPayload, WorkspaceGrantRequest,
+    WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest, WorkspaceRecordPayload,
+    WorkspaceRegisterRequest, WorkspaceRevokeRequest,
 };
 use cadis_store::{
     redact, ApprovalRecord, ApprovalState, ApprovalStore, CadisConfig, CadisHome, CheckpointPolicy,
@@ -127,6 +129,7 @@ pub struct Runtime {
     pending_approvals: HashMap<ApprovalId, PendingApproval>,
     workspaces: HashMap<WorkspaceId, WorkspaceRecord>,
     workspace_grants: HashMap<WorkspaceGrantId, WorkspaceGrantRecord>,
+    last_voice_preflight: Option<VoicePreflightRecord>,
     next_tool: u64,
     next_approval: u64,
     next_workspace_grant: u64,
@@ -181,6 +184,7 @@ impl Runtime {
             pending_approvals: HashMap::new(),
             workspaces,
             workspace_grants,
+            last_voice_preflight: None,
             next_tool: 1,
             next_approval: 1,
             next_workspace_grant,
@@ -363,6 +367,22 @@ impl Runtime {
             ClientRequest::ApprovalRespond(request) => {
                 self.handle_approval_response(request_id, request)
             }
+            ClientRequest::VoiceStatus(_) => {
+                let event = self.event(None, CadisEvent::VoiceStatusUpdated(self.voice_status()));
+                self.accept(request_id, vec![event])
+            }
+            ClientRequest::VoiceDoctor(request) => {
+                let event = self.event(
+                    None,
+                    CadisEvent::VoiceDoctorResponse(
+                        self.voice_doctor_payload(request.include_bridge),
+                    ),
+                );
+                self.accept(request_id, vec![event])
+            }
+            ClientRequest::VoicePreflight(request) => {
+                self.handle_voice_preflight(request_id, request)
+            }
             ClientRequest::VoicePreview(_) => {
                 let started = self.event(None, CadisEvent::VoicePreviewStarted(Default::default()));
                 let completed =
@@ -400,6 +420,7 @@ impl Runtime {
                     sessions: self.sessions.len(),
                     model_provider: self.options.model_provider.clone(),
                     uptime_seconds: self.started_at.elapsed().as_secs(),
+                    voice: self.voice_status(),
                 }),
             ),
             events: Vec::new(),
@@ -1266,6 +1287,159 @@ impl Runtime {
         self.accept(request_id, vec![event])
     }
 
+    fn handle_voice_preflight(
+        &mut self,
+        request_id: RequestId,
+        request: VoicePreflightRequest,
+    ) -> RequestOutcome {
+        let checked_at = now_timestamp();
+        let checks = normalize_voice_checks(request.checks);
+        let status = voice_check_summary_status(&checks);
+        let summary = request
+            .summary
+            .map(|summary| redact(&summary))
+            .filter(|summary| !summary.trim().is_empty())
+            .unwrap_or_else(|| voice_checks_summary(&checks));
+        let surface = request
+            .surface
+            .map(|surface| redact(&surface))
+            .filter(|surface| !surface.trim().is_empty())
+            .unwrap_or_else(|| "local-bridge".to_owned());
+
+        self.last_voice_preflight = Some(VoicePreflightRecord {
+            surface,
+            status,
+            summary,
+            checked_at,
+            checks,
+        });
+
+        let status_event = self.event(None, CadisEvent::VoiceStatusUpdated(self.voice_status()));
+        let response_event = self.event(
+            None,
+            CadisEvent::VoicePreflightResponse(self.voice_doctor_payload(true)),
+        );
+        self.accept(request_id, vec![status_event, response_event])
+    }
+
+    fn voice_status(&self) -> VoiceStatusPayload {
+        let prefs = VoiceRuntimePreferences::from_options(&self.ui_preferences);
+        let checks = self.voice_doctor_checks(true);
+        let state = if !prefs.enabled {
+            VoiceRuntimeState::Disabled
+        } else {
+            voice_runtime_state(&checks)
+        };
+
+        VoiceStatusPayload {
+            enabled: prefs.enabled,
+            state,
+            provider: prefs.provider,
+            voice_id: prefs.voice_id,
+            stt_language: prefs.stt_language,
+            max_spoken_chars: prefs.max_spoken_chars,
+            bridge: "hud-local".to_owned(),
+            last_preflight: self.last_voice_preflight.as_ref().map(|preflight| {
+                VoicePreflightSummary {
+                    surface: preflight.surface.clone(),
+                    status: preflight.status.clone(),
+                    summary: preflight.summary.clone(),
+                    checked_at: preflight.checked_at.clone(),
+                }
+            }),
+        }
+    }
+
+    fn voice_doctor_payload(&self, include_bridge: bool) -> VoiceDoctorPayload {
+        VoiceDoctorPayload {
+            status: self.voice_status(),
+            checks: self.voice_doctor_checks(include_bridge),
+        }
+    }
+
+    fn voice_doctor_checks(&self, include_bridge: bool) -> Vec<VoiceDoctorCheck> {
+        let prefs = VoiceRuntimePreferences::from_options(&self.ui_preferences);
+        let mut checks = Vec::new();
+
+        checks.push(VoiceDoctorCheck {
+            name: "voice.config".to_owned(),
+            status: "ok".to_owned(),
+            message: if prefs.enabled {
+                "voice output is enabled".to_owned()
+            } else {
+                "voice output is disabled".to_owned()
+            },
+        });
+
+        checks.push(VoiceDoctorCheck {
+            name: "voice.provider".to_owned(),
+            status: if is_supported_voice_provider(&prefs.provider) {
+                "ok"
+            } else {
+                "error"
+            }
+            .to_owned(),
+            message: if is_supported_voice_provider(&prefs.provider) {
+                format!("configured provider {}", prefs.provider)
+            } else {
+                format!(
+                    "unsupported provider {}; expected edge, openai, system, or stub",
+                    prefs.provider
+                )
+            },
+        });
+
+        checks.push(VoiceDoctorCheck {
+            name: "voice.tts_voice".to_owned(),
+            status: if prefs.voice_id.trim().is_empty() {
+                "error"
+            } else {
+                "ok"
+            }
+            .to_owned(),
+            message: if prefs.voice_id.trim().is_empty() {
+                "voice_id is empty".to_owned()
+            } else {
+                format!("configured voice {}", prefs.voice_id)
+            },
+        });
+
+        checks.push(VoiceDoctorCheck {
+            name: "voice.stt_language".to_owned(),
+            status: "ok".to_owned(),
+            message: format!("STT language {}", prefs.stt_language),
+        });
+
+        checks.push(VoiceDoctorCheck {
+            name: "voice.bridge".to_owned(),
+            status: "ok".to_owned(),
+            message: "HUD remains the local capture/playback bridge for microphone, MediaRecorder, WebAudio PCM fallback, and native audio playback".to_owned(),
+        });
+
+        if include_bridge {
+            if let Some(preflight) = &self.last_voice_preflight {
+                checks.push(VoiceDoctorCheck {
+                    name: "voice.preflight".to_owned(),
+                    status: preflight.status.clone(),
+                    message: format!(
+                        "{} from {} at {}",
+                        preflight.summary, preflight.surface, preflight.checked_at
+                    ),
+                });
+                checks.extend(preflight.checks.clone());
+            } else {
+                checks.push(VoiceDoctorCheck {
+                    name: "voice.preflight".to_owned(),
+                    status: "warn".to_owned(),
+                    message: "no local bridge preflight has been reported; run HUD voice doctor"
+                        .to_owned(),
+                });
+            }
+        }
+
+        checks
+    }
+
     fn agent_prompt(&self, agent_id: &AgentId, content: &str) -> String {
         let Some(agent) = self.agents.get(agent_id) else {
             return content.to_owned();
@@ -1319,6 +1493,7 @@ impl Runtime {
                     preferences: self.ui_preferences.clone(),
                 }),
             ),
+            self.event(None, CadisEvent::VoiceStatusUpdated(self.voice_status())),
         ];
 
         for (session_id, session) in self.session_records_sorted() {
@@ -2315,6 +2490,60 @@ struct PendingApproval {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+struct VoicePreflightRecord {
+    surface: String,
+    status: String,
+    summary: String,
+    checked_at: Timestamp,
+    checks: Vec<VoiceDoctorCheck>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct VoiceRuntimePreferences {
+    enabled: bool,
+    provider: String,
+    voice_id: String,
+    stt_language: String,
+    max_spoken_chars: usize,
+}
+
+impl VoiceRuntimePreferences {
+    fn from_options(options: &serde_json::Value) -> Self {
+        let voice = options.get("voice").and_then(serde_json::Value::as_object);
+
+        Self {
+            enabled: voice
+                .and_then(|voice| voice.get("enabled"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
+            provider: voice
+                .and_then(|voice| voice.get("provider"))
+                .and_then(serde_json::Value::as_str)
+                .map(normalize_voice_config_string)
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "edge".to_owned()),
+            voice_id: voice
+                .and_then(|voice| voice.get("voice_id"))
+                .and_then(serde_json::Value::as_str)
+                .map(normalize_voice_config_string)
+                .unwrap_or_else(|| "id-ID-GadisNeural".to_owned()),
+            stt_language: voice
+                .and_then(|voice| voice.get("stt_language"))
+                .and_then(serde_json::Value::as_str)
+                .map(normalize_voice_config_string)
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "auto".to_owned()),
+            max_spoken_chars: voice
+                .and_then(|voice| voice.get("max_spoken_chars"))
+                .and_then(serde_json::Value::as_u64)
+                .and_then(|value| usize::try_from(value).ok())
+                .filter(|value| *value > 0)
+                .unwrap_or(800),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct ToolRegistry {
     definitions: Vec<ToolDefinition>,
 }
@@ -2715,6 +2944,86 @@ fn input_usize(input: &serde_json::Value, key: &str) -> Option<usize> {
         .get(key)
         .and_then(serde_json::Value::as_u64)
         .and_then(|value| usize::try_from(value).ok())
+}
+
+fn normalize_voice_checks(checks: Vec<VoiceDoctorCheck>) -> Vec<VoiceDoctorCheck> {
+    checks
+        .into_iter()
+        .filter_map(|check| {
+            let name = check.name.trim();
+            if name.is_empty() {
+                return None;
+            }
+            Some(VoiceDoctorCheck {
+                name: redact(name),
+                status: normalize_voice_check_status(&check.status),
+                message: redact(check.message.trim()),
+            })
+        })
+        .collect()
+}
+
+fn normalize_voice_check_status(status: &str) -> String {
+    match status.trim().to_ascii_lowercase().as_str() {
+        "ok" | "pass" | "passed" | "ready" => "ok",
+        "warn" | "warning" | "degraded" | "unknown" => "warn",
+        "error" | "fail" | "failed" | "blocked" => "error",
+        _ => "warn",
+    }
+    .to_owned()
+}
+
+fn voice_check_summary_status(checks: &[VoiceDoctorCheck]) -> String {
+    if checks.iter().any(|check| check.status == "error") {
+        "error".to_owned()
+    } else if checks.is_empty() || checks.iter().any(|check| check.status == "warn") {
+        "warn".to_owned()
+    } else {
+        "ok".to_owned()
+    }
+}
+
+fn voice_checks_summary(checks: &[VoiceDoctorCheck]) -> String {
+    let errors = checks
+        .iter()
+        .filter(|check| check.status == "error")
+        .count();
+    let warnings = checks.iter().filter(|check| check.status == "warn").count();
+    if errors > 0 {
+        format!("{errors} blocking voice issue{}", plural(errors))
+    } else if warnings > 0 {
+        format!("{warnings} voice warning{}", plural(warnings))
+    } else if checks.is_empty() {
+        "no bridge checks reported".to_owned()
+    } else {
+        "voice bridge ready".to_owned()
+    }
+}
+
+fn plural(count: usize) -> &'static str {
+    if count == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+fn voice_runtime_state(checks: &[VoiceDoctorCheck]) -> VoiceRuntimeState {
+    if checks.iter().any(|check| check.status == "error") {
+        VoiceRuntimeState::Blocked
+    } else if checks.iter().any(|check| check.status == "warn") {
+        VoiceRuntimeState::Degraded
+    } else {
+        VoiceRuntimeState::Ready
+    }
+}
+
+fn normalize_voice_config_string(value: &str) -> String {
+    value.trim().to_owned()
+}
+
+fn is_supported_voice_provider(provider: &str) -> bool {
+    matches!(provider, "edge" | "openai" | "system" | "stub")
 }
 
 fn tool_workspace_summary(input: &serde_json::Value) -> Option<String> {
@@ -3337,7 +3646,8 @@ mod tests {
         AgentModelSetRequest, AgentRenameRequest, AgentSpawnRequest, ApprovalResponseRequest,
         ClientId, ContentKind, EmptyPayload, EventSubscriptionRequest, EventsSnapshotRequest,
         MessageSendRequest, RequestId, ServerFrame, SessionCreateRequest, SessionTargetRequest,
-        ToolCallRequest, WorkspaceAccess, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind,
+        ToolCallRequest, VoiceDoctorCheck, VoiceDoctorRequest, VoicePreflightRequest,
+        WorkspaceAccess, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind,
         WorkspaceRegisterRequest,
     };
 
@@ -3498,10 +3808,85 @@ mod tests {
             DaemonResponse::DaemonStatus(status) => {
                 assert_eq!(status.status, "ok");
                 assert_eq!(status.model_provider, "echo");
+                assert_eq!(status.voice.provider, "edge");
+                assert_eq!(status.voice.state, VoiceRuntimeState::Disabled);
             }
             other => panic!("unexpected response: {other:?}"),
         }
         assert!(outcome.events.is_empty());
+    }
+
+    #[test]
+    fn voice_doctor_reports_missing_local_bridge_preflight() {
+        let mut runtime = runtime();
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_voice_doctor"),
+            ClientId::from("cli_1"),
+            ClientRequest::VoiceDoctor(VoiceDoctorRequest::default()),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        let doctor = outcome
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::VoiceDoctorResponse(payload) => Some(payload),
+                _ => None,
+            })
+            .expect("voice doctor event should be emitted");
+        assert!(doctor.checks.iter().any(|check| {
+            check.name == "voice.preflight"
+                && check.status == "warn"
+                && check.message.contains("no local bridge preflight")
+        }));
+    }
+
+    #[test]
+    fn voice_preflight_promotes_hud_checks_into_status() {
+        let mut runtime = runtime();
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_voice_preflight"),
+            ClientId::from("hud_1"),
+            ClientRequest::VoicePreflight(VoicePreflightRequest {
+                surface: Some("cadis-hud".to_owned()),
+                summary: Some("ready".to_owned()),
+                checks: vec![VoiceDoctorCheck {
+                    name: "microphone".to_owned(),
+                    status: "pass".to_owned(),
+                    message: "1 input visible".to_owned(),
+                }],
+            }),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        let status = outcome
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::VoiceStatusUpdated(payload) => Some(payload),
+                _ => None,
+            })
+            .expect("voice status event should be emitted");
+        assert_eq!(status.last_preflight.as_ref().unwrap().surface, "cadis-hud");
+        assert_eq!(status.last_preflight.as_ref().unwrap().status, "ok");
+
+        let doctor = outcome
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::VoicePreflightResponse(payload) => Some(payload),
+                _ => None,
+            })
+            .expect("voice preflight response should be emitted");
+        assert!(doctor.checks.iter().any(|check| {
+            check.name == "microphone" && check.status == "ok" && check.message == "1 input visible"
+        }));
     }
 
     #[test]

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -4,19 +4,20 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
 use std::time::Instant;
 
 use cadis_models::{
-    provider_catalog, ModelInvocation, ModelProvider, ModelRequest, ModelStreamEvent,
-    ProviderCatalogEntry, ProviderReadiness,
+    provider_catalog, ModelInvocation, ModelProvider, ModelRequest, ModelResponse,
+    ModelStreamEvent, ProviderCatalogEntry, ProviderReadiness,
 };
 use cadis_policy::{PolicyDecision, PolicyEngine};
 use cadis_protocol::{
     AgentEventPayload, AgentId, AgentListPayload, AgentModelChangedPayload, AgentRenamedPayload,
     AgentSpawnRequest, AgentStatus, AgentStatusChangedPayload, ApprovalDecision, ApprovalId,
     ApprovalRequestPayload, ApprovalResolvedPayload, ApprovalResponseRequest, CadisEvent,
-    ClientRequest, DaemonResponse, DaemonStatusPayload, ErrorPayload, EventEnvelope, EventId,
-    MessageCompletedPayload, MessageDeltaPayload, MessageSendRequest, ModelDescriptor,
+    ClientRequest, ContentKind, DaemonResponse, DaemonStatusPayload, ErrorPayload, EventEnvelope,
+    EventId, MessageCompletedPayload, MessageDeltaPayload, MessageSendRequest, ModelDescriptor,
     ModelInvocationPayload, ModelReadiness, ModelsListPayload, OrchestratorRoutePayload,
     ProtocolVersion, RequestAcceptedPayload, RequestEnvelope, RequestId, ResponseEnvelope,
     SessionEventPayload, SessionId, Timestamp, ToolCallId, ToolCallRequest, ToolEventPayload,
@@ -104,10 +105,34 @@ pub struct RequestOutcome {
     pub events: Vec<EventEnvelope>,
 }
 
+/// Daemon-owned model generation work prepared by the runtime.
+pub struct PendingMessageGeneration {
+    /// Immediate response for the client that sent `message.send`.
+    pub response: ResponseEnvelope,
+    /// Events that are ready before provider generation starts.
+    pub initial_events: Vec<EventEnvelope>,
+    /// Provider selected by the daemon runtime.
+    pub provider: Arc<dyn ModelProvider>,
+    /// Prompt text prepared by daemon-owned routing/orchestration.
+    pub prompt: String,
+    /// Optional provider/model selected on the routed agent.
+    pub selected_model: Option<String>,
+    context: MessageGenerationContext,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct MessageGenerationContext {
+    session_id: SessionId,
+    content_kind: ContentKind,
+    agent_id: AgentId,
+    agent_name: String,
+    worker: Option<WorkerDelegation>,
+}
+
 /// CADIS core runtime.
 pub struct Runtime {
     options: RuntimeOptions,
-    provider: Box<dyn ModelProvider>,
+    provider: Arc<dyn ModelProvider>,
     tools: ToolRegistry,
     started_at: Instant,
     next_event: u64,
@@ -161,7 +186,7 @@ impl Runtime {
 
         Self {
             options,
-            provider,
+            provider: Arc::from(provider),
             tools: ToolRegistry::builtin().expect("built-in tool registry should be valid"),
             started_at: Instant::now(),
             next_event: 1,
@@ -384,6 +409,38 @@ impl Runtime {
                 "this request is defined in the protocol but is not implemented in the desktop MVP",
                 false,
             ),
+        }
+    }
+
+    /// Prepares a `message.send` request without running model generation.
+    ///
+    /// The returned plan contains all daemon-authoritative routing/session state
+    /// and enough provider context for the daemon to stream outside the runtime
+    /// mutex. Non-message requests and invalid message requests return a normal
+    /// request outcome.
+    pub fn begin_message_request(
+        &mut self,
+        envelope: RequestEnvelope,
+    ) -> Result<PendingMessageGeneration, Box<RequestOutcome>> {
+        let request_id = envelope.request_id.clone();
+
+        if let Err(error) = envelope.protocol_version.ensure_supported() {
+            return Err(Box::new(self.reject(
+                request_id,
+                "unsupported_protocol_version",
+                error.to_string(),
+                false,
+            )));
+        }
+
+        match envelope.request {
+            ClientRequest::MessageSend(request) => self.begin_message(request_id, request),
+            _ => Err(Box::new(self.reject(
+                request_id,
+                "invalid_request_type",
+                "begin_message_request only accepts message.send",
+                false,
+            ))),
         }
     }
 
@@ -662,6 +719,17 @@ impl Runtime {
         request_id: RequestId,
         request: MessageSendRequest,
     ) -> RequestOutcome {
+        match self.begin_message(request_id, request) {
+            Ok(pending) => self.complete_pending_message_blocking(pending),
+            Err(outcome) => *outcome,
+        }
+    }
+
+    fn begin_message(
+        &mut self,
+        request_id: RequestId,
+        request: MessageSendRequest,
+    ) -> Result<PendingMessageGeneration, Box<RequestOutcome>> {
         let content_kind = request.content_kind;
         let content = request.content;
         let decision =
@@ -670,7 +738,14 @@ impl Runtime {
                 .route_message(request.target_agent_id, &content, &self.agents)
             {
                 Ok(decision) => decision,
-                Err(error) => return self.reject(request_id, error.code, error.message, false),
+                Err(error) => {
+                    return Err(Box::new(self.reject(
+                        request_id,
+                        error.code,
+                        error.message,
+                        false,
+                    )));
+                }
             };
 
         let (route, spawned_agent) = match decision {
@@ -683,7 +758,14 @@ impl Runtime {
                     model: None,
                 }) {
                     Ok(record) => record,
-                    Err(error) => return self.reject(request_id, error.code, error.message, false),
+                    Err(error) => {
+                        return Err(Box::new(self.reject(
+                            request_id,
+                            error.code,
+                            error.message,
+                            false,
+                        )));
+                    }
                 };
                 (
                     RouteDecision {
@@ -829,130 +911,205 @@ impl Runtime {
             .get(&route.agent_id)
             .map(|agent| agent.model.clone())
             .filter(|model| !model.trim().is_empty());
-        let mut streamed_deltas = Vec::new();
-        let stream_result = self.provider.stream_chat(
-            ModelRequest::new(&prompt).with_selected_model(selected_model.as_deref()),
+        let response = self.accept(request_id, Vec::new()).response;
+
+        Ok(PendingMessageGeneration {
+            response,
+            initial_events: events,
+            provider: Arc::clone(&self.provider),
+            prompt,
+            selected_model,
+            context: MessageGenerationContext {
+                session_id,
+                content_kind,
+                agent_id: route.agent_id,
+                agent_name: route.agent_name,
+                worker,
+            },
+        })
+    }
+
+    /// Creates a daemon event for a streamed model delta.
+    pub fn message_delta_event(
+        &mut self,
+        pending: &PendingMessageGeneration,
+        delta: String,
+        invocation: Option<&ModelInvocation>,
+    ) -> EventEnvelope {
+        let model = invocation.map(model_invocation_payload);
+        self.session_event(
+            pending.context.session_id.clone(),
+            CadisEvent::MessageDelta(MessageDeltaPayload {
+                delta,
+                content_kind: pending.context.content_kind,
+                agent_id: Some(pending.context.agent_id.clone()),
+                agent_name: Some(pending.context.agent_name.clone()),
+                model,
+            }),
+        )
+    }
+
+    /// Finalizes a successful streamed model generation.
+    pub fn complete_message_generation(
+        &mut self,
+        pending: PendingMessageGeneration,
+        response: ModelResponse,
+        final_content: String,
+        emitted_delta: bool,
+    ) -> Vec<EventEnvelope> {
+        let mut events = Vec::new();
+        let model = Some(model_invocation_payload(&response.invocation));
+        let mut content = final_content;
+
+        if !emitted_delta {
+            for delta in response.deltas {
+                content.push_str(&delta);
+                events.push(self.message_delta_event(&pending, delta, Some(&response.invocation)));
+            }
+        }
+
+        let context = pending.context;
+        events.push(self.session_event(
+            context.session_id.clone(),
+            CadisEvent::MessageCompleted(MessageCompletedPayload {
+                content_kind: context.content_kind,
+                content: Some(content),
+                agent_id: Some(context.agent_id.clone()),
+                agent_name: Some(context.agent_name.clone()),
+                model,
+            }),
+        ));
+        events.push(self.session_event(
+            context.session_id.clone(),
+            CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
+                agent_id: context.agent_id.clone(),
+                status: AgentStatus::Completed,
+                task: None,
+            }),
+        ));
+        if context.agent_id.as_str() != "main" {
+            events.push(self.session_event(
+                context.session_id.clone(),
+                CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
+                    agent_id: AgentId::from("main"),
+                    status: AgentStatus::Completed,
+                    task: None,
+                }),
+            ));
+        }
+        if let Some(worker) = &context.worker {
+            events.push(self.session_event(
+                context.session_id.clone(),
+                CadisEvent::WorkerCompleted(WorkerEventPayload {
+                    worker_id: worker.worker_id.clone(),
+                    agent_id: Some(context.agent_id.clone()),
+                    parent_agent_id: worker.parent_agent_id.clone(),
+                    status: Some("completed".to_owned()),
+                    cli: None,
+                    cwd: None,
+                    summary: Some(worker.summary.clone()),
+                    worktree: Some(worker.worktree.clone()),
+                    artifacts: Some(worker.artifacts.clone()),
+                }),
+            ));
+        }
+        events.push(self.session_event(
+            context.session_id.clone(),
+            CadisEvent::SessionCompleted(SessionEventPayload {
+                session_id: context.session_id,
+                title: None,
+            }),
+        ));
+        events
+    }
+
+    /// Finalizes a failed streamed model generation.
+    pub fn fail_message_generation(
+        &mut self,
+        pending: PendingMessageGeneration,
+        error: cadis_models::ModelError,
+    ) -> Vec<EventEnvelope> {
+        let context = pending.context;
+        let error_message = error.message().to_owned();
+        let mut events = vec![self.session_event(
+            context.session_id.clone(),
+            CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
+                agent_id: context.agent_id.clone(),
+                status: AgentStatus::Failed,
+                task: Some(error_message.clone()),
+            }),
+        )];
+        if let Some(worker) = &context.worker {
+            events.push(self.session_event(
+                context.session_id.clone(),
+                CadisEvent::WorkerCompleted(WorkerEventPayload {
+                    worker_id: worker.worker_id.clone(),
+                    agent_id: Some(context.agent_id.clone()),
+                    parent_agent_id: worker.parent_agent_id.clone(),
+                    status: Some("failed".to_owned()),
+                    cli: None,
+                    cwd: None,
+                    summary: Some(error_message.clone()),
+                    worktree: Some(worker.worktree.clone()),
+                    artifacts: Some(worker.artifacts.clone()),
+                }),
+            ));
+        }
+        events.push(self.session_event(
+            context.session_id,
+            CadisEvent::SessionFailed(ErrorPayload {
+                code: error.code().to_owned(),
+                message: error_message,
+                retryable: error.retryable(),
+            }),
+        ));
+        events
+    }
+
+    fn complete_pending_message_blocking(
+        &mut self,
+        pending: PendingMessageGeneration,
+    ) -> RequestOutcome {
+        let response = pending.response.clone();
+        let mut events = pending.initial_events.clone();
+        let provider = Arc::clone(&pending.provider);
+        let mut invocation = None;
+        let mut final_content = String::new();
+        let mut emitted_delta = false;
+        let stream_result = provider.stream_chat(
+            ModelRequest::new(&pending.prompt)
+                .with_selected_model(pending.selected_model.as_deref()),
             &mut |event| {
-                if let ModelStreamEvent::Delta(delta) = event {
-                    streamed_deltas.push(delta);
+                match event {
+                    ModelStreamEvent::Started(started) | ModelStreamEvent::Completed(started) => {
+                        invocation = Some(started);
+                    }
+                    ModelStreamEvent::Delta(delta) => {
+                        final_content.push_str(&delta);
+                        emitted_delta = true;
+                        events.push(self.message_delta_event(&pending, delta, invocation.as_ref()));
+                    }
+                    ModelStreamEvent::Failed(_) => {}
                 }
                 Ok(())
             },
         );
 
         match stream_result {
-            Ok(response) => {
-                let model = Some(model_invocation_payload(&response.invocation));
-                let deltas = if streamed_deltas.is_empty() {
-                    response.deltas
-                } else {
-                    streamed_deltas
-                };
-                let mut final_content = String::new();
-                for delta in deltas {
-                    final_content.push_str(&delta);
-                    events.push(self.session_event(
-                        session_id.clone(),
-                        CadisEvent::MessageDelta(MessageDeltaPayload {
-                            delta,
-                            content_kind,
-                            agent_id: Some(route.agent_id.clone()),
-                            agent_name: Some(route.agent_name.clone()),
-                            model: model.clone(),
-                        }),
-                    ));
-                }
-
-                events.push(self.session_event(
-                    session_id.clone(),
-                    CadisEvent::MessageCompleted(MessageCompletedPayload {
-                        content_kind,
-                        content: Some(final_content),
-                        agent_id: Some(route.agent_id.clone()),
-                        agent_name: Some(route.agent_name.clone()),
-                        model,
-                    }),
+            Ok(model_response) => {
+                events.extend(self.complete_message_generation(
+                    pending,
+                    model_response,
+                    final_content,
+                    emitted_delta,
                 ));
-                events.push(self.session_event(
-                    session_id.clone(),
-                    CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
-                        agent_id: route.agent_id.clone(),
-                        status: AgentStatus::Completed,
-                        task: None,
-                    }),
-                ));
-                if route.agent_id.as_str() != "main" {
-                    events.push(self.session_event(
-                        session_id.clone(),
-                        CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
-                            agent_id: AgentId::from("main"),
-                            status: AgentStatus::Completed,
-                            task: None,
-                        }),
-                    ));
-                }
-                if let Some(worker) = &worker {
-                    events.push(self.session_event(
-                        session_id.clone(),
-                        CadisEvent::WorkerCompleted(WorkerEventPayload {
-                            worker_id: worker.worker_id.clone(),
-                            agent_id: Some(route.agent_id.clone()),
-                            parent_agent_id: worker.parent_agent_id.clone(),
-                            status: Some("completed".to_owned()),
-                            cli: None,
-                            cwd: None,
-                            summary: Some(worker.summary.clone()),
-                            worktree: Some(worker.worktree.clone()),
-                            artifacts: Some(worker.artifacts.clone()),
-                        }),
-                    ));
-                }
-                events.push(self.session_event(
-                    session_id.clone(),
-                    CadisEvent::SessionCompleted(SessionEventPayload {
-                        session_id,
-                        title: None,
-                    }),
-                ));
+                RequestOutcome { response, events }
             }
             Err(error) => {
-                let error_message = error.message().to_owned();
-                events.push(self.session_event(
-                    session_id.clone(),
-                    CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
-                        agent_id: route.agent_id.clone(),
-                        status: AgentStatus::Failed,
-                        task: Some(error_message.clone()),
-                    }),
-                ));
-                if let Some(worker) = &worker {
-                    events.push(self.session_event(
-                        session_id.clone(),
-                        CadisEvent::WorkerCompleted(WorkerEventPayload {
-                            worker_id: worker.worker_id.clone(),
-                            agent_id: Some(route.agent_id.clone()),
-                            parent_agent_id: worker.parent_agent_id.clone(),
-                            status: Some("failed".to_owned()),
-                            cli: None,
-                            cwd: None,
-                            summary: Some(error_message.clone()),
-                            worktree: Some(worker.worktree.clone()),
-                            artifacts: Some(worker.artifacts.clone()),
-                        }),
-                    ));
-                }
-                events.push(self.session_event(
-                    session_id,
-                    CadisEvent::SessionFailed(ErrorPayload {
-                        code: error.code().to_owned(),
-                        message: error_message,
-                        retryable: error.retryable(),
-                    }),
-                ));
+                events.extend(self.fail_message_generation(pending, error));
+                RequestOutcome { response, events }
             }
         }
-
-        self.accept(request_id, events)
     }
 
     fn spawn_agent(&mut self, request_id: RequestId, request: AgentSpawnRequest) -> RequestOutcome {
@@ -3344,6 +3501,10 @@ mod tests {
         SessionSubscriptionRequest, SessionTargetRequest, ToolCallRequest, WorkspaceAccess,
         WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceRegisterRequest,
     };
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     fn runtime() -> Runtime {
         runtime_with_spawn_limits(AgentSpawnLimits::default())
@@ -3429,6 +3590,22 @@ mod tests {
             },
             provider,
         )
+    }
+
+    #[derive(Clone, Debug)]
+    struct CountingProvider {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl ModelProvider for CountingProvider {
+        fn name(&self) -> &str {
+            "counting"
+        }
+
+        fn chat(&self, _prompt: &str) -> Result<Vec<String>, cadis_models::ModelError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(vec!["counted".to_owned()])
+        }
     }
 
     fn test_workspace(name: &str) -> PathBuf {
@@ -4039,6 +4216,49 @@ mod tests {
             .any(|event| matches!(event.event, CadisEvent::MessageDelta(_))));
         assert!(outcome
             .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::MessageCompleted(_))));
+    }
+
+    #[test]
+    fn begin_message_request_prepares_progress_without_calling_provider() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = CountingProvider {
+            calls: Arc::clone(&calls),
+        };
+        let mut runtime = runtime_with_provider(Box::new(provider), "counting");
+
+        let pending = runtime
+            .begin_message_request(RequestEnvelope::new(
+                RequestId::from("req_1"),
+                ClientId::from("cli_1"),
+                ClientRequest::MessageSend(MessageSendRequest {
+                    session_id: None,
+                    target_agent_id: None,
+                    content: "hello".to_owned(),
+                    content_kind: ContentKind::Chat,
+                }),
+            ))
+            .expect("message request should be prepared");
+
+        assert!(matches!(
+            pending.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(pending
+            .initial_events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::SessionStarted(_))));
+        assert!(pending.initial_events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentStatusChanged(payload)
+                    if payload.status == AgentStatus::Running
+            )
+        }));
+        assert!(!pending
+            .initial_events
             .iter()
             .any(|event| matches!(event.event, CadisEvent::MessageCompleted(_))));
     }

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -27,7 +27,8 @@ use cadis_protocol::{
     WorkspaceListRequest, WorkspaceRecordPayload, WorkspaceRegisterRequest, WorkspaceRevokeRequest,
 };
 use cadis_store::{
-    redact, ApprovalRecord, ApprovalState, ApprovalStore, CadisConfig, CadisHome, CheckpointPolicy,
+    redact, AgentHomeDiagnostic, AgentHomeDoctorOptions, AgentHomeTemplate, ApprovalRecord,
+    ApprovalState, ApprovalStore, CadisConfig, CadisHome, CheckpointPolicy,
     GrantSource as StoreGrantSource, ProfileHome, ProjectWorkspaceStore, StateStore,
     WorkspaceAccess as StoreWorkspaceAccess, WorkspaceAlias,
     WorkspaceGrantRecord as StoreWorkspaceGrantRecord, WorkspaceKind as StoreWorkspaceKind,
@@ -156,6 +157,7 @@ impl Runtime {
         for (agent_id, record) in recover_agent_records(&state_store) {
             agents.insert(agent_id, record);
         }
+        init_agent_homes(&profile_home, &agents);
         let next_session = next_session_counter(&sessions);
         let next_agent = next_agent_counter(&agents);
 
@@ -1049,6 +1051,7 @@ impl Runtime {
         };
         self.agents.insert(agent_id.clone(), record.clone());
         let _ = self.persist_agent_record(&agent_id);
+        let _ = self.profile_home.init_agent(&record.agent_home_template());
         Ok(record)
     }
 
@@ -1428,6 +1431,8 @@ impl Runtime {
             checks.extend(self.workspace_duplicate_root_checks());
         }
 
+        checks.extend(self.profile_agent_doctor_checks());
+
         if let Some(workspace_id) = request.workspace_id {
             match self.workspaces.get(&workspace_id) {
                 Some(workspace) => {
@@ -1467,6 +1472,23 @@ impl Runtime {
         }
 
         checks
+    }
+
+    fn profile_agent_doctor_checks(&self) -> Vec<WorkspaceDoctorCheck> {
+        match self
+            .profile_home
+            .agent_doctor_diagnostics(AgentHomeDoctorOptions::default())
+        {
+            Ok(diagnostics) => diagnostics
+                .into_iter()
+                .map(agent_home_diagnostic_check)
+                .collect(),
+            Err(error) => vec![WorkspaceDoctorCheck {
+                name: "profile.agents".to_owned(),
+                status: "error".to_owned(),
+                message: format!("could not inspect agent homes: {error}"),
+            }],
+        }
     }
 
     fn workspace_duplicate_root_checks(&self) -> Vec<WorkspaceDoctorCheck> {
@@ -2174,6 +2196,16 @@ impl AgentMetadata {
 }
 
 impl AgentRecord {
+    fn agent_home_template(&self) -> AgentHomeTemplate {
+        AgentHomeTemplate::new(
+            self.id.clone(),
+            self.display_name.clone(),
+            self.role.clone(),
+            self.parent_agent_id.clone(),
+            self.model.clone(),
+        )
+    }
+
     fn event_payload(self) -> AgentEventPayload {
         AgentEventPayload {
             agent_id: self.id,
@@ -2542,6 +2574,20 @@ fn recover_agent_records(state_store: &StateStore) -> HashMap<AgentId, AgentReco
         .into_iter()
         .map(|record| record.metadata.into_record())
         .collect()
+}
+
+fn init_agent_homes(profile_home: &ProfileHome, agents: &HashMap<AgentId, AgentRecord>) {
+    for record in agents.values() {
+        let _ = profile_home.init_agent(&record.agent_home_template());
+    }
+}
+
+fn agent_home_diagnostic_check(diagnostic: AgentHomeDiagnostic) -> WorkspaceDoctorCheck {
+    WorkspaceDoctorCheck {
+        name: diagnostic.name,
+        status: diagnostic.status,
+        message: diagnostic.message,
+    }
 }
 
 fn next_session_counter(sessions: &HashMap<SessionId, SessionRecord>) -> u64 {
@@ -3445,8 +3491,8 @@ mod tests {
         AgentModelSetRequest, AgentRenameRequest, AgentSpawnRequest, ApprovalResponseRequest,
         ClientId, ContentKind, EmptyPayload, EventSubscriptionRequest, EventsSnapshotRequest,
         MessageSendRequest, RequestId, ServerFrame, SessionCreateRequest, SessionTargetRequest,
-        ToolCallRequest, WorkspaceAccess, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind,
-        WorkspaceRegisterRequest,
+        ToolCallRequest, WorkspaceAccess, WorkspaceDoctorRequest, WorkspaceGrantRequest,
+        WorkspaceId, WorkspaceKind, WorkspaceRegisterRequest,
     };
 
     fn runtime() -> Runtime {
@@ -3993,6 +4039,71 @@ mod tests {
                     && agent.model.as_deref() == Some("echo/cadis-local-fallback")
                     && agent.parent_agent_id.as_ref() == Some(&AgentId::from("main"))
             })
+        }));
+    }
+
+    #[test]
+    fn runtime_initializes_agent_home_templates() {
+        let cadis_home = test_workspace("runtime-agent-home");
+        let mut runtime = runtime_with_home(cadis_home.clone());
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_spawn_agent_home"),
+            ClientId::from("cli_1"),
+            ClientRequest::AgentSpawn(AgentSpawnRequest {
+                role: "Review".to_owned(),
+                parent_agent_id: Some(AgentId::from("main")),
+                display_name: Some("Review Scout".to_owned()),
+                model: Some("echo".to_owned()),
+            }),
+        ));
+        let spawned_id = outcome
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::AgentSpawned(payload) => Some(payload.agent_id.clone()),
+                _ => None,
+            })
+            .expect("agent.spawned should be emitted");
+
+        let profile = CadisHome::new(cadis_home).profile("default");
+        assert!(profile.agent("main").agent_toml_path().is_file());
+        let spawned_home = profile.agent(spawned_id.as_str());
+        assert!(spawned_home.agent_toml_path().is_file());
+        assert!(spawned_home.policy_toml_path().is_file());
+        let metadata = spawned_home
+            .load_metadata()
+            .expect("spawned AGENT.toml should parse");
+        assert_eq!(metadata.agent.display_name, "Review Scout");
+        assert_eq!(metadata.agent.role, "Review");
+        assert_eq!(metadata.agent.parent_agent_id.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn workspace_doctor_reports_agent_home_diagnostics() {
+        let cadis_home = test_workspace("runtime-agent-doctor");
+        let mut runtime = runtime_with_home(cadis_home.clone());
+        let policy_path = CadisHome::new(cadis_home)
+            .profile("default")
+            .agent("main")
+            .policy_toml_path();
+        fs::write(policy_path, "[policy\n").expect("corrupt policy should write");
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_agent_doctor"),
+            ClientId::from("cli_1"),
+            ClientRequest::WorkspaceDoctor(WorkspaceDoctorRequest {
+                workspace_id: None,
+                root: None,
+            }),
+        ));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::WorkspaceDoctorResponse(payload)
+                    if payload.checks.iter().any(|check| check.name == "main/agent.POLICY.toml"
+                        && check.status == "error")
+            )
         }));
     }
 

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -28,7 +28,7 @@ use cadis_protocol::{
 };
 use cadis_store::{
     redact, ApprovalRecord, ApprovalState, ApprovalStore, CadisConfig, CadisHome, CheckpointPolicy,
-    GrantSource as StoreGrantSource, ProfileHome, StateStore,
+    GrantSource as StoreGrantSource, ProfileHome, ProjectWorkspaceStore, StateStore,
     WorkspaceAccess as StoreWorkspaceAccess, WorkspaceAlias,
     WorkspaceGrantRecord as StoreWorkspaceGrantRecord, WorkspaceKind as StoreWorkspaceKind,
     WorkspaceMetadata, WorkspaceRegistry, WorkspaceVcs,
@@ -1425,12 +1425,14 @@ impl Runtime {
                 status: "ok".to_owned(),
                 message: format!("{} workspace(s) registered", self.workspaces.len()),
             });
+            checks.extend(self.workspace_duplicate_root_checks());
         }
 
         if let Some(workspace_id) = request.workspace_id {
             match self.workspaces.get(&workspace_id) {
                 Some(workspace) => {
                     checks.push(root_check("workspace.root", &workspace.root));
+                    checks.extend(project_workspace_metadata_checks(workspace));
                     let active_grants = self
                         .workspace_grants
                         .values()
@@ -1452,7 +1454,10 @@ impl Runtime {
 
         if let Some(root) = request.root {
             match canonical_workspace_root(&root) {
-                Ok(root) => checks.push(root_check("request.root", &root)),
+                Ok(root) => {
+                    checks.push(root_check("request.root", &root));
+                    checks.extend(project_workspace_metadata_checks_for_root(&root));
+                }
                 Err(error) => checks.push(WorkspaceDoctorCheck {
                     name: "request.root".to_owned(),
                     status: "error".to_owned(),
@@ -1462,6 +1467,31 @@ impl Runtime {
         }
 
         checks
+    }
+
+    fn workspace_duplicate_root_checks(&self) -> Vec<WorkspaceDoctorCheck> {
+        let mut roots: HashMap<PathBuf, Vec<String>> = HashMap::new();
+        for workspace in self.workspaces.values() {
+            roots
+                .entry(workspace.root.clone())
+                .or_default()
+                .push(workspace.id.to_string());
+        }
+
+        roots
+            .into_iter()
+            .filter_map(|(root, mut ids)| {
+                if ids.len() <= 1 {
+                    return None;
+                }
+                ids.sort();
+                Some(WorkspaceDoctorCheck {
+                    name: "registry.duplicate_root".to_owned(),
+                    status: "warn".to_owned(),
+                    message: format!("{} is registered by {}", root.display(), ids.join(", ")),
+                })
+            })
+            .collect()
     }
 
     fn resolve_tool_session(
@@ -2927,6 +2957,84 @@ fn root_check(name: &str, root: &Path) -> WorkspaceDoctorCheck {
     }
 }
 
+fn project_workspace_metadata_checks(workspace: &WorkspaceRecord) -> Vec<WorkspaceDoctorCheck> {
+    if workspace.kind != WorkspaceKind::Project {
+        return Vec::new();
+    }
+
+    let mut checks = project_workspace_metadata_checks_for_root(&workspace.root);
+    let Some(metadata) = ProjectWorkspaceStore::new(&workspace.root)
+        .load()
+        .ok()
+        .flatten()
+    else {
+        return checks;
+    };
+
+    if metadata.workspace_id != workspace.id.to_string() {
+        checks.push(WorkspaceDoctorCheck {
+            name: "workspace.metadata.id".to_owned(),
+            status: "error".to_owned(),
+            message: format!(
+                ".cadis/workspace.toml workspace_id '{}' does not match registry id '{}'",
+                metadata.workspace_id, workspace.id
+            ),
+        });
+    }
+
+    let metadata_kind = protocol_workspace_kind(metadata.kind);
+    if metadata_kind != workspace.kind {
+        checks.push(WorkspaceDoctorCheck {
+            name: "workspace.metadata.kind".to_owned(),
+            status: "warn".to_owned(),
+            message: format!(
+                ".cadis/workspace.toml kind {:?} differs from registry kind {:?}",
+                metadata_kind, workspace.kind
+            ),
+        });
+    }
+
+    for (name, path) in [
+        ("workspace.metadata.worktree_root", metadata.worktree_root),
+        ("workspace.metadata.artifact_root", metadata.artifact_root),
+        ("workspace.metadata.media_root", metadata.media_root),
+    ] {
+        if path.is_absolute() {
+            checks.push(WorkspaceDoctorCheck {
+                name: name.to_owned(),
+                status: "warn".to_owned(),
+                message: format!("{} should be project-relative", path.display()),
+            });
+        }
+    }
+
+    checks
+}
+
+fn project_workspace_metadata_checks_for_root(root: &Path) -> Vec<WorkspaceDoctorCheck> {
+    let store = ProjectWorkspaceStore::new(root);
+    match store.load() {
+        Ok(Some(_)) => vec![WorkspaceDoctorCheck {
+            name: "workspace.metadata".to_owned(),
+            status: "ok".to_owned(),
+            message: format!("{} exists", store.workspace_toml_path().display()),
+        }],
+        Ok(None) => vec![WorkspaceDoctorCheck {
+            name: "workspace.metadata".to_owned(),
+            status: "warn".to_owned(),
+            message: format!("{} is missing", store.workspace_toml_path().display()),
+        }],
+        Err(error) => vec![WorkspaceDoctorCheck {
+            name: "workspace.metadata".to_owned(),
+            status: "error".to_owned(),
+            message: format!(
+                "could not read {}: {error}",
+                store.workspace_toml_path().display()
+            ),
+        }],
+    }
+}
+
 fn tool_command_summary(tool_name: &str, input: &serde_json::Value) -> Option<String> {
     match tool_name {
         "shell.run" => input_string(input, "command").or_else(|| {
@@ -3664,6 +3772,69 @@ mod tests {
             DaemonResponse::RequestRejected(error)
                 if error.code == "workspace_root_too_broad"
         ));
+    }
+
+    #[test]
+    fn workspace_doctor_reports_project_metadata_mismatch_and_duplicate_roots() {
+        let workspace = test_workspace("doctor-metadata");
+        cadis_store::ProjectWorkspaceStore::new(&workspace)
+            .save(&cadis_store::ProjectWorkspaceMetadata {
+                workspace_id: "wrong-id".to_owned(),
+                kind: cadis_store::WorkspaceKind::Project,
+                vcs: cadis_store::WorkspaceVcs::Git,
+                worktree_root: PathBuf::from(".cadis/worktrees"),
+                artifact_root: PathBuf::from(".cadis/artifacts"),
+                media_root: PathBuf::from(".cadis/media"),
+            })
+            .expect("project workspace metadata should save");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "doctor-a", &workspace);
+        register_workspace(&mut runtime, "doctor-b", &workspace);
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_workspace_doctor"),
+            ClientId::from("cli_1"),
+            ClientRequest::WorkspaceDoctor(WorkspaceDoctorRequest {
+                workspace_id: Some(WorkspaceId::from("doctor-a")),
+                root: None,
+            }),
+        ));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::WorkspaceDoctorResponse(payload)
+                    if payload.checks.iter().any(|check| check.name == "registry.duplicate_root"
+                        && check.status == "warn")
+                        && payload.checks.iter().any(|check| check.name == "workspace.metadata.id"
+                            && check.status == "error")
+            )
+        }));
+    }
+
+    #[test]
+    fn workspace_doctor_warns_when_project_metadata_is_missing() {
+        let workspace = test_workspace("doctor-missing-metadata");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "doctor-missing", &workspace);
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_workspace_doctor"),
+            ClientId::from("cli_1"),
+            ClientRequest::WorkspaceDoctor(WorkspaceDoctorRequest {
+                workspace_id: Some(WorkspaceId::from("doctor-missing")),
+                root: None,
+            }),
+        ));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::WorkspaceDoctorResponse(payload)
+                    if payload.checks.iter().any(|check| check.name == "workspace.metadata"
+                        && check.status == "warn")
+            )
+        }));
     }
 
     #[test]

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -13,19 +13,20 @@ use cadis_models::{
 use cadis_policy::{PolicyDecision, PolicyEngine};
 use cadis_protocol::{
     AgentEventPayload, AgentId, AgentListPayload, AgentModelChangedPayload, AgentRenamedPayload,
-    AgentSpawnRequest, AgentStatus, AgentStatusChangedPayload, ApprovalDecision, ApprovalId,
-    ApprovalRequestPayload, ApprovalResolvedPayload, ApprovalResponseRequest, CadisEvent,
-    ClientRequest, DaemonResponse, DaemonStatusPayload, ErrorPayload, EventEnvelope, EventId,
-    MessageCompletedPayload, MessageDeltaPayload, MessageSendRequest, ModelDescriptor,
-    ModelInvocationPayload, ModelReadiness, ModelsListPayload, OrchestratorRoutePayload,
-    ProtocolVersion, RequestAcceptedPayload, RequestEnvelope, RequestId, ResponseEnvelope,
-    SessionEventPayload, SessionId, Timestamp, ToolCallId, ToolCallRequest, ToolEventPayload,
-    ToolFailedPayload, UiPreferencesPayload, WorkerArtifactLocations, WorkerEventPayload,
-    WorkerLogDeltaPayload, WorkerTailRequest, WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent,
-    WorkerWorktreeState, WorkspaceAccess, WorkspaceDoctorCheck, WorkspaceDoctorPayload,
-    WorkspaceDoctorRequest, WorkspaceGrantId, WorkspaceGrantPayload, WorkspaceGrantRequest,
-    WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest, WorkspaceRecordPayload,
-    WorkspaceRegisterRequest, WorkspaceRevokeRequest,
+    AgentSessionEventPayload, AgentSessionId, AgentSessionStatus, AgentSpawnRequest, AgentStatus,
+    AgentStatusChangedPayload, ApprovalDecision, ApprovalId, ApprovalRequestPayload,
+    ApprovalResolvedPayload, ApprovalResponseRequest, CadisEvent, ClientRequest, DaemonResponse,
+    DaemonStatusPayload, ErrorPayload, EventEnvelope, EventId, MessageCompletedPayload,
+    MessageDeltaPayload, MessageSendRequest, ModelDescriptor, ModelInvocationPayload,
+    ModelReadiness, ModelsListPayload, OrchestratorRoutePayload, ProtocolVersion,
+    RequestAcceptedPayload, RequestEnvelope, RequestId, ResponseEnvelope, SessionEventPayload,
+    SessionId, Timestamp, ToolCallId, ToolCallRequest, ToolEventPayload, ToolFailedPayload,
+    UiPreferencesPayload, WorkerArtifactLocations, WorkerEventPayload, WorkerLogDeltaPayload,
+    WorkerTailRequest, WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent, WorkerWorktreeState,
+    WorkspaceAccess, WorkspaceDoctorCheck, WorkspaceDoctorPayload, WorkspaceDoctorRequest,
+    WorkspaceGrantId, WorkspaceGrantPayload, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind,
+    WorkspaceListPayload, WorkspaceListRequest, WorkspaceRecordPayload, WorkspaceRegisterRequest,
+    WorkspaceRevokeRequest,
 };
 use cadis_store::{
     redact, ApprovalRecord, ApprovalState, ApprovalStore, CadisConfig, CadisHome, CheckpointPolicy,
@@ -98,6 +99,24 @@ impl Default for OrchestratorConfig {
     }
 }
 
+/// Configuration for the in-memory AgentSession state machine.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentRuntimeConfig {
+    /// Default timeout for a per-route agent session.
+    pub default_timeout_sec: i64,
+    /// Maximum state-machine steps a single agent route may consume.
+    pub max_steps_per_session: u32,
+}
+
+impl Default for AgentRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            default_timeout_sec: 900,
+            max_steps_per_session: 1,
+        }
+    }
+}
+
 /// Result of handling one client request.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RequestOutcome {
@@ -116,14 +135,17 @@ pub struct Runtime {
     next_event: u64,
     next_session: u64,
     next_agent: u64,
+    next_agent_session: u64,
     next_route: u64,
     next_worker: u64,
     sessions: HashMap<SessionId, SessionRecord>,
     agents: HashMap<AgentId, AgentRecord>,
+    agent_sessions: HashMap<AgentSessionId, AgentSessionRecord>,
     workers: HashMap<String, WorkerRecord>,
     orchestrator: Orchestrator,
     ui_preferences: serde_json::Value,
     spawn_limits: AgentSpawnLimits,
+    agent_runtime: AgentRuntimeConfig,
     policy: PolicyEngine,
     approval_store: ApprovalStore,
     state_store: StateStore,
@@ -141,6 +163,7 @@ impl Runtime {
     pub fn new(options: RuntimeOptions, provider: Box<dyn ModelProvider>) -> Self {
         let ui_preferences = options.ui_preferences.clone();
         let spawn_limits = AgentSpawnLimits::from_options(&options.ui_preferences);
+        let agent_runtime = AgentRuntimeConfig::from_options(&options.ui_preferences);
         let orchestrator =
             Orchestrator::new(OrchestratorConfig::from_options(&options.ui_preferences));
         let approval_store = ApprovalStore::new(&options.cadis_home);
@@ -171,14 +194,17 @@ impl Runtime {
             next_event: 1,
             next_session,
             next_agent,
+            next_agent_session: 1,
             next_route: 1,
             next_worker: 1,
             sessions,
             agents,
+            agent_sessions: HashMap::new(),
             workers: HashMap::new(),
             orchestrator,
             ui_preferences,
             spawn_limits,
+            agent_runtime,
             policy: PolicyEngine,
             approval_store,
             state_store,
@@ -230,6 +256,7 @@ impl Runtime {
             }
             ClientRequest::SessionCancel(request) => {
                 if self.sessions.remove(&request.session_id).is_some() {
+                    let mut events = self.cancel_agent_sessions_for_session(&request.session_id);
                     let _ = self
                         .state_store
                         .remove_session_metadata(&request.session_id);
@@ -240,7 +267,8 @@ impl Runtime {
                             title: None,
                         }),
                     );
-                    self.accept(request_id, vec![event])
+                    events.push(event);
+                    self.accept(request_id, events)
                 } else {
                     self.reject(
                         request_id,
@@ -752,17 +780,26 @@ impl Runtime {
             ));
         }
 
+        let route_id = format!("route_{:06}", self.next_route);
+        self.next_route += 1;
+        let (agent_session_id, agent_session_started) = self.start_agent_session(
+            session_id.clone(),
+            route_id.clone(),
+            route.agent_id.clone(),
+            route.content.clone(),
+        );
+        events.push(agent_session_started);
+
         events.push(self.session_event(
             session_id.clone(),
             CadisEvent::OrchestratorRoute(OrchestratorRoutePayload {
-                id: format!("route_{:06}", self.next_route),
+                id: route_id,
                 source: "cadisd".to_owned(),
                 target_agent_id: route.agent_id.clone(),
                 target_agent_name: route.agent_name.clone(),
                 reason: route.reason.clone(),
             }),
         ));
-        self.next_route += 1;
 
         let session_workspace = self.session_workspace(&session_id);
         let artifact_root = self.options.cadis_home.join("artifacts").join("workers");
@@ -812,6 +849,33 @@ impl Runtime {
             }),
         ));
 
+        if let Some(event) = self.consume_agent_session_step(&agent_session_id) {
+            events.push(event);
+        }
+        if self
+            .agent_sessions
+            .get(&agent_session_id)
+            .is_some_and(|record| record.status == AgentSessionStatus::BudgetExceeded)
+        {
+            events.push(self.session_event(
+                session_id.clone(),
+                CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
+                    agent_id: route.agent_id.clone(),
+                    status: AgentStatus::Failed,
+                    task: Some("agent budget exceeded".to_owned()),
+                }),
+            ));
+            events.push(self.session_event(
+                session_id,
+                CadisEvent::SessionFailed(ErrorPayload {
+                    code: "agent_budget_exceeded".to_owned(),
+                    message: "agent session exceeded its configured step budget".to_owned(),
+                    retryable: false,
+                }),
+            ));
+            return self.accept(request_id, events);
+        }
+
         let prompt = self.agent_prompt(&route.agent_id, &route.content);
         let selected_model = self
             .agents
@@ -856,12 +920,48 @@ impl Runtime {
                     session_id.clone(),
                     CadisEvent::MessageCompleted(MessageCompletedPayload {
                         content_kind,
-                        content: Some(final_content),
+                        content: Some(final_content.clone()),
                         agent_id: Some(route.agent_id.clone()),
                         agent_name: Some(route.agent_name.clone()),
                         model,
                     }),
                 ));
+                if self.agent_session_timed_out(&agent_session_id) {
+                    let error_message = format!(
+                        "agent session exceeded default_timeout_sec={}",
+                        self.agent_runtime.default_timeout_sec
+                    );
+                    if let Some(event) = self.fail_agent_session(
+                        &agent_session_id,
+                        AgentSessionStatus::TimedOut,
+                        "agent_timeout",
+                        error_message.clone(),
+                    ) {
+                        events.push(event);
+                    }
+                    events.push(self.session_event(
+                        session_id.clone(),
+                        CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
+                            agent_id: route.agent_id.clone(),
+                            status: AgentStatus::Failed,
+                            task: Some(error_message.clone()),
+                        }),
+                    ));
+                    events.push(self.session_event(
+                        session_id,
+                        CadisEvent::SessionFailed(ErrorPayload {
+                            code: "agent_timeout".to_owned(),
+                            message: error_message,
+                            retryable: true,
+                        }),
+                    ));
+                    return self.accept(request_id, events);
+                }
+                if let Some(event) =
+                    self.complete_agent_session(&agent_session_id, final_content.clone())
+                {
+                    events.push(event);
+                }
                 events.push(self.session_event(
                     session_id.clone(),
                     CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
@@ -897,6 +997,14 @@ impl Runtime {
             }
             Err(error) => {
                 let error_message = error.message().to_owned();
+                if let Some(event) = self.fail_agent_session(
+                    &agent_session_id,
+                    AgentSessionStatus::Failed,
+                    error.code(),
+                    error_message.clone(),
+                ) {
+                    events.push(event);
+                }
                 events.push(self.session_event(
                     session_id.clone(),
                     CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
@@ -1310,6 +1418,12 @@ impl Runtime {
         workers
     }
 
+    fn agent_session_records_sorted(&self) -> Vec<AgentSessionRecord> {
+        let mut records = self.agent_sessions.values().cloned().collect::<Vec<_>>();
+        records.sort_by(|left, right| left.id.cmp(&right.id));
+        records
+    }
+
     fn snapshot_events(&mut self) -> Vec<EventEnvelope> {
         let agents = self
             .agent_records_sorted()
@@ -1346,6 +1460,26 @@ impl Runtime {
             ));
         }
 
+        for record in self.agent_session_records_sorted() {
+            let event = match record.status {
+                AgentSessionStatus::Completed => {
+                    CadisEvent::AgentSessionCompleted(record.event_payload())
+                }
+                AgentSessionStatus::Failed
+                | AgentSessionStatus::TimedOut
+                | AgentSessionStatus::BudgetExceeded => {
+                    CadisEvent::AgentSessionFailed(record.event_payload())
+                }
+                AgentSessionStatus::Cancelled => {
+                    CadisEvent::AgentSessionCancelled(record.event_payload())
+                }
+                AgentSessionStatus::Started | AgentSessionStatus::Running => {
+                    CadisEvent::AgentSessionUpdated(record.event_payload())
+                }
+            };
+            events.push(self.session_event(record.session_id.clone(), event));
+        }
+
         for worker in self.worker_records_sorted() {
             let event = if worker.status == "running" {
                 CadisEvent::WorkerStarted(worker.event_payload())
@@ -1373,6 +1507,159 @@ impl Runtime {
         let worker_id = format!("worker_{:06}", self.next_worker);
         self.next_worker += 1;
         worker_id
+    }
+
+    fn next_agent_session_id(&mut self) -> AgentSessionId {
+        let agent_session_id = AgentSessionId::from(format!("ags_{:06}", self.next_agent_session));
+        self.next_agent_session += 1;
+        agent_session_id
+    }
+
+    fn start_agent_session(
+        &mut self,
+        session_id: SessionId,
+        route_id: String,
+        agent_id: AgentId,
+        task: String,
+    ) -> (AgentSessionId, EventEnvelope) {
+        let parent_agent_id = self
+            .agents
+            .get(&agent_id)
+            .and_then(|agent| agent.parent_agent_id.clone());
+        let id = self.next_agent_session_id();
+        let record = AgentSessionRecord {
+            id: id.clone(),
+            session_id: session_id.clone(),
+            route_id,
+            agent_id,
+            parent_agent_id,
+            task,
+            status: AgentSessionStatus::Running,
+            timeout_at: timestamp_after_seconds(self.agent_runtime.default_timeout_sec),
+            budget_steps: self.agent_runtime.max_steps_per_session,
+            steps_used: 0,
+            result: None,
+            error_code: None,
+            error: None,
+            cancellation_requested_at: None,
+        };
+        let event = self.session_event(
+            session_id,
+            CadisEvent::AgentSessionStarted(record.event_payload()),
+        );
+        self.agent_sessions.insert(id.clone(), record);
+        (id, event)
+    }
+
+    fn consume_agent_session_step(
+        &mut self,
+        agent_session_id: &AgentSessionId,
+    ) -> Option<EventEnvelope> {
+        let (session_id, payload) = {
+            let record = self.agent_sessions.get_mut(agent_session_id)?;
+            if record.steps_used >= record.budget_steps {
+                record.status = AgentSessionStatus::BudgetExceeded;
+                record.error_code = Some("agent_budget_exceeded".to_owned());
+                record.error = Some(format!(
+                    "agent session exceeded max_steps_per_session={}",
+                    record.budget_steps
+                ));
+                (
+                    record.session_id.clone(),
+                    CadisEvent::AgentSessionFailed(record.event_payload()),
+                )
+            } else {
+                record.steps_used += 1;
+                (
+                    record.session_id.clone(),
+                    CadisEvent::AgentSessionUpdated(record.event_payload()),
+                )
+            }
+        };
+        Some(self.session_event(session_id, payload))
+    }
+
+    fn complete_agent_session(
+        &mut self,
+        agent_session_id: &AgentSessionId,
+        result: impl Into<String>,
+    ) -> Option<EventEnvelope> {
+        let (session_id, payload) = {
+            let record = self.agent_sessions.get_mut(agent_session_id)?;
+            record.status = AgentSessionStatus::Completed;
+            record.result = Some(redact(&result.into()));
+            (record.session_id.clone(), record.event_payload())
+        };
+        Some(self.session_event(session_id, CadisEvent::AgentSessionCompleted(payload)))
+    }
+
+    fn fail_agent_session(
+        &mut self,
+        agent_session_id: &AgentSessionId,
+        status: AgentSessionStatus,
+        code: impl Into<String>,
+        error: impl Into<String>,
+    ) -> Option<EventEnvelope> {
+        let (session_id, payload) = {
+            let record = self.agent_sessions.get_mut(agent_session_id)?;
+            record.status = status;
+            record.error_code = Some(code.into());
+            record.error = Some(redact(&error.into()));
+            (record.session_id.clone(), record.event_payload())
+        };
+        Some(self.session_event(session_id, CadisEvent::AgentSessionFailed(payload)))
+    }
+
+    fn agent_session_timed_out(&self, agent_session_id: &AgentSessionId) -> bool {
+        self.agent_sessions
+            .get(agent_session_id)
+            .is_some_and(|record| timestamp_is_past(&record.timeout_at))
+    }
+
+    fn cancel_agent_sessions_for_session(&mut self, session_id: &SessionId) -> Vec<EventEnvelope> {
+        let agent_session_ids = self
+            .agent_sessions
+            .iter()
+            .filter(|(_, record)| {
+                &record.session_id == session_id && !agent_session_is_terminal(record.status)
+            })
+            .map(|(agent_session_id, _)| agent_session_id.clone())
+            .collect::<Vec<_>>();
+        let cancellation_requested_at = now_timestamp();
+
+        let mut events = Vec::new();
+        for agent_session_id in agent_session_ids {
+            let Some((event_session_id, payload, agent_id)) = ({
+                self.agent_sessions
+                    .get_mut(&agent_session_id)
+                    .map(|record| {
+                        record.status = AgentSessionStatus::Cancelled;
+                        record.error_code = Some("session_cancelled".to_owned());
+                        record.error = Some("session was cancelled".to_owned());
+                        record.cancellation_requested_at = Some(cancellation_requested_at.clone());
+                        (
+                            record.session_id.clone(),
+                            record.event_payload(),
+                            record.agent_id.clone(),
+                        )
+                    })
+            }) else {
+                continue;
+            };
+            events.push(self.session_event(
+                event_session_id.clone(),
+                CadisEvent::AgentSessionCancelled(payload),
+            ));
+            events.push(self.session_event(
+                event_session_id,
+                CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
+                    agent_id,
+                    status: AgentStatus::Cancelled,
+                    task: Some("session cancelled".to_owned()),
+                }),
+            ));
+        }
+        events
     }
 
     fn start_worker(
@@ -1976,6 +2263,23 @@ impl AgentSpawnLimits {
     }
 }
 
+impl AgentRuntimeConfig {
+    fn from_options(options: &serde_json::Value) -> Self {
+        let defaults = Self::default();
+        let Some(agent_runtime) = options.get("agent_runtime") else {
+            return defaults;
+        };
+
+        Self {
+            default_timeout_sec: json_i64(agent_runtime, "default_timeout_sec")
+                .filter(|value| *value > 0)
+                .unwrap_or(defaults.default_timeout_sec),
+            max_steps_per_session: json_u32(agent_runtime, "max_steps_per_session")
+                .unwrap_or(defaults.max_steps_per_session),
+        }
+    }
+}
+
 impl OrchestratorConfig {
     fn from_options(options: &serde_json::Value) -> Self {
         let defaults = Self::default();
@@ -2254,6 +2558,45 @@ impl AgentRecord {
             parent_agent_id: self.parent_agent_id,
             model: Some(self.model),
             status: Some(self.status),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AgentSessionRecord {
+    id: AgentSessionId,
+    session_id: SessionId,
+    route_id: String,
+    agent_id: AgentId,
+    parent_agent_id: Option<AgentId>,
+    task: String,
+    status: AgentSessionStatus,
+    timeout_at: Timestamp,
+    budget_steps: u32,
+    steps_used: u32,
+    result: Option<String>,
+    error_code: Option<String>,
+    error: Option<String>,
+    cancellation_requested_at: Option<Timestamp>,
+}
+
+impl AgentSessionRecord {
+    fn event_payload(&self) -> AgentSessionEventPayload {
+        AgentSessionEventPayload {
+            agent_session_id: self.id.clone(),
+            session_id: self.session_id.clone(),
+            route_id: self.route_id.clone(),
+            agent_id: self.agent_id.clone(),
+            parent_agent_id: self.parent_agent_id.clone(),
+            task: self.task.clone(),
+            status: self.status,
+            timeout_at: self.timeout_at.clone(),
+            budget_steps: self.budget_steps,
+            steps_used: self.steps_used,
+            result: self.result.clone(),
+            error_code: self.error_code.clone(),
+            error: self.error.clone(),
+            cancellation_requested_at: self.cancellation_requested_at.clone(),
         }
     }
 }
@@ -2846,6 +3189,18 @@ fn timestamp_after_minutes(minutes: i64) -> Timestamp {
     let value =
         (Utc::now() + Duration::minutes(minutes)).to_rfc3339_opts(SecondsFormat::Secs, true);
     Timestamp::new_utc(value).expect("chrono UTC timestamp should satisfy protocol")
+}
+
+fn timestamp_after_seconds(seconds: i64) -> Timestamp {
+    let value =
+        (Utc::now() + Duration::seconds(seconds)).to_rfc3339_opts(SecondsFormat::Secs, true);
+    Timestamp::new_utc(value).expect("chrono UTC timestamp should satisfy protocol")
+}
+
+fn timestamp_is_past(timestamp: &Timestamp) -> bool {
+    DateTime::parse_from_rfc3339(timestamp.as_str())
+        .map(|timestamp| timestamp.with_timezone(&Utc) <= Utc::now())
+        .unwrap_or(true)
 }
 
 fn approval_is_expired(record: &ApprovalRecord) -> bool {
@@ -3462,11 +3817,33 @@ fn branch_slug(value: &str) -> String {
     }
 }
 
+fn agent_session_is_terminal(status: AgentSessionStatus) -> bool {
+    matches!(
+        status,
+        AgentSessionStatus::Completed
+            | AgentSessionStatus::Failed
+            | AgentSessionStatus::Cancelled
+            | AgentSessionStatus::TimedOut
+            | AgentSessionStatus::BudgetExceeded
+    )
+}
+
 fn json_usize(value: &serde_json::Value, key: &str) -> Option<usize> {
     value
         .get(key)
         .and_then(serde_json::Value::as_u64)
         .and_then(|value| usize::try_from(value).ok())
+}
+
+fn json_u32(value: &serde_json::Value, key: &str) -> Option<u32> {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+}
+
+fn json_i64(value: &serde_json::Value, key: &str) -> Option<i64> {
+    value.get(key).and_then(serde_json::Value::as_i64)
 }
 
 fn merge_json(mut base: serde_json::Value, patch: serde_json::Value) -> serde_json::Value {
@@ -3577,6 +3954,33 @@ mod tests {
                 }),
             },
             provider,
+        )
+    }
+
+    fn runtime_with_agent_runtime_config(agent_runtime: AgentRuntimeConfig) -> Runtime {
+        Runtime::new(
+            RuntimeOptions {
+                cadis_home: test_workspace("cadis-home"),
+                profile_id: "default".to_owned(),
+                socket_path: Some(PathBuf::from("/tmp/cadis-test.sock")),
+                model_provider: "echo".to_owned(),
+                ui_preferences: serde_json::json!({
+                    "agent_spawn": {
+                        "max_depth": AgentSpawnLimits::default().max_depth,
+                        "max_children_per_parent": AgentSpawnLimits::default().max_children_per_parent,
+                        "max_total_agents": AgentSpawnLimits::default().max_total_agents
+                    },
+                    "agent_runtime": {
+                        "default_timeout_sec": agent_runtime.default_timeout_sec,
+                        "max_steps_per_session": agent_runtime.max_steps_per_session
+                    },
+                    "orchestrator": {
+                        "worker_delegation_enabled": true,
+                        "default_worker_role": "Worker"
+                    }
+                }),
+            },
+            Box::<EchoProvider>::default(),
         )
     }
 
@@ -4182,6 +4586,138 @@ mod tests {
             .events
             .iter()
             .any(|event| matches!(event.event, CadisEvent::MessageCompleted(_))));
+    }
+
+    #[test]
+    fn message_send_emits_agent_session_lifecycle_events() {
+        let mut runtime = runtime();
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_agent_session"),
+            ClientId::from("cli_1"),
+            ClientRequest::MessageSend(MessageSendRequest {
+                session_id: None,
+                target_agent_id: Some(AgentId::from("codex")),
+                content: "run tests".to_owned(),
+                content_kind: ContentKind::Chat,
+            }),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        let started = outcome.events.iter().find_map(|event| match &event.event {
+            CadisEvent::AgentSessionStarted(payload) => Some(payload),
+            _ => None,
+        });
+        let started = started.expect("agent.session.started should be emitted");
+        assert_eq!(started.agent_id.as_str(), "codex");
+        assert_eq!(started.route_id, "route_000001");
+        assert_eq!(started.status, AgentSessionStatus::Running);
+        assert_eq!(started.task, "run tests");
+        assert_eq!(started.budget_steps, 1);
+        assert_eq!(started.steps_used, 0);
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentSessionUpdated(payload)
+                    if payload.agent_session_id == started.agent_session_id
+                        && payload.steps_used == 1
+            )
+        }));
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentSessionCompleted(payload)
+                    if payload.agent_session_id == started.agent_session_id
+                        && payload.result.as_deref().is_some_and(|result| result.contains("run tests"))
+            )
+        }));
+    }
+
+    #[test]
+    fn agent_session_budget_limit_fails_before_provider_execution() {
+        let mut runtime = runtime_with_agent_runtime_config(AgentRuntimeConfig {
+            default_timeout_sec: 900,
+            max_steps_per_session: 0,
+        });
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_budget"),
+            ClientId::from("cli_1"),
+            ClientRequest::MessageSend(MessageSendRequest {
+                session_id: None,
+                target_agent_id: Some(AgentId::from("codex")),
+                content: "run tests".to_owned(),
+                content_kind: ContentKind::Chat,
+            }),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentSessionFailed(payload)
+                    if payload.status == AgentSessionStatus::BudgetExceeded
+                        && payload.error_code.as_deref() == Some("agent_budget_exceeded")
+            )
+        }));
+        assert!(!outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::MessageCompleted(_))));
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::SessionFailed(payload)
+                    if payload.code == "agent_budget_exceeded"
+            )
+        }));
+    }
+
+    #[test]
+    fn session_cancel_marks_running_agent_sessions_cancelled() {
+        let mut runtime = runtime();
+        let session_id = runtime.create_session(Some("Cancelable".to_owned()), None);
+        let (agent_session_id, _event) = runtime.start_agent_session(
+            session_id.clone(),
+            "route_000001".to_owned(),
+            AgentId::from("codex"),
+            "wait for user".to_owned(),
+        );
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_cancel"),
+            ClientId::from("cli_1"),
+            ClientRequest::SessionCancel(SessionTargetRequest {
+                session_id: session_id.clone(),
+            }),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentSessionCancelled(payload)
+                    if payload.agent_session_id == agent_session_id
+                        && payload.status == AgentSessionStatus::Cancelled
+                        && payload.cancellation_requested_at.is_some()
+            )
+        }));
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentStatusChanged(payload)
+                    if payload.agent_id.as_str() == "codex"
+                        && payload.status == AgentStatus::Cancelled
+            )
+        }));
     }
 
     #[test]

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -29,8 +29,8 @@ use cadis_protocol::{
 use cadis_store::{
     redact, AgentHomeDiagnostic, AgentHomeDoctorOptions, AgentHomeTemplate, ApprovalRecord,
     ApprovalState, ApprovalStore, CadisConfig, CadisHome, CheckpointPolicy,
-    GrantSource as StoreGrantSource, ProfileHome, ProjectWorkspaceStore, StateStore,
-    WorkspaceAccess as StoreWorkspaceAccess, WorkspaceAlias,
+    GrantSource as StoreGrantSource, ProfileHome, ProjectWorkspaceStore, ProjectWorktreeDiagnostic,
+    StateStore, WorkerArtifactPathSet, WorkspaceAccess as StoreWorkspaceAccess, WorkspaceAlias,
     WorkspaceGrantRecord as StoreWorkspaceGrantRecord, WorkspaceKind as StoreWorkspaceKind,
     WorkspaceMetadata, WorkspaceRegistry, WorkspaceVcs,
 };
@@ -761,7 +761,6 @@ impl Runtime {
         self.next_route += 1;
 
         let session_workspace = self.session_workspace(&session_id);
-        let artifact_root = self.options.cadis_home.join("artifacts").join("workers");
         let worker = route.worker_summary.as_ref().map(|summary| {
             let worker_id = self.next_worker_id();
             WorkerDelegation {
@@ -770,7 +769,9 @@ impl Runtime {
                     session_workspace.as_deref(),
                     &route.content,
                 ),
-                artifacts: worker_artifact_locations(&artifact_root, &worker_id),
+                artifacts: worker_artifact_locations(
+                    &self.profile_home.worker_artifact_paths(&worker_id),
+                ),
                 worker_id,
                 parent_agent_id: self
                     .agents
@@ -1462,6 +1463,7 @@ impl Runtime {
                 Ok(root) => {
                     checks.push(root_check("request.root", &root));
                     checks.extend(project_workspace_metadata_checks_for_root(&root));
+                    checks.extend(project_worker_worktree_checks_for_root(&root));
                 }
                 Err(error) => checks.push(WorkspaceDoctorCheck {
                     name: "request.root".to_owned(),
@@ -3009,6 +3011,7 @@ fn project_workspace_metadata_checks(workspace: &WorkspaceRecord) -> Vec<Workspa
     }
 
     let mut checks = project_workspace_metadata_checks_for_root(&workspace.root);
+    checks.extend(project_worker_worktree_checks_for_root(&workspace.root));
     let Some(metadata) = ProjectWorkspaceStore::new(&workspace.root)
         .load()
         .ok()
@@ -3078,6 +3081,31 @@ fn project_workspace_metadata_checks_for_root(root: &Path) -> Vec<WorkspaceDocto
                 store.workspace_toml_path().display()
             ),
         }],
+    }
+}
+
+fn project_worker_worktree_checks_for_root(root: &Path) -> Vec<WorkspaceDoctorCheck> {
+    let store = ProjectWorkspaceStore::new(root);
+    match store.worker_worktree_diagnostics() {
+        Ok(diagnostics) => diagnostics
+            .into_iter()
+            .map(project_worktree_diagnostic_check)
+            .collect(),
+        Err(error) => vec![WorkspaceDoctorCheck {
+            name: "workspace.worktrees.metadata".to_owned(),
+            status: "error".to_owned(),
+            message: format!("could not inspect worker worktree metadata: {error}"),
+        }],
+    }
+}
+
+fn project_worktree_diagnostic_check(
+    diagnostic: ProjectWorktreeDiagnostic,
+) -> WorkspaceDoctorCheck {
+    WorkspaceDoctorCheck {
+        name: diagnostic.name,
+        status: diagnostic.status,
+        message: diagnostic.message,
     }
 }
 
@@ -3386,9 +3414,11 @@ fn planned_worker_worktree(
 ) -> WorkerWorktreeIntent {
     let worktree_root = workspace
         .map(|workspace| {
-            Path::new(workspace)
-                .join(".cadis")
-                .join("worktrees")
+            let store = ProjectWorkspaceStore::new(workspace);
+            let metadata = store.load().ok().flatten();
+            store
+                .worker_worktree_paths(worker_id, metadata.as_ref())
+                .worktree_root
                 .display()
                 .to_string()
         })
@@ -3410,17 +3440,14 @@ fn planned_worker_worktree(
     }
 }
 
-fn worker_artifact_locations(root: &Path, worker_id: &str) -> WorkerArtifactLocations {
-    let root = root.join(worker_id);
-    let root_display = root.display().to_string();
-
+fn worker_artifact_locations(paths: &WorkerArtifactPathSet) -> WorkerArtifactLocations {
     WorkerArtifactLocations {
-        root: root_display,
-        patch: root.join("patch.diff").display().to_string(),
-        test_report: root.join("test-report.json").display().to_string(),
-        summary: root.join("summary.md").display().to_string(),
-        changed_files: root.join("changed-files.json").display().to_string(),
-        memory_candidates: root.join("memory-candidates.jsonl").display().to_string(),
+        root: paths.root.display().to_string(),
+        patch: paths.patch.display().to_string(),
+        test_report: paths.test_report.display().to_string(),
+        summary: paths.summary.display().to_string(),
+        changed_files: paths.changed_files.display().to_string(),
+        memory_candidates: paths.memory_candidates.display().to_string(),
     }
 }
 
@@ -3879,6 +3906,59 @@ mod tests {
                 CadisEvent::WorkspaceDoctorResponse(payload)
                     if payload.checks.iter().any(|check| check.name == "workspace.metadata"
                         && check.status == "warn")
+            )
+        }));
+    }
+
+    #[test]
+    fn workspace_doctor_reports_stale_worker_worktree_metadata() {
+        let workspace = test_workspace("doctor-stale-worktree");
+        let mut runtime = runtime();
+        let store = cadis_store::ProjectWorkspaceStore::new(&workspace);
+        store
+            .save(&cadis_store::ProjectWorkspaceMetadata {
+                workspace_id: "doctor-stale".to_owned(),
+                kind: cadis_store::WorkspaceKind::Project,
+                vcs: cadis_store::WorkspaceVcs::Git,
+                worktree_root: PathBuf::from(".cadis/worktrees"),
+                artifact_root: PathBuf::from(".cadis/artifacts"),
+                media_root: PathBuf::from(".cadis/media"),
+            })
+            .expect("project workspace metadata should save");
+        store
+            .save_worker_worktree_metadata(&cadis_store::ProjectWorkerWorktreeMetadata {
+                worker_id: "worker_000001".to_owned(),
+                workspace_id: "doctor-stale".to_owned(),
+                worktree_path: PathBuf::from(".cadis/worktrees/worker_000001"),
+                branch_name: "cadis/worker_000001/example".to_owned(),
+                base_ref: Some("HEAD".to_owned()),
+                state: cadis_store::ProjectWorkerWorktreeState::Planned,
+                artifact_root: runtime
+                    .profile_home
+                    .root()
+                    .join("artifacts/workers/worker_000001"),
+            })
+            .expect("worker worktree metadata should save");
+
+        register_workspace(&mut runtime, "doctor-stale", &workspace);
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_workspace_doctor"),
+            ClientId::from("cli_1"),
+            ClientRequest::WorkspaceDoctor(WorkspaceDoctorRequest {
+                workspace_id: Some(WorkspaceId::from("doctor-stale")),
+                root: None,
+            }),
+        ));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::WorkspaceDoctorResponse(payload)
+                    if payload.checks.iter().any(|check| check.name == "workspace.worktrees.worker_000001.path"
+                        && check.status == "warn")
+                        && payload.checks.iter().any(|check| check.name == "workspace.worktrees.worker_000001.artifacts"
+                            && check.status == "warn")
             )
         }));
     }
@@ -4788,8 +4868,8 @@ mod tests {
             "cadis/worker_000001/run-focused-tests"
         );
         let expected_patch = runtime
-            .options
-            .cadis_home
+            .profile_home
+            .root()
             .join("artifacts/workers/worker_000001/patch.diff")
             .display()
             .to_string();

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -28,7 +28,7 @@ use cadis_protocol::{
 };
 use cadis_store::{
     redact, ApprovalRecord, ApprovalState, ApprovalStore, CadisConfig, CadisHome, CheckpointPolicy,
-    GrantSource as StoreGrantSource, ProfileHome, StateStore,
+    GrantSource as StoreGrantSource, ProfileHome, StateRecoveryDiagnostic, StateStore,
     WorkspaceAccess as StoreWorkspaceAccess, WorkspaceAlias,
     WorkspaceGrantRecord as StoreWorkspaceGrantRecord, WorkspaceKind as StoreWorkspaceKind,
     WorkspaceMetadata, WorkspaceRegistry, WorkspaceVcs,
@@ -117,6 +117,7 @@ pub struct Runtime {
     next_worker: u64,
     sessions: HashMap<SessionId, SessionRecord>,
     agents: HashMap<AgentId, AgentRecord>,
+    workers: HashMap<String, WorkerRecord>,
     orchestrator: Orchestrator,
     ui_preferences: serde_json::Value,
     spawn_limits: AgentSpawnLimits,
@@ -127,6 +128,7 @@ pub struct Runtime {
     pending_approvals: HashMap<ApprovalId, PendingApproval>,
     workspaces: HashMap<WorkspaceId, WorkspaceRecord>,
     workspace_grants: HashMap<WorkspaceGrantId, WorkspaceGrantRecord>,
+    recovery_diagnostics: Vec<ErrorPayload>,
     next_tool: u64,
     next_approval: u64,
     next_workspace_grant: u64,
@@ -151,13 +153,23 @@ impl Runtime {
         let workspaces = load_workspace_registry(&profile_home);
         let workspace_grants = load_workspace_grants(&profile_home, &workspaces);
         let next_workspace_grant = next_workspace_grant_counter(&workspace_grants);
-        let sessions = recover_session_records(&state_store);
+        let RuntimeRecovery {
+            records: sessions,
+            mut diagnostics,
+        } = recover_session_records(&state_store);
         let mut agents = default_agents(&options.model_provider);
-        for (agent_id, record) in recover_agent_records(&state_store) {
+        let agent_recovery = recover_agent_records(&state_store);
+        diagnostics.extend(agent_recovery.diagnostics);
+        for (agent_id, record) in agent_recovery.records {
             agents.insert(agent_id, record);
         }
+        let worker_recovery = recover_worker_records(&state_store);
+        diagnostics.extend(worker_recovery.diagnostics);
+        let mut workers = worker_recovery.records;
+        diagnostics.extend(reconcile_recovered_workers(&state_store, &mut workers));
         let next_session = next_session_counter(&sessions);
         let next_agent = next_agent_counter(&agents);
+        let next_worker = next_worker_counter(&workers);
 
         Self {
             options,
@@ -168,9 +180,10 @@ impl Runtime {
             next_session,
             next_agent,
             next_route: 1,
-            next_worker: 1,
+            next_worker,
             sessions,
             agents,
+            workers,
             orchestrator,
             ui_preferences,
             spawn_limits,
@@ -181,6 +194,7 @@ impl Runtime {
             pending_approvals: HashMap::new(),
             workspaces,
             workspace_grants,
+            recovery_diagnostics: diagnostics,
             next_tool: 1,
             next_approval: 1,
             next_workspace_grant,
@@ -780,20 +794,19 @@ impl Runtime {
         });
 
         if let Some(worker) = &worker {
-            events.push(self.session_event(
-                session_id.clone(),
-                CadisEvent::WorkerStarted(WorkerEventPayload {
-                    worker_id: worker.worker_id.clone(),
-                    agent_id: Some(route.agent_id.clone()),
-                    parent_agent_id: worker.parent_agent_id.clone(),
-                    status: Some("running".to_owned()),
-                    cli: None,
-                    cwd: None,
-                    summary: Some(worker.summary.clone()),
-                    worktree: Some(worker.worktree.clone()),
-                    artifacts: Some(worker.artifacts.clone()),
-                }),
-            ));
+            let payload = WorkerEventPayload {
+                worker_id: worker.worker_id.clone(),
+                agent_id: Some(route.agent_id.clone()),
+                parent_agent_id: worker.parent_agent_id.clone(),
+                status: Some("running".to_owned()),
+                cli: None,
+                cwd: None,
+                summary: Some(worker.summary.clone()),
+                worktree: Some(worker.worktree.clone()),
+                artifacts: Some(worker.artifacts.clone()),
+            };
+            self.track_worker_event(session_id.clone(), &payload);
+            events.push(self.session_event(session_id.clone(), CadisEvent::WorkerStarted(payload)));
         }
 
         if route.agent_id.as_str() != "main" {
@@ -888,20 +901,24 @@ impl Runtime {
                     ));
                 }
                 if let Some(worker) = &worker {
-                    events.push(self.session_event(
-                        session_id.clone(),
-                        CadisEvent::WorkerCompleted(WorkerEventPayload {
-                            worker_id: worker.worker_id.clone(),
-                            agent_id: Some(route.agent_id.clone()),
-                            parent_agent_id: worker.parent_agent_id.clone(),
-                            status: Some("completed".to_owned()),
-                            cli: None,
-                            cwd: None,
-                            summary: Some(worker.summary.clone()),
-                            worktree: Some(worker.worktree.clone()),
-                            artifacts: Some(worker.artifacts.clone()),
-                        }),
-                    ));
+                    let payload = WorkerEventPayload {
+                        worker_id: worker.worker_id.clone(),
+                        agent_id: Some(route.agent_id.clone()),
+                        parent_agent_id: worker.parent_agent_id.clone(),
+                        status: Some("completed".to_owned()),
+                        cli: None,
+                        cwd: None,
+                        summary: Some(worker.summary.clone()),
+                        worktree: Some(worker.worktree.clone()),
+                        artifacts: Some(worker.artifacts.clone()),
+                    };
+                    self.track_worker_event(session_id.clone(), &payload);
+                    events.push(
+                        self.session_event(
+                            session_id.clone(),
+                            CadisEvent::WorkerCompleted(payload),
+                        ),
+                    );
                 }
                 events.push(self.session_event(
                     session_id.clone(),
@@ -922,20 +939,24 @@ impl Runtime {
                     }),
                 ));
                 if let Some(worker) = &worker {
-                    events.push(self.session_event(
-                        session_id.clone(),
-                        CadisEvent::WorkerCompleted(WorkerEventPayload {
-                            worker_id: worker.worker_id.clone(),
-                            agent_id: Some(route.agent_id.clone()),
-                            parent_agent_id: worker.parent_agent_id.clone(),
-                            status: Some("failed".to_owned()),
-                            cli: None,
-                            cwd: None,
-                            summary: Some(error_message.clone()),
-                            worktree: Some(worker.worktree.clone()),
-                            artifacts: Some(worker.artifacts.clone()),
-                        }),
-                    ));
+                    let payload = WorkerEventPayload {
+                        worker_id: worker.worker_id.clone(),
+                        agent_id: Some(route.agent_id.clone()),
+                        parent_agent_id: worker.parent_agent_id.clone(),
+                        status: Some("failed".to_owned()),
+                        cli: None,
+                        cwd: None,
+                        summary: Some(error_message.clone()),
+                        worktree: Some(worker.worktree.clone()),
+                        artifacts: Some(worker.artifacts.clone()),
+                    };
+                    self.track_worker_event(session_id.clone(), &payload);
+                    events.push(
+                        self.session_event(
+                            session_id.clone(),
+                            CadisEvent::WorkerCompleted(payload),
+                        ),
+                    );
                 }
                 events.push(self.session_event(
                     session_id,
@@ -1295,13 +1316,25 @@ impl Runtime {
         sessions
     }
 
+    fn worker_records_sorted(&self) -> Vec<WorkerRecord> {
+        let mut workers = self.workers.values().cloned().collect::<Vec<_>>();
+        workers.sort_by(|left, right| left.worker_id.cmp(&right.worker_id));
+        workers
+    }
+
     fn snapshot_events(&mut self) -> Vec<EventEnvelope> {
         let agents = self
             .agent_records_sorted()
             .into_iter()
             .map(AgentRecord::event_payload)
             .collect();
-        let mut events = vec![
+        let diagnostics = self.recovery_diagnostics.clone();
+        let mut events = diagnostics
+            .into_iter()
+            .map(|diagnostic| self.event(None, CadisEvent::DaemonError(diagnostic)))
+            .collect::<Vec<_>>();
+
+        events.extend([
             self.event(
                 None,
                 CadisEvent::AgentListResponse(AgentListPayload { agents }),
@@ -1319,7 +1352,7 @@ impl Runtime {
                     preferences: self.ui_preferences.clone(),
                 }),
             ),
-        ];
+        ]);
 
         for (session_id, session) in self.session_records_sorted() {
             events.push(self.session_event(
@@ -1329,6 +1362,18 @@ impl Runtime {
                     title: session.title,
                 }),
             ));
+        }
+
+        for worker in self.worker_records_sorted() {
+            let session_id = worker.session_id.clone();
+            let is_terminal = worker.is_terminal();
+            let payload = worker.event_payload();
+            let event = if is_terminal {
+                CadisEvent::WorkerCompleted(payload)
+            } else {
+                CadisEvent::WorkerStarted(payload)
+            };
+            events.push(self.session_event(session_id, event));
         }
 
         events
@@ -1794,6 +1839,15 @@ impl Runtime {
         let _ = self.persist_session_record(&session_id);
     }
 
+    fn track_worker_event(&mut self, session_id: SessionId, payload: &WorkerEventPayload) {
+        let worker_id = payload.worker_id.clone();
+        self.workers.insert(
+            worker_id.clone(),
+            WorkerRecord::from_event_payload(session_id, payload, now_timestamp()),
+        );
+        let _ = self.persist_worker_record(&worker_id);
+    }
+
     fn persist_session_record(
         &self,
         session_id: &SessionId,
@@ -1803,6 +1857,14 @@ impl Runtime {
                 session_id,
                 &SessionMetadata::from_record(session_id.clone(), record),
             )?;
+        }
+        Ok(())
+    }
+
+    fn persist_worker_record(&self, worker_id: &str) -> Result<(), cadis_store::StoreError> {
+        if let Some(record) = self.workers.get(worker_id) {
+            self.state_store
+                .write_worker_metadata(worker_id, &WorkerMetadata::from_record(record))?;
         }
         Ok(())
     }
@@ -2157,6 +2219,117 @@ impl AgentRecord {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+struct WorkerRecord {
+    worker_id: String,
+    session_id: SessionId,
+    agent_id: Option<AgentId>,
+    parent_agent_id: Option<AgentId>,
+    status: String,
+    cli: Option<String>,
+    cwd: Option<String>,
+    summary: Option<String>,
+    worktree: Option<WorkerWorktreeIntent>,
+    artifacts: Option<WorkerArtifactLocations>,
+    updated_at: Timestamp,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+struct WorkerMetadata {
+    worker_id: String,
+    session_id: SessionId,
+    agent_id: Option<AgentId>,
+    parent_agent_id: Option<AgentId>,
+    status: String,
+    cli: Option<String>,
+    cwd: Option<String>,
+    summary: Option<String>,
+    worktree: Option<WorkerWorktreeIntent>,
+    artifacts: Option<WorkerArtifactLocations>,
+    updated_at: Timestamp,
+}
+
+impl WorkerRecord {
+    fn from_event_payload(
+        session_id: SessionId,
+        payload: &WorkerEventPayload,
+        updated_at: Timestamp,
+    ) -> Self {
+        Self {
+            worker_id: payload.worker_id.clone(),
+            session_id,
+            agent_id: payload.agent_id.clone(),
+            parent_agent_id: payload.parent_agent_id.clone(),
+            status: payload
+                .status
+                .clone()
+                .unwrap_or_else(|| "running".to_owned()),
+            cli: payload.cli.clone(),
+            cwd: payload.cwd.clone(),
+            summary: payload.summary.clone(),
+            worktree: payload.worktree.clone(),
+            artifacts: payload.artifacts.clone(),
+            updated_at,
+        }
+    }
+
+    fn event_payload(self) -> WorkerEventPayload {
+        WorkerEventPayload {
+            worker_id: self.worker_id,
+            agent_id: self.agent_id,
+            parent_agent_id: self.parent_agent_id,
+            status: Some(self.status),
+            cli: self.cli,
+            cwd: self.cwd,
+            summary: self.summary,
+            worktree: self.worktree,
+            artifacts: self.artifacts,
+        }
+    }
+
+    fn is_terminal(&self) -> bool {
+        worker_status_is_terminal(&self.status)
+    }
+}
+
+impl WorkerMetadata {
+    fn from_record(record: &WorkerRecord) -> Self {
+        Self {
+            worker_id: record.worker_id.clone(),
+            session_id: record.session_id.clone(),
+            agent_id: record.agent_id.clone(),
+            parent_agent_id: record.parent_agent_id.clone(),
+            status: record.status.clone(),
+            cli: record.cli.clone(),
+            cwd: record.cwd.clone(),
+            summary: record.summary.clone(),
+            worktree: record.worktree.clone(),
+            artifacts: record.artifacts.clone(),
+            updated_at: record.updated_at.clone(),
+        }
+    }
+
+    fn into_record(self) -> (String, WorkerRecord) {
+        let worker_id = self.worker_id;
+        (
+            worker_id.clone(),
+            WorkerRecord {
+                worker_id,
+                session_id: self.session_id,
+                agent_id: self.agent_id,
+                parent_agent_id: self.parent_agent_id,
+                status: self.status,
+                cli: self.cli,
+                cwd: self.cwd,
+                summary: self.summary,
+                worktree: self.worktree,
+                artifacts: self.artifacts,
+                updated_at: self.updated_at,
+            },
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct WorkspaceRecord {
     id: WorkspaceId,
     kind: WorkspaceKind,
@@ -2494,24 +2667,151 @@ fn protocol_readiness(readiness: ProviderReadiness) -> ModelReadiness {
     }
 }
 
-fn recover_session_records(state_store: &StateStore) -> HashMap<SessionId, SessionRecord> {
-    state_store
-        .recover_session_metadata::<SessionMetadata>()
-        .map(|recovery| recovery.records)
-        .unwrap_or_default()
+#[derive(Debug)]
+struct RuntimeRecovery<K, V> {
+    records: HashMap<K, V>,
+    diagnostics: Vec<ErrorPayload>,
+}
+
+fn recover_session_records(state_store: &StateStore) -> RuntimeRecovery<SessionId, SessionRecord> {
+    match state_store.recover_session_metadata::<SessionMetadata>() {
+        Ok(recovery) => RuntimeRecovery {
+            records: recovery
+                .records
+                .into_iter()
+                .map(|record| record.metadata.into_record())
+                .collect(),
+            diagnostics: recovery_diagnostics("session", recovery.diagnostics),
+        },
+        Err(error) => RuntimeRecovery {
+            records: HashMap::new(),
+            diagnostics: vec![recovery_error(
+                "session_recovery_failed",
+                error.to_string(),
+                true,
+            )],
+        },
+    }
+}
+
+fn recover_agent_records(state_store: &StateStore) -> RuntimeRecovery<AgentId, AgentRecord> {
+    match state_store.recover_agent_metadata::<AgentMetadata>() {
+        Ok(recovery) => RuntimeRecovery {
+            records: recovery
+                .records
+                .into_iter()
+                .map(|record| record.metadata.into_record())
+                .collect(),
+            diagnostics: recovery_diagnostics("agent", recovery.diagnostics),
+        },
+        Err(error) => RuntimeRecovery {
+            records: HashMap::new(),
+            diagnostics: vec![recovery_error(
+                "agent_recovery_failed",
+                error.to_string(),
+                true,
+            )],
+        },
+    }
+}
+
+fn recover_worker_records(state_store: &StateStore) -> RuntimeRecovery<String, WorkerRecord> {
+    match state_store.recover_worker_metadata::<WorkerMetadata>() {
+        Ok(recovery) => RuntimeRecovery {
+            records: recovery
+                .records
+                .into_iter()
+                .map(|record| record.metadata.into_record())
+                .collect(),
+            diagnostics: recovery_diagnostics("worker", recovery.diagnostics),
+        },
+        Err(error) => RuntimeRecovery {
+            records: HashMap::new(),
+            diagnostics: vec![recovery_error(
+                "worker_recovery_failed",
+                error.to_string(),
+                true,
+            )],
+        },
+    }
+}
+
+fn reconcile_recovered_workers(
+    state_store: &StateStore,
+    workers: &mut HashMap<String, WorkerRecord>,
+) -> Vec<ErrorPayload> {
+    let mut diagnostics = Vec::new();
+
+    for worker in workers.values_mut() {
+        if worker.is_terminal() {
+            continue;
+        }
+
+        worker.status = "failed".to_owned();
+        worker.summary = Some(match worker.summary.take() {
+            Some(summary) if !summary.trim().is_empty() => {
+                format!("{summary} (marked failed during daemon recovery)")
+            }
+            _ => "Worker was marked failed during daemon recovery".to_owned(),
+        });
+        worker.updated_at = now_timestamp();
+
+        match state_store.write_worker_metadata(
+            &worker.worker_id,
+            &WorkerMetadata::from_record(worker),
+        ) {
+            Ok(()) => diagnostics.push(recovery_error(
+                "worker_recovered_stale",
+                format!(
+                    "worker '{}' had non-terminal status on daemon startup and was marked failed",
+                    worker.worker_id
+                ),
+                false,
+            )),
+            Err(error) => diagnostics.push(recovery_error(
+                "worker_recovery_persist_failed",
+                format!(
+                    "worker '{}' was marked failed in memory, but recovery state could not be persisted: {error}",
+                    worker.worker_id
+                ),
+                true,
+            )),
+        }
+    }
+
+    diagnostics
+}
+
+fn recovery_diagnostics(
+    kind: &'static str,
+    diagnostics: Vec<StateRecoveryDiagnostic>,
+) -> Vec<ErrorPayload> {
+    diagnostics
         .into_iter()
-        .map(|record| record.metadata.into_record())
+        .map(|diagnostic| {
+            recovery_error(
+                format!("{kind}_metadata_recovery_skipped"),
+                format!(
+                    "skipped invalid {kind} metadata '{}': {}",
+                    diagnostic.path.display(),
+                    diagnostic.reason
+                ),
+                false,
+            )
+        })
         .collect()
 }
 
-fn recover_agent_records(state_store: &StateStore) -> HashMap<AgentId, AgentRecord> {
-    state_store
-        .recover_agent_metadata::<AgentMetadata>()
-        .map(|recovery| recovery.records)
-        .unwrap_or_default()
-        .into_iter()
-        .map(|record| record.metadata.into_record())
-        .collect()
+fn recovery_error(
+    code: impl Into<String>,
+    message: impl Into<String>,
+    retryable: bool,
+) -> ErrorPayload {
+    ErrorPayload {
+        code: code.into(),
+        message: message.into(),
+        retryable,
+    }
 }
 
 fn next_session_counter(sessions: &HashMap<SessionId, SessionRecord>) -> u64 {
@@ -2532,6 +2832,23 @@ fn next_agent_counter(agents: &HashMap<AgentId, AgentRecord>) -> u64 {
         .max()
         .unwrap_or(0)
         + 1
+}
+
+fn next_worker_counter(workers: &HashMap<String, WorkerRecord>) -> u64 {
+    workers
+        .keys()
+        .filter_map(|worker_id| worker_id.strip_prefix("worker_"))
+        .filter_map(|suffix| suffix.parse::<u64>().ok())
+        .max()
+        .unwrap_or(0)
+        + 1
+}
+
+fn worker_status_is_terminal(status: &str) -> bool {
+    matches!(
+        status,
+        "completed" | "failed" | "cancelled" | "canceled" | "expired"
+    )
 }
 
 fn load_workspace_registry(profile_home: &ProfileHome) -> HashMap<WorkspaceId, WorkspaceRecord> {
@@ -3822,6 +4139,169 @@ mod tests {
                     && agent.model.as_deref() == Some("echo/cadis-local-fallback")
                     && agent.parent_agent_id.as_ref() == Some(&AgentId::from("main"))
             })
+        }));
+    }
+
+    #[test]
+    fn worker_metadata_survives_runtime_restart_and_snapshot_replays_worker() {
+        let cadis_home = test_workspace("persistent-worker-home");
+        let worker_id = {
+            let mut runtime = runtime_with_home(cadis_home.clone());
+            let outcome = runtime.handle_request(RequestEnvelope::new(
+                RequestId::from("req_worker"),
+                ClientId::from("hud_1"),
+                ClientRequest::MessageSend(MessageSendRequest {
+                    session_id: None,
+                    target_agent_id: None,
+                    content: "/route @codex run focused tests".to_owned(),
+                    content_kind: ContentKind::Chat,
+                }),
+            ));
+
+            assert!(matches!(
+                outcome.response.response,
+                DaemonResponse::RequestAccepted(_)
+            ));
+            outcome
+                .events
+                .iter()
+                .find_map(|event| match &event.event {
+                    CadisEvent::WorkerCompleted(payload) => Some(payload.worker_id.clone()),
+                    _ => None,
+                })
+                .expect("worker.completed should be emitted")
+        };
+
+        assert_eq!(worker_id, "worker_000001");
+
+        let mut runtime = runtime_with_home(cadis_home);
+        let snapshot = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_snapshot"),
+            ClientId::from("hud_1"),
+            ClientRequest::EventsSnapshot(EventsSnapshotRequest::default()),
+        ));
+
+        assert!(snapshot.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::WorkerCompleted(payload)
+                    if payload.worker_id == worker_id
+                        && payload.agent_id.as_ref().map(AgentId::as_str) == Some("codex")
+                        && payload.status.as_deref() == Some("completed")
+            )
+        }));
+
+        let next = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_next_worker"),
+            ClientId::from("hud_1"),
+            ClientRequest::MessageSend(MessageSendRequest {
+                session_id: None,
+                target_agent_id: None,
+                content: "/route @codex inspect next task".to_owned(),
+                content_kind: ContentKind::Chat,
+            }),
+        ));
+
+        assert!(next.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::WorkerStarted(payload)
+                    if payload.worker_id == "worker_000002"
+                        && payload.status.as_deref() == Some("running")
+            )
+        }));
+    }
+
+    #[test]
+    fn stale_running_worker_metadata_is_failed_on_runtime_recovery() {
+        let cadis_home = test_workspace("stale-worker-home");
+        let state_store = StateStore::new(&CadisConfig {
+            cadis_home: cadis_home.clone(),
+            ..CadisConfig::default()
+        });
+        state_store
+            .ensure_layout()
+            .expect("state layout should initialize");
+        state_store
+            .write_worker_metadata(
+                "worker_000007",
+                &WorkerMetadata {
+                    worker_id: "worker_000007".to_owned(),
+                    session_id: SessionId::from("ses_stale"),
+                    agent_id: Some(AgentId::from("codex")),
+                    parent_agent_id: Some(AgentId::from("main")),
+                    status: "running".to_owned(),
+                    cli: None,
+                    cwd: None,
+                    summary: Some("stale worker".to_owned()),
+                    worktree: None,
+                    artifacts: None,
+                    updated_at: now_timestamp(),
+                },
+            )
+            .expect("stale worker metadata should write");
+
+        let mut runtime = runtime_with_home(cadis_home);
+        let snapshot = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_snapshot"),
+            ClientId::from("hud_1"),
+            ClientRequest::EventsSnapshot(EventsSnapshotRequest::default()),
+        ));
+
+        assert!(snapshot.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::DaemonError(payload)
+                    if payload.code == "worker_recovered_stale"
+                        && payload.message.contains("worker_000007")
+            )
+        }));
+        assert!(snapshot.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::WorkerCompleted(payload)
+                    if payload.worker_id == "worker_000007"
+                        && payload.status.as_deref() == Some("failed")
+                        && payload.summary.as_deref().is_some_and(|summary| {
+                            summary.contains("marked failed during daemon recovery")
+                        })
+            )
+        }));
+
+        let recovered = state_store
+            .recover_worker_metadata::<WorkerMetadata>()
+            .expect("worker metadata should recover");
+        assert_eq!(recovered.records.len(), 1);
+        assert_eq!(recovered.records[0].metadata.status, "failed");
+    }
+
+    #[test]
+    fn invalid_session_metadata_surfaces_recovery_diagnostic_in_snapshot() {
+        let cadis_home = test_workspace("invalid-session-recovery");
+        let state_store = StateStore::new(&CadisConfig {
+            cadis_home: cadis_home.clone(),
+            ..CadisConfig::default()
+        });
+        state_store
+            .ensure_layout()
+            .expect("state layout should initialize");
+        fs::write(state_store.state_dir().join("sessions/broken.json"), "{")
+            .expect("corrupt session metadata should write");
+
+        let mut runtime = runtime_with_home(cadis_home);
+        let snapshot = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_snapshot"),
+            ClientId::from("hud_1"),
+            ClientRequest::EventsSnapshot(EventsSnapshotRequest::default()),
+        ));
+
+        assert!(snapshot.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::DaemonError(payload)
+                    if payload.code == "session_metadata_recovery_skipped"
+                        && payload.message.contains("broken.json")
+            )
         }));
     }
 

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 
 use cadis_models::{
     provider_catalog_for_config, ModelCatalogConfig, ModelInvocation, ModelProvider, ModelRequest,
-    ModelStreamEvent, ProviderCatalogEntry, ProviderReadiness,
+    ModelStreamControl, ModelStreamEvent, ProviderCatalogEntry, ProviderReadiness,
 };
 use cadis_policy::{PolicyDecision, PolicyEngine};
 use cadis_protocol::{
@@ -847,7 +847,7 @@ impl Runtime {
                 if let ModelStreamEvent::Delta(delta) = event {
                     streamed_deltas.push(delta);
                 }
-                Ok(())
+                Ok(ModelStreamControl::Continue)
             },
         );
 

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -4103,6 +4103,7 @@ impl ToolDefinition {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn approval_placeholder(
         name: &'static str,
         description: &'static str,
@@ -5604,6 +5605,9 @@ mod tests {
                 profile_id: "default".to_owned(),
                 socket_path: Some(PathBuf::from("/tmp/cadis-test.sock")),
                 model_provider: "echo".to_owned(),
+                ollama_model: "llama3.2".to_owned(),
+                openai_model: "gpt-5.2".to_owned(),
+                openai_api_key_configured: false,
                 ui_preferences: serde_json::json!({
                     "voice": {
                         "enabled": enabled,

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -15,18 +15,18 @@ use cadis_protocol::{
     AgentEventPayload, AgentId, AgentListPayload, AgentModelChangedPayload, AgentRenamedPayload,
     AgentSpawnRequest, AgentStatus, AgentStatusChangedPayload, ApprovalDecision, ApprovalId,
     ApprovalRequestPayload, ApprovalResolvedPayload, ApprovalResponseRequest, CadisEvent,
-    ClientRequest, DaemonResponse, DaemonStatusPayload, ErrorPayload, EventEnvelope, EventId,
-    MessageCompletedPayload, MessageDeltaPayload, MessageSendRequest, ModelDescriptor,
+    ClientRequest, ContentKind, DaemonResponse, DaemonStatusPayload, ErrorPayload, EventEnvelope,
+    EventId, MessageCompletedPayload, MessageDeltaPayload, MessageSendRequest, ModelDescriptor,
     ModelInvocationPayload, ModelReadiness, ModelsListPayload, OrchestratorRoutePayload,
     ProtocolVersion, RequestAcceptedPayload, RequestEnvelope, RequestId, ResponseEnvelope,
     SessionEventPayload, SessionId, Timestamp, ToolCallId, ToolCallRequest, ToolEventPayload,
     ToolFailedPayload, UiPreferencesPayload, VoiceDoctorCheck, VoiceDoctorPayload,
-    VoicePreflightRequest, VoicePreflightSummary, VoiceRuntimeState, VoiceStatusPayload,
-    WorkerArtifactLocations, WorkerEventPayload, WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent,
-    WorkerWorktreeState, WorkspaceAccess, WorkspaceDoctorCheck, WorkspaceDoctorPayload,
-    WorkspaceDoctorRequest, WorkspaceGrantId, WorkspaceGrantPayload, WorkspaceGrantRequest,
-    WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest, WorkspaceRecordPayload,
-    WorkspaceRegisterRequest, WorkspaceRevokeRequest,
+    VoicePreferences, VoicePreflightRequest, VoicePreflightSummary, VoicePreviewRequest,
+    VoiceRuntimeState, VoiceStatusPayload, WorkerArtifactLocations, WorkerEventPayload,
+    WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent, WorkerWorktreeState, WorkspaceAccess,
+    WorkspaceDoctorCheck, WorkspaceDoctorPayload, WorkspaceDoctorRequest, WorkspaceGrantId,
+    WorkspaceGrantPayload, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceListPayload,
+    WorkspaceListRequest, WorkspaceRecordPayload, WorkspaceRegisterRequest, WorkspaceRevokeRequest,
 };
 use cadis_store::{
     redact, ApprovalRecord, ApprovalState, ApprovalStore, CadisConfig, CadisHome, CheckpointPolicy,
@@ -93,6 +93,84 @@ impl Default for OrchestratorConfig {
         Self {
             worker_delegation_enabled: true,
             default_worker_role: "Worker".to_owned(),
+        }
+    }
+}
+
+/// Text-to-speech provider contract owned by the daemon runtime.
+pub trait TtsProvider: Send {
+    /// Stable provider identifier.
+    fn id(&self) -> &'static str;
+
+    /// Human-readable provider label.
+    fn label(&self) -> &'static str;
+
+    /// Curated voice IDs this provider can report without external calls.
+    fn supported_voices(&self) -> Vec<TtsVoice>;
+
+    /// Speaks or queues short speakable text.
+    fn speak(&mut self, request: TtsRequest<'_>) -> Result<TtsOutput, TtsError>;
+
+    /// Stops current speech where the provider supports cancellation.
+    fn stop(&mut self) -> Result<(), TtsError>;
+}
+
+/// Curated voice metadata exposed by TTS providers.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TtsVoice {
+    /// Provider voice identifier.
+    pub id: &'static str,
+    /// Display label.
+    pub label: &'static str,
+    /// BCP-47 locale.
+    pub locale: &'static str,
+    /// Display gender label from the provider catalog.
+    pub gender: &'static str,
+}
+
+/// TTS request after daemon speech policy has allowed the text.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TtsRequest<'a> {
+    /// Redaction-checked speakable text.
+    pub text: &'a str,
+    /// Requested voice ID.
+    pub voice_id: &'a str,
+    /// Speaking rate adjustment.
+    pub rate: i16,
+    /// Pitch adjustment.
+    pub pitch: i16,
+    /// Volume adjustment.
+    pub volume: i16,
+}
+
+/// Successful TTS provider outcome.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TtsOutput {
+    /// Provider that handled the request.
+    pub provider: String,
+    /// Voice selected for the request.
+    pub voice_id: String,
+    /// Character count accepted by the provider.
+    pub spoken_chars: usize,
+}
+
+/// Structured TTS provider error.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TtsError {
+    /// Stable provider error code.
+    pub code: String,
+    /// Redacted human-readable message.
+    pub message: String,
+    /// Whether retrying may help.
+    pub retryable: bool,
+}
+
+impl TtsError {
+    fn new(code: impl Into<String>, message: impl Into<String>, retryable: bool) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            retryable,
         }
     }
 }
@@ -383,17 +461,8 @@ impl Runtime {
             ClientRequest::VoicePreflight(request) => {
                 self.handle_voice_preflight(request_id, request)
             }
-            ClientRequest::VoicePreview(_) => {
-                let started = self.event(None, CadisEvent::VoicePreviewStarted(Default::default()));
-                let completed =
-                    self.event(None, CadisEvent::VoicePreviewCompleted(Default::default()));
-                self.accept(request_id, vec![started, completed])
-            }
-            ClientRequest::VoiceStop(_) => {
-                let completed =
-                    self.event(None, CadisEvent::VoicePreviewCompleted(Default::default()));
-                self.accept(request_id, vec![completed])
-            }
+            ClientRequest::VoicePreview(request) => self.handle_voice_preview(request_id, request),
+            ClientRequest::VoiceStop(_) => self.handle_voice_stop(request_id),
             ClientRequest::SessionUnsubscribe(_) | ClientRequest::WorkerTail(_) => self.reject(
                 request_id,
                 "not_implemented",
@@ -884,12 +953,13 @@ impl Runtime {
                     session_id.clone(),
                     CadisEvent::MessageCompleted(MessageCompletedPayload {
                         content_kind,
-                        content: Some(final_content),
+                        content: Some(final_content.clone()),
                         agent_id: Some(route.agent_id.clone()),
                         agent_name: Some(route.agent_name.clone()),
                         model,
                     }),
                 ));
+                events.extend(self.auto_speech_events(&session_id, content_kind, &final_content));
                 events.push(self.session_event(
                     session_id.clone(),
                     CadisEvent::AgentStatusChanged(AgentStatusChangedPayload {
@@ -1322,6 +1392,111 @@ impl Runtime {
         self.accept(request_id, vec![status_event, response_event])
     }
 
+    fn handle_voice_preview(
+        &mut self,
+        request_id: RequestId,
+        request: VoicePreviewRequest,
+    ) -> RequestOutcome {
+        let prefs = VoiceRuntimePreferences::from_preview(&self.ui_preferences, request.prefs);
+        match speech_decision(
+            &prefs,
+            ContentKind::Chat,
+            &request.text,
+            SpeechMode::Preview,
+        ) {
+            SpeechDecision::Speak => {
+                let started = self.event(None, CadisEvent::VoicePreviewStarted(Default::default()));
+                match self.speak_with_provider(&prefs, request.text.trim()) {
+                    Ok(_) => {
+                        let completed =
+                            self.event(None, CadisEvent::VoicePreviewCompleted(Default::default()));
+                        self.accept(request_id, vec![started, completed])
+                    }
+                    Err(error) => {
+                        let failed = self.event(
+                            None,
+                            CadisEvent::VoicePreviewFailed(ErrorPayload {
+                                code: error.code,
+                                message: error.message,
+                                retryable: error.retryable,
+                            }),
+                        );
+                        self.accept(request_id, vec![started, failed])
+                    }
+                }
+            }
+            SpeechDecision::Blocked(reason) | SpeechDecision::RequiresSummary(reason) => {
+                let failed = self.event(
+                    None,
+                    CadisEvent::VoicePreviewFailed(ErrorPayload {
+                        code: reason.to_owned(),
+                        message: "voice preview text is not speakable by daemon policy".to_owned(),
+                        retryable: false,
+                    }),
+                );
+                self.accept(request_id, vec![failed])
+            }
+        }
+    }
+
+    fn handle_voice_stop(&mut self, request_id: RequestId) -> RequestOutcome {
+        let prefs = VoiceRuntimePreferences::from_options(&self.ui_preferences);
+        let mut provider = tts_provider_from_config(&prefs.provider);
+        let event = match provider.stop() {
+            Ok(()) => CadisEvent::VoicePreviewCompleted(Default::default()),
+            Err(error) => CadisEvent::VoicePreviewFailed(ErrorPayload {
+                code: error.code,
+                message: error.message,
+                retryable: error.retryable,
+            }),
+        };
+        let event = self.event(None, event);
+        self.accept(request_id, vec![event])
+    }
+
+    fn speak_with_provider(
+        &self,
+        prefs: &VoiceRuntimePreferences,
+        text: &str,
+    ) -> Result<TtsOutput, TtsError> {
+        let mut provider = tts_provider_from_config(&prefs.provider);
+        provider.speak(TtsRequest {
+            text,
+            voice_id: &prefs.voice_id,
+            rate: prefs.rate,
+            pitch: prefs.pitch,
+            volume: prefs.volume,
+        })
+    }
+
+    fn auto_speech_events(
+        &mut self,
+        session_id: &SessionId,
+        content_kind: ContentKind,
+        text: &str,
+    ) -> Vec<EventEnvelope> {
+        let prefs = VoiceRuntimePreferences::from_options(&self.ui_preferences);
+        if speech_decision(&prefs, content_kind, text, SpeechMode::AutoSpeak)
+            != SpeechDecision::Speak
+        {
+            return Vec::new();
+        }
+
+        match self.speak_with_provider(&prefs, text.trim()) {
+            Ok(_) => vec![
+                self.session_event(
+                    session_id.clone(),
+                    CadisEvent::VoiceStarted(Default::default()),
+                ),
+                self.session_event(
+                    session_id.clone(),
+                    CadisEvent::VoiceCompleted(Default::default()),
+                ),
+            ],
+            Err(_) => Vec::new(),
+        }
+    }
+
     fn voice_status(&self) -> VoiceStatusPayload {
         let prefs = VoiceRuntimePreferences::from_options(&self.ui_preferences);
         let checks = self.voice_doctor_checks(true);
@@ -1359,6 +1534,8 @@ impl Runtime {
 
     fn voice_doctor_checks(&self, include_bridge: bool) -> Vec<VoiceDoctorCheck> {
         let prefs = VoiceRuntimePreferences::from_options(&self.ui_preferences);
+        let provider = tts_provider_from_config(&prefs.provider);
+        let voice_count = provider.supported_voices().len();
         let mut checks = Vec::new();
 
         checks.push(VoiceDoctorCheck {
@@ -1380,7 +1557,12 @@ impl Runtime {
             }
             .to_owned(),
             message: if is_supported_voice_provider(&prefs.provider) {
-                format!("configured provider {}", prefs.provider)
+                format!(
+                    "configured provider {} ({}, {} curated voices)",
+                    provider.id(),
+                    provider.label(),
+                    voice_count
+                )
             } else {
                 format!(
                     "unsupported provider {}; expected edge, openai, system, or stub",
@@ -2504,6 +2686,10 @@ struct VoiceRuntimePreferences {
     provider: String,
     voice_id: String,
     stt_language: String,
+    rate: i16,
+    pitch: i16,
+    volume: i16,
+    auto_speak: bool,
     max_spoken_chars: usize,
 }
 
@@ -2533,6 +2719,28 @@ impl VoiceRuntimePreferences {
                 .map(normalize_voice_config_string)
                 .filter(|value| !value.is_empty())
                 .unwrap_or_else(|| "auto".to_owned()),
+            rate: voice
+                .and_then(|voice| voice.get("rate"))
+                .and_then(serde_json::Value::as_i64)
+                .and_then(|value| i16::try_from(value).ok())
+                .map(clamp_voice_adjustment)
+                .unwrap_or_default(),
+            pitch: voice
+                .and_then(|voice| voice.get("pitch"))
+                .and_then(serde_json::Value::as_i64)
+                .and_then(|value| i16::try_from(value).ok())
+                .map(clamp_voice_adjustment)
+                .unwrap_or_default(),
+            volume: voice
+                .and_then(|voice| voice.get("volume"))
+                .and_then(serde_json::Value::as_i64)
+                .and_then(|value| i16::try_from(value).ok())
+                .map(clamp_voice_adjustment)
+                .unwrap_or_default(),
+            auto_speak: voice
+                .and_then(|voice| voice.get("auto_speak"))
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false),
             max_spoken_chars: voice
                 .and_then(|voice| voice.get("max_spoken_chars"))
                 .and_then(serde_json::Value::as_u64)
@@ -2541,6 +2749,235 @@ impl VoiceRuntimePreferences {
                 .unwrap_or(800),
         }
     }
+
+    fn from_preview(options: &serde_json::Value, prefs: Option<VoicePreferences>) -> Self {
+        let mut runtime_prefs = Self::from_options(options);
+        if let Some(prefs) = prefs {
+            runtime_prefs.voice_id = normalize_voice_config_string(&prefs.voice_id);
+            runtime_prefs.rate = clamp_voice_adjustment(prefs.rate);
+            runtime_prefs.pitch = clamp_voice_adjustment(prefs.pitch);
+            runtime_prefs.volume = clamp_voice_adjustment(prefs.volume);
+        }
+        runtime_prefs
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TtsProviderKind {
+    Edge,
+    OpenAi,
+    System,
+    Stub,
+    Unsupported,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct StubbedTtsProvider {
+    kind: TtsProviderKind,
+    configured_id: String,
+}
+
+impl StubbedTtsProvider {
+    fn new(provider: &str) -> Self {
+        Self {
+            kind: tts_provider_kind(provider),
+            configured_id: normalize_voice_config_string(provider),
+        }
+    }
+}
+
+impl TtsProvider for StubbedTtsProvider {
+    fn id(&self) -> &'static str {
+        match self.kind {
+            TtsProviderKind::Edge => "edge",
+            TtsProviderKind::OpenAi => "openai",
+            TtsProviderKind::System => "system",
+            TtsProviderKind::Stub => "stub",
+            TtsProviderKind::Unsupported => "unsupported",
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self.kind {
+            TtsProviderKind::Edge => "Edge TTS daemon stub",
+            TtsProviderKind::OpenAi => "OpenAI TTS daemon stub",
+            TtsProviderKind::System => "System speech daemon stub",
+            TtsProviderKind::Stub => "Deterministic test TTS stub",
+            TtsProviderKind::Unsupported => "Unsupported TTS provider",
+        }
+    }
+
+    fn supported_voices(&self) -> Vec<TtsVoice> {
+        curated_tts_voices()
+    }
+
+    fn speak(&mut self, request: TtsRequest<'_>) -> Result<TtsOutput, TtsError> {
+        if self.kind == TtsProviderKind::Unsupported {
+            return Err(TtsError::new(
+                "unsupported_tts_provider",
+                format!("unsupported TTS provider '{}'", self.configured_id),
+                false,
+            ));
+        }
+        Ok(TtsOutput {
+            provider: self.id().to_owned(),
+            voice_id: request.voice_id.to_owned(),
+            spoken_chars: request.text.chars().count(),
+        })
+    }
+
+    fn stop(&mut self) -> Result<(), TtsError> {
+        if self.kind == TtsProviderKind::Unsupported {
+            return Err(TtsError::new(
+                "unsupported_tts_provider",
+                format!("unsupported TTS provider '{}'", self.configured_id),
+                false,
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn tts_provider_from_config(provider: &str) -> Box<dyn TtsProvider> {
+    Box::new(StubbedTtsProvider::new(provider))
+}
+
+fn tts_provider_kind(provider: &str) -> TtsProviderKind {
+    match provider {
+        "edge" => TtsProviderKind::Edge,
+        "openai" => TtsProviderKind::OpenAi,
+        "system" => TtsProviderKind::System,
+        "stub" => TtsProviderKind::Stub,
+        _ => TtsProviderKind::Unsupported,
+    }
+}
+
+fn curated_tts_voices() -> Vec<TtsVoice> {
+    vec![
+        TtsVoice {
+            id: "id-ID-ArdiNeural",
+            label: "Ardi (Indonesian, Male)",
+            locale: "id-ID",
+            gender: "Male",
+        },
+        TtsVoice {
+            id: "id-ID-GadisNeural",
+            label: "Gadis (Indonesian, Female)",
+            locale: "id-ID",
+            gender: "Female",
+        },
+        TtsVoice {
+            id: "ms-MY-OsmanNeural",
+            label: "Osman (Malay, Male)",
+            locale: "ms-MY",
+            gender: "Male",
+        },
+        TtsVoice {
+            id: "ms-MY-YasminNeural",
+            label: "Yasmin (Malay, Female)",
+            locale: "ms-MY",
+            gender: "Female",
+        },
+        TtsVoice {
+            id: "en-US-AvaNeural",
+            label: "Ava (US, Female)",
+            locale: "en-US",
+            gender: "Female",
+        },
+        TtsVoice {
+            id: "en-US-AndrewNeural",
+            label: "Andrew (US, Male)",
+            locale: "en-US",
+            gender: "Male",
+        },
+        TtsVoice {
+            id: "en-US-EmmaNeural",
+            label: "Emma (US, Female)",
+            locale: "en-US",
+            gender: "Female",
+        },
+        TtsVoice {
+            id: "en-US-BrianNeural",
+            label: "Brian (US, Male)",
+            locale: "en-US",
+            gender: "Male",
+        },
+        TtsVoice {
+            id: "en-GB-SoniaNeural",
+            label: "Sonia (GB, Female)",
+            locale: "en-GB",
+            gender: "Female",
+        },
+        TtsVoice {
+            id: "en-GB-RyanNeural",
+            label: "Ryan (GB, Male)",
+            locale: "en-GB",
+            gender: "Male",
+        },
+    ]
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SpeechMode {
+    AutoSpeak,
+    Preview,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum SpeechDecision {
+    Speak,
+    Blocked(&'static str),
+    RequiresSummary(&'static str),
+}
+
+fn speech_decision(
+    prefs: &VoiceRuntimePreferences,
+    content_kind: ContentKind,
+    text: &str,
+    mode: SpeechMode,
+) -> SpeechDecision {
+    let text = text.trim();
+    if text.is_empty() {
+        return SpeechDecision::Blocked("empty_text");
+    }
+
+    if mode == SpeechMode::AutoSpeak {
+        if !prefs.enabled {
+            return SpeechDecision::Blocked("voice_disabled");
+        }
+        if !prefs.auto_speak {
+            return SpeechDecision::Blocked("auto_speak_disabled");
+        }
+    }
+
+    match content_kind {
+        ContentKind::Code => return SpeechDecision::Blocked("code_not_speakable"),
+        ContentKind::Diff => return SpeechDecision::Blocked("diff_not_speakable"),
+        ContentKind::TerminalLog => return SpeechDecision::Blocked("terminal_log_not_speakable"),
+        ContentKind::TestResult if text.chars().count() > prefs.max_spoken_chars => {
+            return SpeechDecision::Blocked("long_tool_output_not_speakable");
+        }
+        ContentKind::TestResult if looks_like_raw_tool_output(text) => {
+            return SpeechDecision::Blocked("raw_tool_output_not_speakable");
+        }
+        _ => {}
+    }
+
+    if text.chars().count() > prefs.max_spoken_chars {
+        return SpeechDecision::RequiresSummary("content_exceeds_max_spoken_chars");
+    }
+
+    SpeechDecision::Speak
+}
+
+fn looks_like_raw_tool_output(text: &str) -> bool {
+    let line_count = text.lines().count();
+    line_count > 12
+        || text.contains("```")
+        || text.contains("diff --git")
+        || text.contains("thread '")
+        || text.contains("panicked at")
+        || text.contains("error[E")
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -3625,6 +4062,10 @@ fn json_usize(value: &serde_json::Value, key: &str) -> Option<usize> {
         .and_then(|value| usize::try_from(value).ok())
 }
 
+fn clamp_voice_adjustment(value: i16) -> i16 {
+    value.clamp(-50, 50)
+}
+
 fn merge_json(mut base: serde_json::Value, patch: serde_json::Value) -> serde_json::Value {
     match (&mut base, patch) {
         (serde_json::Value::Object(base), serde_json::Value::Object(patch)) => {
@@ -3675,6 +4116,40 @@ mod tests {
             cadis_home,
             AgentSpawnLimits::default(),
             OrchestratorConfig::default(),
+        )
+    }
+
+    fn runtime_with_voice(enabled: bool, auto_speak: bool, max_spoken_chars: usize) -> Runtime {
+        Runtime::new(
+            RuntimeOptions {
+                cadis_home: test_workspace("cadis-home"),
+                profile_id: "default".to_owned(),
+                socket_path: Some(PathBuf::from("/tmp/cadis-test.sock")),
+                model_provider: "echo".to_owned(),
+                ui_preferences: serde_json::json!({
+                    "voice": {
+                        "enabled": enabled,
+                        "provider": "stub",
+                        "voice_id": "id-ID-GadisNeural",
+                        "stt_language": "auto",
+                        "rate": 0,
+                        "pitch": 0,
+                        "volume": 0,
+                        "auto_speak": auto_speak,
+                        "max_spoken_chars": max_spoken_chars
+                    },
+                    "agent_spawn": {
+                        "max_depth": AgentSpawnLimits::default().max_depth,
+                        "max_children_per_parent": AgentSpawnLimits::default().max_children_per_parent,
+                        "max_total_agents": AgentSpawnLimits::default().max_total_agents
+                    },
+                    "orchestrator": {
+                        "worker_delegation_enabled": true,
+                        "default_worker_role": "Worker"
+                    }
+                }),
+            },
+            Box::<EchoProvider>::default(),
         )
     }
 
@@ -3795,6 +4270,23 @@ mod tests {
         ));
     }
 
+    fn send_message_with_kind(
+        runtime: &mut Runtime,
+        content_kind: ContentKind,
+        content: &str,
+    ) -> RequestOutcome {
+        runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_message"),
+            ClientId::from("cli_1"),
+            ClientRequest::MessageSend(MessageSendRequest {
+                session_id: None,
+                target_agent_id: None,
+                content: content.to_owned(),
+                content_kind,
+            }),
+        ))
+    }
+
     #[test]
     fn status_returns_typed_response() {
         let mut runtime = runtime();
@@ -3887,6 +4379,130 @@ mod tests {
         assert!(doctor.checks.iter().any(|check| {
             check.name == "microphone" && check.status == "ok" && check.message == "1 input visible"
         }));
+    }
+
+    #[test]
+    fn voice_provider_stubs_report_curated_catalog_without_external_calls() {
+        for provider_id in ["edge", "openai", "system", "stub"] {
+            let provider = tts_provider_from_config(provider_id);
+            assert_eq!(provider.id(), provider_id);
+            assert!(provider
+                .supported_voices()
+                .iter()
+                .any(|voice| voice.id == "id-ID-GadisNeural"));
+        }
+    }
+
+    #[test]
+    fn voice_preview_uses_daemon_provider_stub() {
+        let mut runtime = runtime_with_voice(false, false, 800);
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_voice_preview"),
+            ClientId::from("hud_1"),
+            ClientRequest::VoicePreview(VoicePreviewRequest {
+                text: "Halo, saya CADIS.".to_owned(),
+                prefs: Some(VoicePreferences {
+                    voice_id: "id-ID-GadisNeural".to_owned(),
+                    rate: 5,
+                    pitch: 0,
+                    volume: 0,
+                }),
+            }),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::VoicePreviewStarted(_))));
+        assert!(outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::VoicePreviewCompleted(_))));
+    }
+
+    #[test]
+    fn auto_speak_speaks_short_final_chat_response() {
+        let mut runtime = runtime_with_voice(true, true, 10_000);
+        let outcome = send_message_with_kind(&mut runtime, ContentKind::Chat, "hello");
+
+        assert!(outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::MessageCompleted(_))));
+        assert!(outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::VoiceStarted(_))));
+        assert!(outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::VoiceCompleted(_))));
+    }
+
+    #[test]
+    fn speech_policy_blocks_code_diff_and_terminal_log() {
+        for content_kind in [
+            ContentKind::Code,
+            ContentKind::Diff,
+            ContentKind::TerminalLog,
+        ] {
+            let mut runtime = runtime_with_voice(true, true, 10_000);
+            let outcome = send_message_with_kind(&mut runtime, content_kind, "unsafe to speak");
+
+            assert!(outcome
+                .events
+                .iter()
+                .any(|event| matches!(event.event, CadisEvent::MessageCompleted(_))));
+            assert!(!outcome
+                .events
+                .iter()
+                .any(|event| matches!(event.event, CadisEvent::VoiceStarted(_))));
+            assert!(!outcome
+                .events
+                .iter()
+                .any(|event| matches!(event.event, CadisEvent::VoiceCompleted(_))));
+        }
+    }
+
+    #[test]
+    fn speech_policy_blocks_long_tool_output() {
+        let prefs = VoiceRuntimePreferences {
+            enabled: true,
+            provider: "stub".to_owned(),
+            voice_id: "id-ID-GadisNeural".to_owned(),
+            stt_language: "auto".to_owned(),
+            rate: 0,
+            pitch: 0,
+            volume: 0,
+            auto_speak: true,
+            max_spoken_chars: 40,
+        };
+        let output = "running 42 tests\n".repeat(12);
+
+        assert_eq!(
+            speech_decision(
+                &prefs,
+                ContentKind::TestResult,
+                &output,
+                SpeechMode::AutoSpeak
+            ),
+            SpeechDecision::Blocked("long_tool_output_not_speakable")
+        );
+
+        let mut runtime = runtime_with_voice(true, true, 40);
+        let outcome = send_message_with_kind(&mut runtime, ContentKind::TestResult, &output);
+        assert!(!outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::VoiceStarted(_))));
+        assert!(!outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::VoiceCompleted(_))));
     }
 
     #[test]

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -21,10 +21,11 @@ use cadis_protocol::{
     ProtocolVersion, RequestAcceptedPayload, RequestEnvelope, RequestId, ResponseEnvelope,
     SessionEventPayload, SessionId, Timestamp, ToolCallId, ToolCallRequest, ToolEventPayload,
     ToolFailedPayload, UiPreferencesPayload, WorkerArtifactLocations, WorkerEventPayload,
-    WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent, WorkerWorktreeState, WorkspaceAccess,
-    WorkspaceDoctorCheck, WorkspaceDoctorPayload, WorkspaceDoctorRequest, WorkspaceGrantId,
-    WorkspaceGrantPayload, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceListPayload,
-    WorkspaceListRequest, WorkspaceRecordPayload, WorkspaceRegisterRequest, WorkspaceRevokeRequest,
+    WorkerLogDeltaPayload, WorkerTailRequest, WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent,
+    WorkerWorktreeState, WorkspaceAccess, WorkspaceDoctorCheck, WorkspaceDoctorPayload,
+    WorkspaceDoctorRequest, WorkspaceGrantId, WorkspaceGrantPayload, WorkspaceGrantRequest,
+    WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest, WorkspaceRecordPayload,
+    WorkspaceRegisterRequest, WorkspaceRevokeRequest,
 };
 use cadis_store::{
     redact, ApprovalRecord, ApprovalState, ApprovalStore, CadisConfig, CadisHome, CheckpointPolicy,
@@ -40,6 +41,8 @@ const FILE_READ_LIMIT_BYTES: usize = 64 * 1024;
 const FILE_SEARCH_LIMIT_BYTES: u64 = 1024 * 1024;
 const FILE_SEARCH_DEFAULT_LIMIT: usize = 50;
 const APPROVAL_TIMEOUT_MINUTES: i64 = 5;
+const WORKER_TAIL_DEFAULT_LINES: usize = 64;
+const WORKER_TAIL_MAX_LINES: usize = 1_000;
 
 /// Runtime options supplied by the daemon process.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -117,6 +120,7 @@ pub struct Runtime {
     next_worker: u64,
     sessions: HashMap<SessionId, SessionRecord>,
     agents: HashMap<AgentId, AgentRecord>,
+    workers: HashMap<String, WorkerRecord>,
     orchestrator: Orchestrator,
     ui_preferences: serde_json::Value,
     spawn_limits: AgentSpawnLimits,
@@ -171,6 +175,7 @@ impl Runtime {
             next_worker: 1,
             sessions,
             agents,
+            workers: HashMap::new(),
             orchestrator,
             ui_preferences,
             spawn_limits,
@@ -374,7 +379,8 @@ impl Runtime {
                     self.event(None, CadisEvent::VoicePreviewCompleted(Default::default()));
                 self.accept(request_id, vec![completed])
             }
-            ClientRequest::SessionUnsubscribe(_) | ClientRequest::WorkerTail(_) => self.reject(
+            ClientRequest::WorkerTail(request) => self.worker_tail(request_id, request),
+            ClientRequest::SessionUnsubscribe(_) => self.reject(
                 request_id,
                 "not_implemented",
                 "this request is defined in the protocol but is not implemented in the desktop MVP",
@@ -780,20 +786,7 @@ impl Runtime {
         });
 
         if let Some(worker) = &worker {
-            events.push(self.session_event(
-                session_id.clone(),
-                CadisEvent::WorkerStarted(WorkerEventPayload {
-                    worker_id: worker.worker_id.clone(),
-                    agent_id: Some(route.agent_id.clone()),
-                    parent_agent_id: worker.parent_agent_id.clone(),
-                    status: Some("running".to_owned()),
-                    cli: None,
-                    cwd: None,
-                    summary: Some(worker.summary.clone()),
-                    worktree: Some(worker.worktree.clone()),
-                    artifacts: Some(worker.artifacts.clone()),
-                }),
-            ));
+            events.extend(self.start_worker(session_id.clone(), route.agent_id.clone(), worker));
         }
 
         if route.agent_id.as_str() != "main" {
@@ -888,19 +881,10 @@ impl Runtime {
                     ));
                 }
                 if let Some(worker) = &worker {
-                    events.push(self.session_event(
-                        session_id.clone(),
-                        CadisEvent::WorkerCompleted(WorkerEventPayload {
-                            worker_id: worker.worker_id.clone(),
-                            agent_id: Some(route.agent_id.clone()),
-                            parent_agent_id: worker.parent_agent_id.clone(),
-                            status: Some("completed".to_owned()),
-                            cli: None,
-                            cwd: None,
-                            summary: Some(worker.summary.clone()),
-                            worktree: Some(worker.worktree.clone()),
-                            artifacts: Some(worker.artifacts.clone()),
-                        }),
+                    events.extend(self.complete_worker(
+                        &worker.worker_id,
+                        "completed",
+                        worker.summary.clone(),
                     ));
                 }
                 events.push(self.session_event(
@@ -922,19 +906,10 @@ impl Runtime {
                     }),
                 ));
                 if let Some(worker) = &worker {
-                    events.push(self.session_event(
-                        session_id.clone(),
-                        CadisEvent::WorkerCompleted(WorkerEventPayload {
-                            worker_id: worker.worker_id.clone(),
-                            agent_id: Some(route.agent_id.clone()),
-                            parent_agent_id: worker.parent_agent_id.clone(),
-                            status: Some("failed".to_owned()),
-                            cli: None,
-                            cwd: None,
-                            summary: Some(error_message.clone()),
-                            worktree: Some(worker.worktree.clone()),
-                            artifacts: Some(worker.artifacts.clone()),
-                        }),
+                    events.extend(self.complete_worker(
+                        &worker.worker_id,
+                        "failed",
+                        error_message.clone(),
                     ));
                 }
                 events.push(self.session_event(
@@ -947,6 +922,40 @@ impl Runtime {
                 ));
             }
         }
+
+        self.accept(request_id, events)
+    }
+
+    fn worker_tail(&mut self, request_id: RequestId, request: WorkerTailRequest) -> RequestOutcome {
+        let Some(worker) = self.workers.get(&request.worker_id).cloned() else {
+            return self.reject(
+                request_id,
+                "worker_not_found",
+                format!("worker '{}' was not found", request.worker_id),
+                false,
+            );
+        };
+
+        let line_limit = request
+            .lines
+            .and_then(|lines| usize::try_from(lines).ok())
+            .unwrap_or(WORKER_TAIL_DEFAULT_LINES)
+            .min(WORKER_TAIL_MAX_LINES);
+        let start = worker.log_lines.len().saturating_sub(line_limit);
+        let events = worker.log_lines[start..]
+            .iter()
+            .map(|line| {
+                self.session_event(
+                    worker.session_id.clone(),
+                    CadisEvent::WorkerLogDelta(WorkerLogDeltaPayload {
+                        worker_id: worker.worker_id.clone(),
+                        delta: line.clone(),
+                        agent_id: worker.agent_id.clone(),
+                        parent_agent_id: worker.parent_agent_id.clone(),
+                    }),
+                )
+            })
+            .collect();
 
         self.accept(request_id, events)
     }
@@ -1295,6 +1304,12 @@ impl Runtime {
         sessions
     }
 
+    fn worker_records_sorted(&self) -> Vec<WorkerRecord> {
+        let mut workers = self.workers.values().cloned().collect::<Vec<_>>();
+        workers.sort_by(|left, right| left.worker_id.cmp(&right.worker_id));
+        workers
+    }
+
     fn snapshot_events(&mut self) -> Vec<EventEnvelope> {
         let agents = self
             .agent_records_sorted()
@@ -1331,6 +1346,15 @@ impl Runtime {
             ));
         }
 
+        for worker in self.worker_records_sorted() {
+            let event = if worker.status == "running" {
+                CadisEvent::WorkerStarted(worker.event_payload())
+            } else {
+                CadisEvent::WorkerCompleted(worker.event_payload())
+            };
+            events.push(self.session_event(worker.session_id.clone(), event));
+        }
+
         events
     }
 
@@ -1349,6 +1373,84 @@ impl Runtime {
         let worker_id = format!("worker_{:06}", self.next_worker);
         self.next_worker += 1;
         worker_id
+    }
+
+    fn start_worker(
+        &mut self,
+        session_id: SessionId,
+        agent_id: AgentId,
+        worker: &WorkerDelegation,
+    ) -> Vec<EventEnvelope> {
+        let record = WorkerRecord::from_delegation(session_id, Some(agent_id), worker);
+        let worker_id = record.worker_id.clone();
+        let mut events = vec![self.session_event(
+            record.session_id.clone(),
+            CadisEvent::WorkerStarted(record.event_payload()),
+        )];
+        self.workers.insert(worker_id.clone(), record);
+        if let Some(event) =
+            self.append_worker_log(&worker_id, format!("started: {}\n", worker.summary))
+        {
+            events.push(event);
+        }
+        events
+    }
+
+    fn complete_worker(
+        &mut self,
+        worker_id: &str,
+        status: &str,
+        summary: String,
+    ) -> Vec<EventEnvelope> {
+        let mut events = Vec::new();
+        if let Some(event) = self.append_worker_log(worker_id, format!("{status}: {summary}\n")) {
+            events.push(event);
+        }
+        if let Some(event) = self.update_worker_status(worker_id, status, Some(summary)) {
+            events.push(event);
+        }
+        events
+    }
+
+    fn append_worker_log(
+        &mut self,
+        worker_id: &str,
+        delta: impl Into<String>,
+    ) -> Option<EventEnvelope> {
+        let delta = redact(&delta.into());
+        let (session_id, payload) = {
+            let worker = self.workers.get_mut(worker_id)?;
+            worker.log_lines.push(delta.clone());
+            (
+                worker.session_id.clone(),
+                WorkerLogDeltaPayload {
+                    worker_id: worker.worker_id.clone(),
+                    delta,
+                    agent_id: worker.agent_id.clone(),
+                    parent_agent_id: worker.parent_agent_id.clone(),
+                },
+            )
+        };
+
+        Some(self.session_event(session_id, CadisEvent::WorkerLogDelta(payload)))
+    }
+
+    fn update_worker_status(
+        &mut self,
+        worker_id: &str,
+        status: &str,
+        summary: Option<String>,
+    ) -> Option<EventEnvelope> {
+        let (session_id, payload) = {
+            let worker = self.workers.get_mut(worker_id)?;
+            worker.status = status.to_owned();
+            if let Some(summary) = summary {
+                worker.summary = Some(summary);
+            }
+            (worker.session_id.clone(), worker.event_payload())
+        };
+
+        Some(self.session_event(session_id, CadisEvent::WorkerCompleted(payload)))
     }
 
     fn next_tool_call_id(&mut self) -> ToolCallId {
@@ -2307,6 +2409,57 @@ struct WorkerDelegation {
     summary: String,
     worktree: WorkerWorktreeIntent,
     artifacts: WorkerArtifactLocations,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WorkerRecord {
+    worker_id: String,
+    session_id: SessionId,
+    agent_id: Option<AgentId>,
+    parent_agent_id: Option<AgentId>,
+    status: String,
+    cli: Option<String>,
+    cwd: Option<String>,
+    summary: Option<String>,
+    worktree: Option<WorkerWorktreeIntent>,
+    artifacts: Option<WorkerArtifactLocations>,
+    log_lines: Vec<String>,
+}
+
+impl WorkerRecord {
+    fn from_delegation(
+        session_id: SessionId,
+        agent_id: Option<AgentId>,
+        worker: &WorkerDelegation,
+    ) -> Self {
+        Self {
+            worker_id: worker.worker_id.clone(),
+            session_id,
+            agent_id,
+            parent_agent_id: worker.parent_agent_id.clone(),
+            status: "running".to_owned(),
+            cli: None,
+            cwd: None,
+            summary: Some(worker.summary.clone()),
+            worktree: Some(worker.worktree.clone()),
+            artifacts: Some(worker.artifacts.clone()),
+            log_lines: Vec::new(),
+        }
+    }
+
+    fn event_payload(&self) -> WorkerEventPayload {
+        WorkerEventPayload {
+            worker_id: self.worker_id.clone(),
+            agent_id: self.agent_id.clone(),
+            parent_agent_id: self.parent_agent_id.clone(),
+            status: Some(self.status.clone()),
+            cli: self.cli.clone(),
+            cwd: self.cwd.clone(),
+            summary: self.summary.clone(),
+            worktree: self.worktree.clone(),
+            artifacts: self.artifacts.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -3337,8 +3490,8 @@ mod tests {
         AgentModelSetRequest, AgentRenameRequest, AgentSpawnRequest, ApprovalResponseRequest,
         ClientId, ContentKind, EmptyPayload, EventSubscriptionRequest, EventsSnapshotRequest,
         MessageSendRequest, RequestId, ServerFrame, SessionCreateRequest, SessionTargetRequest,
-        ToolCallRequest, WorkspaceAccess, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind,
-        WorkspaceRegisterRequest,
+        ToolCallRequest, WorkerTailRequest, WorkspaceAccess, WorkspaceGrantRequest, WorkspaceId,
+        WorkspaceKind, WorkspaceRegisterRequest,
     };
 
     fn runtime() -> Runtime {
@@ -4518,6 +4671,96 @@ mod tests {
                 .map(|artifacts| artifacts.patch.as_str()),
             Some(expected_patch.as_str())
         );
+    }
+
+    #[test]
+    fn worker_tail_replays_registered_worker_log_lines() {
+        let mut runtime = runtime();
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_worker_route"),
+            ClientId::from("hud_1"),
+            ClientRequest::MessageSend(MessageSendRequest {
+                session_id: None,
+                target_agent_id: None,
+                content: "/route @codex run focused tests".to_owned(),
+                content_kind: ContentKind::Chat,
+            }),
+        ));
+
+        let worker_id = outcome
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::WorkerStarted(payload) => Some(payload.worker_id.clone()),
+                _ => None,
+            })
+            .expect("worker.started should be emitted");
+        let live_log_count = outcome
+            .events
+            .iter()
+            .filter(|event| matches!(event.event, CadisEvent::WorkerLogDelta(_)))
+            .count();
+        assert_eq!(live_log_count, 2);
+
+        let tail = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_worker_tail"),
+            ClientId::from("cli_1"),
+            ClientRequest::WorkerTail(WorkerTailRequest {
+                worker_id: worker_id.clone(),
+                lines: Some(1),
+            }),
+        ));
+        assert!(matches!(
+            tail.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        let deltas = tail
+            .events
+            .iter()
+            .filter_map(|event| match &event.event {
+                CadisEvent::WorkerLogDelta(payload) => Some(payload),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].worker_id, worker_id);
+        assert_eq!(
+            deltas[0].agent_id.as_ref().map(AgentId::as_str),
+            Some("codex")
+        );
+        assert_eq!(
+            deltas[0].delta,
+            "completed: Route @codex: run focused tests\n"
+        );
+
+        let snapshot = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_snapshot_workers"),
+            ClientId::from("hud_1"),
+            ClientRequest::EventsSnapshot(EventsSnapshotRequest::default()),
+        ));
+        assert!(snapshot.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::WorkerCompleted(payload)
+                    if payload.worker_id == worker_id
+                        && payload.status.as_deref() == Some("completed")
+            )
+        }));
+    }
+
+    #[test]
+    fn worker_tail_rejects_unknown_worker() {
+        let mut runtime = runtime();
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_missing_worker_tail"),
+            ClientId::from("cli_1"),
+            ClientRequest::WorkerTail(WorkerTailRequest {
+                worker_id: "worker_missing".to_owned(),
+                lines: Some(10),
+            }),
+        ));
+
+        assert_rejected(outcome, "worker_not_found");
     }
 
     #[test]

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -30,7 +30,7 @@ use cadis_protocol::{
 };
 use cadis_store::{
     redact, ApprovalRecord, ApprovalState, ApprovalStore, CadisConfig, CadisHome, CheckpointPolicy,
-    GrantSource as StoreGrantSource, ProfileHome, StateStore,
+    GrantSource as StoreGrantSource, ProfileHome, StateRecoveryDiagnostic, StateStore,
     WorkspaceAccess as StoreWorkspaceAccess, WorkspaceAlias,
     WorkspaceGrantRecord as StoreWorkspaceGrantRecord, WorkspaceKind as StoreWorkspaceKind,
     WorkspaceMetadata, WorkspaceRegistry, WorkspaceVcs,
@@ -149,6 +149,7 @@ pub struct Runtime {
     policy: PolicyEngine,
     approval_store: ApprovalStore,
     state_store: StateStore,
+    recovery_diagnostics: Vec<RuntimeRecoveryDiagnostic>,
     profile_home: ProfileHome,
     pending_approvals: HashMap<ApprovalId, PendingApproval>,
     workspaces: HashMap<WorkspaceId, WorkspaceRecord>,
@@ -179,12 +180,17 @@ impl Runtime {
         let workspace_grants = load_workspace_grants(&profile_home, &workspaces);
         let next_workspace_grant = next_workspace_grant_counter(&workspace_grants);
         let sessions = recover_session_records(&state_store);
+        let agent_session_recovery = recover_agent_session_records(&state_store);
+        let agent_sessions = agent_session_recovery.records;
+        let recovery_diagnostics = agent_session_recovery.diagnostics;
         let mut agents = default_agents(&options.model_provider);
         for (agent_id, record) in recover_agent_records(&state_store) {
             agents.insert(agent_id, record);
         }
         let next_session = next_session_counter(&sessions);
         let next_agent = next_agent_counter(&agents);
+        let next_agent_session = next_agent_session_counter(&agent_sessions);
+        let next_route = next_route_counter(&agent_sessions);
 
         Self {
             options,
@@ -194,12 +200,12 @@ impl Runtime {
             next_event: 1,
             next_session,
             next_agent,
-            next_agent_session: 1,
-            next_route: 1,
+            next_agent_session,
+            next_route,
             next_worker: 1,
             sessions,
             agents,
-            agent_sessions: HashMap::new(),
+            agent_sessions,
             workers: HashMap::new(),
             orchestrator,
             ui_preferences,
@@ -208,6 +214,7 @@ impl Runtime {
             policy: PolicyEngine,
             approval_store,
             state_store,
+            recovery_diagnostics,
             profile_home,
             pending_approvals: HashMap::new(),
             workspaces,
@@ -1450,6 +1457,17 @@ impl Runtime {
             ),
         ];
 
+        for diagnostic in self.recovery_diagnostics.clone() {
+            events.push(self.event(
+                None,
+                CadisEvent::DaemonError(ErrorPayload {
+                    code: diagnostic.code,
+                    message: diagnostic.message,
+                    retryable: false,
+                }),
+            ));
+        }
+
         for (session_id, session) in self.session_records_sorted() {
             events.push(self.session_event(
                 session_id.clone(),
@@ -1548,6 +1566,7 @@ impl Runtime {
             CadisEvent::AgentSessionStarted(record.event_payload()),
         );
         self.agent_sessions.insert(id.clone(), record);
+        let _ = self.persist_agent_session_record(&id);
         (id, event)
     }
 
@@ -1576,6 +1595,7 @@ impl Runtime {
                 )
             }
         };
+        let _ = self.persist_agent_session_record(agent_session_id);
         Some(self.session_event(session_id, payload))
     }
 
@@ -1590,6 +1610,7 @@ impl Runtime {
             record.result = Some(redact(&result.into()));
             (record.session_id.clone(), record.event_payload())
         };
+        let _ = self.persist_agent_session_record(agent_session_id);
         Some(self.session_event(session_id, CadisEvent::AgentSessionCompleted(payload)))
     }
 
@@ -1607,6 +1628,7 @@ impl Runtime {
             record.error = Some(redact(&error.into()));
             (record.session_id.clone(), record.event_payload())
         };
+        let _ = self.persist_agent_session_record(agent_session_id);
         Some(self.session_event(session_id, CadisEvent::AgentSessionFailed(payload)))
     }
 
@@ -1646,6 +1668,7 @@ impl Runtime {
             }) else {
                 continue;
             };
+            let _ = self.persist_agent_session_record(&agent_session_id);
             events.push(self.session_event(
                 event_session_id.clone(),
                 CadisEvent::AgentSessionCancelled(payload),
@@ -2204,6 +2227,19 @@ impl Runtime {
         Ok(())
     }
 
+    fn persist_agent_session_record(
+        &self,
+        agent_session_id: &AgentSessionId,
+    ) -> Result<(), cadis_store::StoreError> {
+        if let Some(record) = self.agent_sessions.get(agent_session_id) {
+            self.state_store.write_agent_session_metadata(
+                agent_session_id,
+                &AgentSessionMetadata::from_record(record),
+            )?;
+        }
+        Ok(())
+    }
+
     fn accept(&self, request_id: RequestId, events: Vec<EventEnvelope>) -> RequestOutcome {
         RequestOutcome {
             response: ResponseEnvelope::new(
@@ -2563,6 +2599,18 @@ impl AgentRecord {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+struct RuntimeRecoveryDiagnostic {
+    code: String,
+    message: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AgentSessionRecovery {
+    records: HashMap<AgentSessionId, AgentSessionRecord>,
+    diagnostics: Vec<RuntimeRecoveryDiagnostic>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct AgentSessionRecord {
     id: AgentSessionId,
     session_id: SessionId,
@@ -2578,6 +2626,68 @@ struct AgentSessionRecord {
     error_code: Option<String>,
     error: Option<String>,
     cancellation_requested_at: Option<Timestamp>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+struct AgentSessionMetadata {
+    agent_session_id: AgentSessionId,
+    session_id: SessionId,
+    route_id: String,
+    agent_id: AgentId,
+    parent_agent_id: Option<AgentId>,
+    task: String,
+    status: AgentSessionStatus,
+    timeout_at: Timestamp,
+    budget_steps: u32,
+    steps_used: u32,
+    result: Option<String>,
+    error_code: Option<String>,
+    error: Option<String>,
+    cancellation_requested_at: Option<Timestamp>,
+}
+
+impl AgentSessionMetadata {
+    fn from_record(record: &AgentSessionRecord) -> Self {
+        Self {
+            agent_session_id: record.id.clone(),
+            session_id: record.session_id.clone(),
+            route_id: record.route_id.clone(),
+            agent_id: record.agent_id.clone(),
+            parent_agent_id: record.parent_agent_id.clone(),
+            task: record.task.clone(),
+            status: record.status,
+            timeout_at: record.timeout_at.clone(),
+            budget_steps: record.budget_steps,
+            steps_used: record.steps_used,
+            result: record.result.clone(),
+            error_code: record.error_code.clone(),
+            error: record.error.clone(),
+            cancellation_requested_at: record.cancellation_requested_at.clone(),
+        }
+    }
+
+    fn into_record(self) -> (AgentSessionId, AgentSessionRecord) {
+        let id = self.agent_session_id;
+        (
+            id.clone(),
+            AgentSessionRecord {
+                id,
+                session_id: self.session_id,
+                route_id: self.route_id,
+                agent_id: self.agent_id,
+                parent_agent_id: self.parent_agent_id,
+                task: self.task,
+                status: self.status,
+                timeout_at: self.timeout_at,
+                budget_steps: self.budget_steps,
+                steps_used: self.steps_used,
+                result: self.result,
+                error_code: self.error_code,
+                error: self.error,
+                cancellation_requested_at: self.cancellation_requested_at,
+            },
+        )
+    }
 }
 
 impl AgentSessionRecord {
@@ -3010,10 +3120,73 @@ fn recover_agent_records(state_store: &StateStore) -> HashMap<AgentId, AgentReco
         .collect()
 }
 
+fn recover_agent_session_records(state_store: &StateStore) -> AgentSessionRecovery {
+    match state_store.recover_agent_session_metadata::<AgentSessionMetadata>() {
+        Ok(recovery) => AgentSessionRecovery {
+            records: recovery
+                .records
+                .into_iter()
+                .map(|record| record.metadata.into_record())
+                .collect(),
+            diagnostics: recovery
+                .diagnostics
+                .into_iter()
+                .map(agent_session_recovery_diagnostic)
+                .collect(),
+        },
+        Err(error) => AgentSessionRecovery {
+            records: HashMap::new(),
+            diagnostics: vec![RuntimeRecoveryDiagnostic {
+                code: "agent_session_recovery_failed".to_owned(),
+                message: redact(&format!(
+                    "could not scan durable AgentSession metadata: {error}"
+                )),
+            }],
+        },
+    }
+}
+
+fn agent_session_recovery_diagnostic(
+    diagnostic: StateRecoveryDiagnostic,
+) -> RuntimeRecoveryDiagnostic {
+    let file_name = diagnostic
+        .path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("unknown");
+    RuntimeRecoveryDiagnostic {
+        code: "agent_session_recovery_skipped".to_owned(),
+        message: redact(&format!(
+            "skipped durable AgentSession metadata state/agent-sessions/{file_name}: {}",
+            diagnostic.reason
+        )),
+    }
+}
+
 fn next_session_counter(sessions: &HashMap<SessionId, SessionRecord>) -> u64 {
     sessions
         .keys()
         .filter_map(|session_id| session_id.as_str().strip_prefix("ses_"))
+        .filter_map(|suffix| suffix.parse::<u64>().ok())
+        .max()
+        .unwrap_or(0)
+        + 1
+}
+
+fn next_agent_session_counter(agent_sessions: &HashMap<AgentSessionId, AgentSessionRecord>) -> u64 {
+    agent_sessions
+        .keys()
+        .filter_map(|agent_session_id| agent_session_id.as_str().strip_prefix("ags_"))
+        .filter_map(|suffix| suffix.parse::<u64>().ok())
+        .max()
+        .unwrap_or(0)
+        + 1
+}
+
+fn next_route_counter(agent_sessions: &HashMap<AgentSessionId, AgentSessionRecord>) -> u64 {
+    agent_sessions
+        .values()
+        .filter_map(|record| record.route_id.strip_prefix("route_"))
         .filter_map(|suffix| suffix.parse::<u64>().ok())
         .max()
         .unwrap_or(0)
@@ -4632,6 +4805,141 @@ mod tests {
                 CadisEvent::AgentSessionCompleted(payload)
                     if payload.agent_session_id == started.agent_session_id
                         && payload.result.as_deref().is_some_and(|result| result.contains("run tests"))
+            )
+        }));
+    }
+
+    #[test]
+    fn agent_session_metadata_survives_runtime_restart_and_snapshot() {
+        let cadis_home = test_workspace("persistent-agent-session-home");
+        let completed = {
+            let mut runtime = runtime_with_home(cadis_home.clone());
+            let outcome = runtime.handle_request(RequestEnvelope::new(
+                RequestId::from("req_agent_session_persist"),
+                ClientId::from("cli_1"),
+                ClientRequest::MessageSend(MessageSendRequest {
+                    session_id: None,
+                    target_agent_id: Some(AgentId::from("codex")),
+                    content: "run recovery tests".to_owned(),
+                    content_kind: ContentKind::Chat,
+                }),
+            ));
+
+            outcome
+                .events
+                .iter()
+                .find_map(|event| match &event.event {
+                    CadisEvent::AgentSessionCompleted(payload) => Some(payload.clone()),
+                    _ => None,
+                })
+                .expect("agent.session.completed should be emitted")
+        };
+
+        let store = StateStore::new(&CadisConfig {
+            cadis_home: cadis_home.clone(),
+            ..CadisConfig::default()
+        });
+        assert!(store
+            .agent_session_path(&completed.agent_session_id)
+            .is_file());
+
+        let mut runtime = runtime_with_home(cadis_home);
+        let snapshot = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_agent_session_snapshot"),
+            ClientId::from("hud_1"),
+            ClientRequest::EventsSnapshot(EventsSnapshotRequest::default()),
+        ));
+
+        assert!(snapshot.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentSessionCompleted(payload)
+                    if payload.agent_session_id == completed.agent_session_id
+                        && payload.route_id == completed.route_id
+                        && payload.status == AgentSessionStatus::Completed
+                        && payload.steps_used == 1
+                        && payload.result.as_deref().is_some_and(|result| result.contains("run recovery tests"))
+            )
+        }));
+
+        let next = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_agent_session_next"),
+            ClientId::from("cli_1"),
+            ClientRequest::MessageSend(MessageSendRequest {
+                session_id: None,
+                target_agent_id: Some(AgentId::from("codex")),
+                content: "next route".to_owned(),
+                content_kind: ContentKind::Chat,
+            }),
+        ));
+
+        assert!(next.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentSessionStarted(payload)
+                    if payload.agent_session_id.as_str() == "ags_000002"
+                        && payload.route_id == "route_000002"
+            )
+        }));
+    }
+
+    #[test]
+    fn corrupt_agent_session_metadata_reports_diagnostic_and_ignores_partial_temp_file() {
+        let cadis_home = test_workspace("corrupt-agent-session-home");
+        let store = StateStore::new(&CadisConfig {
+            cadis_home: cadis_home.clone(),
+            ..CadisConfig::default()
+        });
+        store.ensure_layout().expect("state layout should exist");
+        let valid = AgentSessionMetadata {
+            agent_session_id: AgentSessionId::from("ags_000041"),
+            session_id: SessionId::from("ses_recovered"),
+            route_id: "route_000041".to_owned(),
+            agent_id: AgentId::from("codex"),
+            parent_agent_id: Some(AgentId::from("main")),
+            task: "recover me".to_owned(),
+            status: AgentSessionStatus::Running,
+            timeout_at: Timestamp::new_utc("2026-04-26T00:15:00Z")
+                .expect("test timestamp should be valid"),
+            budget_steps: 2,
+            steps_used: 1,
+            result: None,
+            error_code: None,
+            error: None,
+            cancellation_requested_at: None,
+        };
+
+        store
+            .write_agent_session_metadata(&valid.agent_session_id, &valid)
+            .expect("valid AgentSession metadata should write");
+        let agent_sessions_dir = cadis_home.join("state/agent-sessions");
+        fs::write(agent_sessions_dir.join("corrupt.json"), "{")
+            .expect("corrupt AgentSession metadata should write");
+        fs::write(agent_sessions_dir.join(".ags_partial.json.tmp.1"), "{")
+            .expect("partial AgentSession temp metadata should write");
+
+        let mut runtime = runtime_with_home(cadis_home);
+        let snapshot = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_corrupt_agent_session_snapshot"),
+            ClientId::from("hud_1"),
+            ClientRequest::EventsSnapshot(EventsSnapshotRequest::default()),
+        ));
+
+        assert!(snapshot.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentSessionUpdated(payload)
+                    if payload.agent_session_id.as_str() == "ags_000041"
+                        && payload.task == "recover me"
+            )
+        }));
+        assert!(snapshot.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::DaemonError(error)
+                    if error.code == "agent_session_recovery_skipped"
+                        && error.message.contains("corrupt.json")
+                        && !error.message.contains(".ags_partial")
             )
         }));
     }

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -247,15 +247,19 @@ impl Runtime {
             }
             ClientRequest::SessionSubscribe(request) => {
                 if let Some(session) = self.sessions.get(&request.session_id) {
-                    let title = session.title.clone();
-                    let event = self.session_event(
-                        request.session_id.clone(),
-                        CadisEvent::SessionUpdated(SessionEventPayload {
-                            session_id: request.session_id,
-                            title,
-                        }),
-                    );
-                    self.accept(request_id, vec![event])
+                    let events = if request.include_snapshot {
+                        let title = session.title.clone();
+                        vec![self.session_event(
+                            request.session_id.clone(),
+                            CadisEvent::SessionUpdated(SessionEventPayload {
+                                session_id: request.session_id,
+                                title,
+                            }),
+                        )]
+                    } else {
+                        Vec::new()
+                    };
+                    self.accept(request_id, events)
                 } else {
                     self.reject(
                         request_id,
@@ -3336,9 +3340,9 @@ mod tests {
     use cadis_protocol::{
         AgentModelSetRequest, AgentRenameRequest, AgentSpawnRequest, ApprovalResponseRequest,
         ClientId, ContentKind, EmptyPayload, EventSubscriptionRequest, EventsSnapshotRequest,
-        MessageSendRequest, RequestId, ServerFrame, SessionCreateRequest, SessionTargetRequest,
-        ToolCallRequest, WorkspaceAccess, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind,
-        WorkspaceRegisterRequest,
+        MessageSendRequest, RequestId, ServerFrame, SessionCreateRequest,
+        SessionSubscriptionRequest, SessionTargetRequest, ToolCallRequest, WorkspaceAccess,
+        WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceRegisterRequest,
     };
 
     fn runtime() -> Runtime {
@@ -3740,8 +3744,11 @@ mod tests {
         let outcome = runtime.handle_request(RequestEnvelope::new(
             RequestId::from("req_subscribe_session"),
             ClientId::from("cli_1"),
-            ClientRequest::SessionSubscribe(SessionTargetRequest {
+            ClientRequest::SessionSubscribe(SessionSubscriptionRequest {
                 session_id: session_id.clone(),
+                since_event_id: None,
+                replay_limit: None,
+                include_snapshot: true,
             }),
         ));
 
@@ -3770,7 +3777,12 @@ mod tests {
         let outcome = runtime.handle_request(RequestEnvelope::new(
             RequestId::from("req_subscribe_removed_session"),
             ClientId::from("cli_1"),
-            ClientRequest::SessionSubscribe(SessionTargetRequest { session_id }),
+            ClientRequest::SessionSubscribe(SessionSubscriptionRequest {
+                session_id,
+                since_event_id: None,
+                replay_limit: None,
+                include_snapshot: true,
+            }),
         ));
 
         assert!(matches!(
@@ -4098,6 +4110,44 @@ mod tests {
             ClientRequest::EventsSubscribe(EventSubscriptionRequest {
                 include_snapshot: false,
                 ..EventSubscriptionRequest::default()
+            }),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(outcome.events.is_empty());
+    }
+
+    #[test]
+    fn session_subscribe_can_skip_initial_snapshot() {
+        let mut runtime = runtime();
+        let create = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_create"),
+            ClientId::from("cli_1"),
+            ClientRequest::SessionCreate(SessionCreateRequest {
+                title: Some("Quiet session stream".to_owned()),
+                cwd: None,
+            }),
+        ));
+        let session_id = create
+            .events
+            .into_iter()
+            .find_map(|event| match event.event {
+                CadisEvent::SessionStarted(payload) => Some(payload.session_id),
+                _ => None,
+            })
+            .expect("session.started should be emitted");
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_subscribe"),
+            ClientId::from("cli_1"),
+            ClientRequest::SessionSubscribe(SessionSubscriptionRequest {
+                session_id,
+                since_event_id: None,
+                replay_limit: None,
+                include_snapshot: false,
             }),
         ));
 

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -4202,6 +4202,40 @@ mod tests {
     }
 
     #[test]
+    fn message_send_surfaces_structured_provider_error() {
+        let provider = provider_from_config(
+            "openai",
+            "http://127.0.0.1:11434",
+            "llama3.2",
+            "https://api.openai.com/v1",
+            "gpt-5.2",
+            None,
+        );
+        let mut runtime = runtime_with_provider(provider, "openai");
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_chat"),
+            ClientId::from("hud_1"),
+            ClientRequest::MessageSend(MessageSendRequest {
+                session_id: None,
+                target_agent_id: Some(AgentId::from("main")),
+                content: "hello".to_owned(),
+                content_kind: ContentKind::Chat,
+            }),
+        ));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::SessionFailed(error)
+                    if error.code == "model_auth_missing"
+                        && !error.retryable
+                        && error.message.contains("OpenAI provider requires")
+            )
+        }));
+    }
+
+    #[test]
     fn agent_list_returns_roster_snapshot() {
         let mut runtime = runtime();
         let outcome = runtime.handle_request(RequestEnvelope::new(

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -7,8 +7,8 @@ use std::process::Command;
 use std::time::Instant;
 
 use cadis_models::{
-    provider_catalog, ModelInvocation, ModelProvider, ModelRequest, ModelStreamEvent,
-    ProviderCatalogEntry, ProviderReadiness,
+    provider_catalog_for_config, ModelCatalogConfig, ModelInvocation, ModelProvider, ModelRequest,
+    ModelStreamEvent, ProviderCatalogEntry, ProviderReadiness,
 };
 use cadis_policy::{PolicyDecision, PolicyEngine};
 use cadis_protocol::{
@@ -52,6 +52,12 @@ pub struct RuntimeOptions {
     pub socket_path: Option<PathBuf>,
     /// Configured model provider label.
     pub model_provider: String,
+    /// Configured Ollama model used for catalog visibility.
+    pub ollama_model: String,
+    /// Configured OpenAI model used for catalog visibility.
+    pub openai_model: String,
+    /// Whether an OpenAI API key is present in the daemon environment.
+    pub openai_api_key_configured: bool,
     /// Initial daemon-owned UI preferences.
     pub ui_preferences: serde_json::Value,
 }
@@ -329,7 +335,7 @@ impl Runtime {
             ClientRequest::WorkspaceRevoke(request) => self.workspace_revoke(request_id, request),
             ClientRequest::WorkspaceDoctor(request) => self.workspace_doctor(request_id, request),
             ClientRequest::ModelsList(_) => {
-                let models = provider_catalog()
+                let models = provider_catalog_for_config(&self.model_catalog_config())
                     .into_iter()
                     .map(model_descriptor_from_catalog_entry)
                     .collect();
@@ -381,6 +387,15 @@ impl Runtime {
                 false,
             ),
         }
+    }
+
+    fn model_catalog_config(&self) -> ModelCatalogConfig {
+        ModelCatalogConfig::new(
+            self.options.model_provider.clone(),
+            self.options.ollama_model.clone(),
+            self.options.openai_model.clone(),
+            self.options.openai_api_key_configured,
+        )
     }
 
     fn status(&self, request_id: RequestId) -> RequestOutcome {
@@ -3379,6 +3394,9 @@ mod tests {
                 profile_id: "default".to_owned(),
                 socket_path: Some(PathBuf::from("/tmp/cadis-test.sock")),
                 model_provider: "echo".to_owned(),
+                ollama_model: "llama3.2".to_owned(),
+                openai_model: "gpt-5.2".to_owned(),
+                openai_api_key_configured: false,
                 ui_preferences: serde_json::json!({
                     "hud": {
                         "theme": "arc",
@@ -3411,6 +3429,9 @@ mod tests {
                 profile_id: "default".to_owned(),
                 socket_path: Some(PathBuf::from("/tmp/cadis-test.sock")),
                 model_provider: model_provider.to_owned(),
+                ollama_model: "llama3.2".to_owned(),
+                openai_model: "gpt-5.2".to_owned(),
+                openai_api_key_configured: false,
                 ui_preferences: serde_json::json!({
                     "agent_spawn": {
                         "max_depth": AgentSpawnLimits::default().max_depth,
@@ -4291,6 +4312,62 @@ mod tests {
         );
         assert_eq!(ollama.effective_provider.as_deref(), Some("ollama"));
         assert!(!ollama.fallback);
+    }
+
+    #[test]
+    fn models_list_uses_runtime_model_config() {
+        let mut runtime = Runtime::new(
+            RuntimeOptions {
+                cadis_home: test_workspace("cadis-home-model-config"),
+                profile_id: "default".to_owned(),
+                socket_path: Some(PathBuf::from("/tmp/cadis-test.sock")),
+                model_provider: "openai".to_owned(),
+                ollama_model: "qwen2.5-coder".to_owned(),
+                openai_model: "gpt-5.4".to_owned(),
+                openai_api_key_configured: true,
+                ui_preferences: serde_json::json!({
+                    "agent_spawn": {
+                        "max_depth": AgentSpawnLimits::default().max_depth,
+                        "max_children_per_parent": AgentSpawnLimits::default().max_children_per_parent,
+                        "max_total_agents": AgentSpawnLimits::default().max_total_agents
+                    },
+                    "orchestrator": {
+                        "worker_delegation_enabled": true,
+                        "default_worker_role": "Worker"
+                    }
+                }),
+            },
+            Box::<EchoProvider>::default(),
+        );
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_1"),
+            ClientId::from("hud_1"),
+            ClientRequest::ModelsList(EmptyPayload::default()),
+        ));
+        let models = outcome
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::ModelsListResponse(payload) => Some(&payload.models),
+                _ => None,
+            })
+            .expect("models.list.response should be emitted");
+
+        let ollama = models
+            .iter()
+            .find(|model| model.provider == "ollama")
+            .expect("ollama should be listed");
+        assert_eq!(ollama.model, "qwen2.5-coder");
+        assert_eq!(ollama.effective_model.as_deref(), Some("qwen2.5-coder"));
+
+        let openai = models
+            .iter()
+            .find(|model| model.provider == "openai")
+            .expect("openai should be listed");
+        assert_eq!(openai.model, "gpt-5.4");
+        assert_eq!(openai.effective_model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(openai.readiness, Some(ModelReadiness::Ready));
     }
 
     #[test]

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -13,7 +13,8 @@ use cadis_core::{Runtime, RuntimeOptions};
 use cadis_models::provider_from_config;
 use cadis_protocol::{
     ClientRequest, DaemonResponse, ErrorPayload, EventEnvelope, EventId, EventSubscriptionRequest,
-    RequestEnvelope, RequestId, ResponseEnvelope, ServerFrame,
+    RequestEnvelope, RequestId, ResponseEnvelope, ServerFrame, SessionId,
+    SessionSubscriptionRequest,
 };
 use cadis_store::{
     ensure_layout, load_config, openai_api_key_from_env, redact, CadisConfig, EventLog,
@@ -147,7 +148,12 @@ where
         match serde_json::from_str::<RequestEnvelope>(&line) {
             Ok(envelope) => {
                 let subscription = match &envelope.request {
-                    ClientRequest::EventsSubscribe(request) => Some(request.clone()),
+                    ClientRequest::EventsSubscribe(request) => {
+                        Some(EventBusSubscription::all(request))
+                    }
+                    ClientRequest::SessionSubscribe(request) => {
+                        Some(EventBusSubscription::session(request))
+                    }
                     _ => None,
                 };
                 let snapshot_only = matches!(envelope.request, ClientRequest::EventsSnapshot(_));
@@ -155,15 +161,21 @@ where
                     .lock()
                     .map_err(|_| io::Error::other("runtime mutex was poisoned"))?
                     .handle_request(envelope);
+                let accepted_subscription = matches!(
+                    &outcome.response.response,
+                    DaemonResponse::RequestAccepted(_)
+                )
+                .then_some(subscription)
+                .flatten();
 
                 write_frame(&mut writer, &ServerFrame::Response(outcome.response))?;
 
-                if let Some(subscription) = subscription {
+                if let Some(subscription) = accepted_subscription {
                     for event in outcome.events {
                         write_frame(&mut writer, &ServerFrame::Event(event))?;
                     }
 
-                    let (replay, receiver) = event_bus.subscribe(&subscription);
+                    let (replay, receiver) = event_bus.subscribe(subscription);
                     for event in replay {
                         write_frame(&mut writer, &ServerFrame::Event(event))?;
                     }
@@ -213,7 +225,56 @@ struct EventBus {
 
 struct EventBusInner {
     replay: VecDeque<EventEnvelope>,
-    subscribers: Vec<mpsc::Sender<EventEnvelope>>,
+    subscribers: Vec<EventSubscriber>,
+}
+
+struct EventSubscriber {
+    subscription: EventBusSubscription,
+    sender: mpsc::Sender<EventEnvelope>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct EventBusSubscription {
+    since_event_id: Option<EventId>,
+    replay_limit: Option<u32>,
+    filter: EventFilter,
+}
+
+impl EventBusSubscription {
+    fn all(request: &EventSubscriptionRequest) -> Self {
+        Self {
+            since_event_id: request.since_event_id.clone(),
+            replay_limit: request.replay_limit,
+            filter: EventFilter::All,
+        }
+    }
+
+    fn session(request: &SessionSubscriptionRequest) -> Self {
+        Self {
+            since_event_id: request.since_event_id.clone(),
+            replay_limit: request.replay_limit,
+            filter: EventFilter::Session(request.session_id.clone()),
+        }
+    }
+
+    fn matches(&self, event: &EventEnvelope) -> bool {
+        self.filter.matches(event)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum EventFilter {
+    All,
+    Session(SessionId),
+}
+
+impl EventFilter {
+    fn matches(&self, event: &EventEnvelope) -> bool {
+        match self {
+            Self::All => true,
+            Self::Session(session_id) => event.session_id.as_ref() == Some(session_id),
+        }
+    }
 }
 
 impl EventBus {
@@ -240,14 +301,15 @@ impl EventBus {
             inner.replay.push_back(event.clone());
         }
 
-        inner
-            .subscribers
-            .retain(|subscriber| subscriber.send(event.clone()).is_ok());
+        inner.subscribers.retain(|subscriber| {
+            !subscriber.subscription.matches(&event)
+                || subscriber.sender.send(event.clone()).is_ok()
+        });
     }
 
     fn subscribe(
         &self,
-        request: &EventSubscriptionRequest,
+        subscription: EventBusSubscription,
     ) -> (Vec<EventEnvelope>, mpsc::Receiver<EventEnvelope>) {
         let (sender, receiver) = mpsc::channel();
         let Ok(mut inner) = self.inner.lock() else {
@@ -257,11 +319,15 @@ impl EventBus {
 
         let replay = bounded_replay(
             &inner.replay,
-            request.since_event_id.as_ref(),
-            request.replay_limit,
+            subscription.since_event_id.as_ref(),
+            subscription.replay_limit,
             self.max_replay,
+            &subscription.filter,
         );
-        inner.subscribers.push(sender);
+        inner.subscribers.push(EventSubscriber {
+            subscription,
+            sender,
+        });
         (replay, receiver)
     }
 }
@@ -271,6 +337,7 @@ fn bounded_replay(
     since_event_id: Option<&EventId>,
     replay_limit: Option<u32>,
     max_replay: usize,
+    filter: &EventFilter,
 ) -> Vec<EventEnvelope> {
     let limit = replay_limit
         .and_then(|limit| usize::try_from(limit).ok())
@@ -284,7 +351,12 @@ fn bounded_replay(
         .and_then(|event_id| replay.iter().position(|event| &event.event_id == event_id))
         .map(|index| index + 1)
         .unwrap_or(0);
-    let available = replay.iter().skip(start_index).cloned().collect::<Vec<_>>();
+    let available = replay
+        .iter()
+        .skip(start_index)
+        .filter(|event| filter.matches(event))
+        .cloned()
+        .collect::<Vec<_>>();
     let start = available.len().saturating_sub(limit);
     available[start..].to_vec()
 }
@@ -292,7 +364,7 @@ fn bounded_replay(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cadis_protocol::{CadisEvent, EmptyPayload, Timestamp};
+    use cadis_protocol::{CadisEvent, EmptyPayload, SessionEventPayload, Timestamp};
 
     #[test]
     fn bounded_replay_returns_events_after_retained_event_id() {
@@ -302,7 +374,13 @@ mod tests {
             event("evt_000003"),
         ]);
 
-        let events = bounded_replay(&replay, Some(&EventId::from("evt_000001")), Some(1), 8);
+        let events = bounded_replay(
+            &replay,
+            Some(&EventId::from("evt_000001")),
+            Some(1),
+            8,
+            &EventFilter::All,
+        );
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].event_id.as_str(), "evt_000003");
@@ -311,11 +389,12 @@ mod tests {
     #[test]
     fn event_bus_fans_out_published_runtime_events() {
         let bus = EventBus::new(8);
-        let (_replay, receiver) = bus.subscribe(&EventSubscriptionRequest {
-            include_snapshot: false,
-            replay_limit: Some(8),
-            since_event_id: None,
-        });
+        let (_replay, receiver) =
+            bus.subscribe(EventBusSubscription::all(&EventSubscriptionRequest {
+                include_snapshot: false,
+                replay_limit: Some(8),
+                since_event_id: None,
+            }));
 
         bus.publish(event("evt_000001"));
 
@@ -323,6 +402,82 @@ mod tests {
             .try_recv()
             .expect("subscriber should receive event");
         assert_eq!(received.event_id.as_str(), "evt_000001");
+    }
+
+    #[test]
+    fn event_bus_replays_only_matching_session_events() {
+        let bus = EventBus::new(8);
+        bus.publish(session_event("evt_000001", "ses_target"));
+        bus.publish(session_event("evt_000002", "ses_other"));
+        bus.publish(session_event("evt_000003", "ses_target"));
+
+        let (replay, _receiver) = bus.subscribe(EventBusSubscription {
+            since_event_id: Some(EventId::from("evt_000001")),
+            replay_limit: Some(8),
+            filter: EventFilter::Session(SessionId::from("ses_target")),
+        });
+
+        assert_eq!(replay.len(), 1);
+        assert_eq!(replay[0].event_id.as_str(), "evt_000003");
+    }
+
+    #[test]
+    fn event_bus_fans_out_session_events_to_two_filtered_clients() {
+        let bus = EventBus::new(8);
+        let subscription = EventBusSubscription {
+            since_event_id: None,
+            replay_limit: Some(8),
+            filter: EventFilter::Session(SessionId::from("ses_target")),
+        };
+        let (_replay, left) = bus.subscribe(subscription.clone());
+        let (_replay, right) = bus.subscribe(subscription);
+
+        bus.publish(session_event("evt_000001", "ses_other"));
+        assert!(left.try_recv().is_err());
+        assert!(right.try_recv().is_err());
+
+        bus.publish(session_event("evt_000002", "ses_target"));
+
+        let left_event = left
+            .try_recv()
+            .expect("left subscriber should receive event");
+        let right_event = right
+            .try_recv()
+            .expect("right subscriber should receive event");
+        assert_eq!(left_event.event_id.as_str(), "evt_000002");
+        assert_eq!(right_event.event_id.as_str(), "evt_000002");
+    }
+
+    #[test]
+    fn event_bus_keeps_unmatched_filtered_subscribers() {
+        let bus = EventBus::new(8);
+        let (_replay, receiver) = bus.subscribe(EventBusSubscription {
+            since_event_id: None,
+            replay_limit: Some(8),
+            filter: EventFilter::Session(SessionId::from("ses_target")),
+        });
+
+        bus.publish(session_event("evt_000001", "ses_other"));
+        bus.publish(session_event("evt_000002", "ses_target"));
+
+        let received = receiver
+            .try_recv()
+            .expect("subscriber should remain attached until a matching event");
+        assert_eq!(received.event_id.as_str(), "evt_000002");
+    }
+
+    fn session_event(event_id: &str, session_id: &str) -> EventEnvelope {
+        let session_id = SessionId::from(session_id);
+        EventEnvelope::new(
+            EventId::from(event_id),
+            Timestamp::new_utc("2026-04-26T00:00:00Z").expect("timestamp should parse"),
+            "cadisd",
+            Some(session_id.clone()),
+            CadisEvent::SessionStarted(SessionEventPayload {
+                session_id,
+                title: None,
+            }),
+        )
     }
 
     fn event(event_id: &str) -> EventEnvelope {

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -10,7 +10,9 @@ use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 
 use cadis_core::{PendingMessageGeneration, Runtime, RuntimeOptions};
-use cadis_models::{provider_from_config, ModelError, ModelRequest, ModelStreamEvent};
+use cadis_models::{
+    provider_from_config, ModelError, ModelRequest, ModelStreamControl, ModelStreamEvent,
+};
 use cadis_protocol::{
     ClientRequest, DaemonResponse, ErrorPayload, EventEnvelope, EventId, EventSubscriptionRequest,
     RequestEnvelope, RequestId, ResponseEnvelope, ServerFrame, SessionId,
@@ -282,9 +284,9 @@ fn serve_pending_message_generation<W: Write>(
                         ModelError::with_code("event_write_failed", error.to_string(), false)
                     })?;
                 }
-                ModelStreamEvent::Failed(_) => {}
+                ModelStreamEvent::Failed(_) | ModelStreamEvent::Cancelled(_) => {}
             }
-            Ok(())
+            Ok(ModelStreamControl::Continue)
         },
     );
 
@@ -588,6 +590,9 @@ mod tests {
                 profile_id: "default".to_owned(),
                 socket_path: None,
                 model_provider: "waiting".to_owned(),
+                ollama_model: "llama3.2".to_owned(),
+                openai_model: "gpt-5.2".to_owned(),
+                openai_api_key_configured: false,
                 ui_preferences: serde_json::json!({}),
             },
             Box::new(WaitingProvider {
@@ -616,7 +621,7 @@ mod tests {
             provider
                 .stream_chat(
                     ModelRequest::new(&prompt).with_selected_model(selected_model.as_deref()),
-                    &mut |_event| Ok(()),
+                    &mut |_event| Ok(ModelStreamControl::Continue),
                 )
                 .expect("waiting provider should complete")
         });
@@ -658,6 +663,9 @@ mod tests {
                 profile_id: "default".to_owned(),
                 socket_path: Some(socket_path.clone()),
                 model_provider: "waiting".to_owned(),
+                ollama_model: "llama3.2".to_owned(),
+                openai_model: "gpt-5.2".to_owned(),
+                openai_api_key_configured: false,
                 ui_preferences: serde_json::json!({}),
             },
             Box::new(WaitingProvider {

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -64,13 +64,14 @@ fn run() -> Result<(), Box<dyn Error>> {
 }
 
 fn build_runtime(config: &CadisConfig, socket_path: Option<PathBuf>) -> Arc<Mutex<Runtime>> {
+    let openai_api_key = openai_api_key_from_env();
     let provider = provider_from_config(
         &config.model.provider,
         &config.model.ollama_endpoint,
         &config.model.ollama_model,
         &config.model.openai_base_url,
         &config.model.openai_model,
-        openai_api_key_from_env().as_deref(),
+        openai_api_key.as_deref(),
     );
 
     Arc::new(Mutex::new(Runtime::new(
@@ -79,6 +80,9 @@ fn build_runtime(config: &CadisConfig, socket_path: Option<PathBuf>) -> Arc<Mute
             profile_id: config.profile.default_profile.clone(),
             socket_path,
             model_provider: config.model.provider.clone(),
+            ollama_model: config.model.ollama_model.clone(),
+            openai_model: config.model.openai_model.clone(),
+            openai_api_key_configured: openai_api_key.is_some(),
             ui_preferences: config.ui_preferences(),
         },
         provider,

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -469,9 +469,10 @@ mod tests {
     use cadis_models::{ModelInvocation, ModelProvider, ModelResponse};
     use cadis_protocol::{
         CadisEvent, ClientId, ContentKind, DaemonResponse, EmptyPayload, MessageSendRequest,
-        RequestEnvelope, SessionEventPayload, Timestamp,
+        RequestEnvelope, ServerFrame, SessionCreateRequest, SessionEventPayload, Timestamp,
     };
     use std::sync::Condvar;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn bounded_replay_returns_events_after_retained_event_id() {
@@ -635,6 +636,163 @@ mod tests {
         assert_eq!(response.deltas, vec!["done".to_owned()]);
     }
 
+    #[test]
+    fn socket_clients_share_session_events_while_status_and_agent_list_stay_live() {
+        let cadis_home = test_workspace("cadis-daemon-socket-live-subscribe");
+        let socket_path = cadis_home.join("run").join("cadisd-test.sock");
+        let entered = Arc::new((Mutex::new(false), Condvar::new()));
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let config = CadisConfig {
+            cadis_home: cadis_home.clone(),
+            ..CadisConfig::default()
+        };
+        ensure_layout(&config).expect("test CADIS layout should be created");
+
+        let runtime = Arc::new(Mutex::new(Runtime::new(
+            RuntimeOptions {
+                cadis_home,
+                profile_id: "default".to_owned(),
+                socket_path: Some(socket_path.clone()),
+                model_provider: "waiting".to_owned(),
+                ui_preferences: serde_json::json!({}),
+            },
+            Box::new(WaitingProvider {
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+            }),
+        )));
+        let event_log = EventLog::new(&config);
+        let event_bus = EventBus::new(32);
+        let listener = UnixListener::bind(&socket_path).expect("test socket should bind");
+        let accept_runtime = Arc::clone(&runtime);
+        let accept_event_log = event_log.clone();
+        let accept_event_bus = event_bus.clone();
+        let accept_thread = thread::spawn(move || {
+            for _ in 0..4 {
+                let (stream, _) = listener.accept().expect("test client should connect");
+                let runtime = Arc::clone(&accept_runtime);
+                let event_log = accept_event_log.clone();
+                let event_bus = accept_event_bus.clone();
+                thread::spawn(move || {
+                    let _ = serve_unix_stream(stream, runtime, event_log, event_bus);
+                });
+            }
+        });
+
+        let mut control = TestClient::connect(&socket_path);
+        let mut subscriber_one = TestClient::connect(&socket_path);
+        let mut subscriber_two = TestClient::connect(&socket_path);
+        let mut messenger = TestClient::connect(&socket_path);
+        accept_thread
+            .join()
+            .expect("test accept thread should not panic");
+
+        control.send(RequestEnvelope::new(
+            RequestId::from("req_create_session"),
+            ClientId::from("cli_control"),
+            ClientRequest::SessionCreate(SessionCreateRequest {
+                title: Some("Socket fan-out".to_owned()),
+                cwd: None,
+            }),
+        ));
+        assert!(matches!(
+            control.read_frame(),
+            ServerFrame::Response(ResponseEnvelope {
+                response: DaemonResponse::RequestAccepted(_),
+                ..
+            })
+        ));
+        let session_id = match control.read_frame() {
+            ServerFrame::Event(EventEnvelope {
+                event: CadisEvent::SessionStarted(payload),
+                ..
+            }) => payload.session_id,
+            other => panic!("expected session.started event, got {other:?}"),
+        };
+
+        let subscribe = |request_id: &str| {
+            RequestEnvelope::new(
+                RequestId::from(request_id),
+                ClientId::from(request_id),
+                ClientRequest::SessionSubscribe(SessionSubscriptionRequest {
+                    session_id: session_id.clone(),
+                    since_event_id: None,
+                    replay_limit: Some(16),
+                    include_snapshot: false,
+                }),
+            )
+        };
+        subscriber_one.send(subscribe("req_subscribe_one"));
+        subscriber_two.send(subscribe("req_subscribe_two"));
+        assert_accepted_response(&mut subscriber_one);
+        assert_accepted_response(&mut subscriber_two);
+
+        messenger.send(RequestEnvelope::new(
+            RequestId::from("req_message"),
+            ClientId::from("cli_message"),
+            ClientRequest::MessageSend(MessageSendRequest {
+                session_id: Some(session_id.clone()),
+                target_agent_id: None,
+                content: "hold generation open".to_owned(),
+                content_kind: ContentKind::Chat,
+            }),
+        ));
+        assert_accepted_response(&mut messenger);
+
+        wait_for_flag(&entered);
+
+        let route_one = subscriber_one
+            .read_event_matching(|event| matches!(event.event, CadisEvent::OrchestratorRoute(_)));
+        let route_two = subscriber_two
+            .read_event_matching(|event| matches!(event.event, CadisEvent::OrchestratorRoute(_)));
+        assert_eq!(route_one.event_id, route_two.event_id);
+        assert_eq!(route_one.session_id.as_ref(), Some(&session_id));
+        assert_eq!(route_two.session_id.as_ref(), Some(&session_id));
+
+        let status_one = subscriber_one
+            .read_event_matching(|event| matches!(event.event, CadisEvent::AgentStatusChanged(_)));
+        let status_two = subscriber_two
+            .read_event_matching(|event| matches!(event.event, CadisEvent::AgentStatusChanged(_)));
+        assert_eq!(status_one.event_id, status_two.event_id);
+
+        control.send(RequestEnvelope::new(
+            RequestId::from("req_status"),
+            ClientId::from("cli_control"),
+            ClientRequest::DaemonStatus(EmptyPayload::default()),
+        ));
+        match control.read_frame() {
+            ServerFrame::Response(ResponseEnvelope {
+                response: DaemonResponse::DaemonStatus(status),
+                ..
+            }) => assert_eq!(status.status, "ok"),
+            other => panic!("expected daemon.status.response during generation, got {other:?}"),
+        }
+
+        control.send(RequestEnvelope::new(
+            RequestId::from("req_agent_list"),
+            ClientId::from("cli_control"),
+            ClientRequest::AgentList(EmptyPayload::default()),
+        ));
+        assert_accepted_response(&mut control);
+        let agent_list = control
+            .read_event_matching(|event| matches!(event.event, CadisEvent::AgentListResponse(_)));
+        assert!(agent_list.session_id.is_none());
+
+        set_flag(&release);
+
+        let delta_one = subscriber_one
+            .read_event_matching(|event| matches!(event.event, CadisEvent::MessageDelta(_)));
+        let delta_two = subscriber_two
+            .read_event_matching(|event| matches!(event.event, CadisEvent::MessageDelta(_)));
+        assert_eq!(delta_one.event_id, delta_two.event_id);
+
+        let completed_one = subscriber_one
+            .read_event_matching(|event| matches!(event.event, CadisEvent::MessageCompleted(_)));
+        let completed_two = subscriber_two
+            .read_event_matching(|event| matches!(event.event, CadisEvent::MessageCompleted(_)));
+        assert_eq!(completed_one.event_id, completed_two.event_id);
+    }
+
     #[derive(Clone, Debug)]
     struct WaitingProvider {
         entered: Arc<(Mutex<bool>, Condvar)>,
@@ -688,6 +846,77 @@ mod tests {
         let (lock, condvar) = &**flag;
         *lock.lock().expect("flag mutex should lock") = true;
         condvar.notify_all();
+    }
+
+    struct TestClient {
+        reader: BufReader<UnixStream>,
+        writer: UnixStream,
+    }
+
+    impl TestClient {
+        fn connect(socket_path: &Path) -> Self {
+            let stream = UnixStream::connect(socket_path).expect("test client should connect");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("test client read timeout should be set");
+            let reader_stream = stream
+                .try_clone()
+                .expect("test client stream should clone for reading");
+            reader_stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("test client reader timeout should be set");
+            Self {
+                reader: BufReader::new(reader_stream),
+                writer: stream,
+            }
+        }
+
+        fn send(&mut self, request: RequestEnvelope) {
+            serde_json::to_writer(&mut self.writer, &request)
+                .expect("request frame should serialize");
+            self.writer
+                .write_all(b"\n")
+                .expect("request frame newline should write");
+            self.writer.flush().expect("request frame should flush");
+        }
+
+        fn read_frame(&mut self) -> ServerFrame {
+            let mut line = String::new();
+            self.reader
+                .read_line(&mut line)
+                .expect("server frame should be readable before timeout");
+            assert!(!line.is_empty(), "server closed the test client stream");
+            serde_json::from_str(&line).expect("server frame should deserialize")
+        }
+
+        fn read_event_matching(
+            &mut self,
+            mut predicate: impl FnMut(&EventEnvelope) -> bool,
+        ) -> EventEnvelope {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            loop {
+                let frame = self.read_frame();
+                if let ServerFrame::Event(event) = frame {
+                    if predicate(&event) {
+                        return event;
+                    }
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "timed out waiting for matching event"
+                );
+            }
+        }
+    }
+
+    fn assert_accepted_response(client: &mut TestClient) {
+        assert!(matches!(
+            client.read_frame(),
+            ServerFrame::Response(ResponseEnvelope {
+                response: DaemonResponse::RequestAccepted(_),
+                ..
+            })
+        ));
     }
 
     fn test_workspace(name: &str) -> PathBuf {

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -408,6 +408,10 @@ fn print_check(config: &CadisConfig, socket_path: &Path) {
     println!("ollama_endpoint: {}", config.model.ollama_endpoint);
     println!("openai_model: {}", config.model.openai_model);
     println!("openai_base_url: {}", redact(&config.model.openai_base_url));
+    println!("voice_enabled: {}", config.voice.enabled);
+    println!("voice_provider: {}", config.voice.provider);
+    println!("voice_id: {}", config.voice.voice_id);
+    println!("voice_stt_language: {}", config.voice.stt_language);
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -9,8 +9,8 @@ use std::process;
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 
-use cadis_core::{Runtime, RuntimeOptions};
-use cadis_models::provider_from_config;
+use cadis_core::{PendingMessageGeneration, Runtime, RuntimeOptions};
+use cadis_models::{provider_from_config, ModelError, ModelRequest, ModelStreamEvent};
 use cadis_protocol::{
     ClientRequest, DaemonResponse, ErrorPayload, EventEnvelope, EventId, EventSubscriptionRequest,
     RequestEnvelope, RequestId, ResponseEnvelope, ServerFrame, SessionId,
@@ -157,6 +157,31 @@ where
                     _ => None,
                 };
                 let snapshot_only = matches!(envelope.request, ClientRequest::EventsSnapshot(_));
+                if matches!(envelope.request, ClientRequest::MessageSend(_)) {
+                    let pending = runtime
+                        .lock()
+                        .map_err(|_| io::Error::other("runtime mutex was poisoned"))?
+                        .begin_message_request(envelope);
+                    match pending {
+                        Ok(pending) => {
+                            serve_pending_message_generation(
+                                &mut writer,
+                                Arc::clone(&runtime),
+                                &event_log,
+                                &event_bus,
+                                pending,
+                            )?;
+                        }
+                        Err(outcome) => {
+                            let outcome = *outcome;
+                            write_frame(&mut writer, &ServerFrame::Response(outcome.response))?;
+                            for event in outcome.events {
+                                emit_event(&mut writer, &event_log, &event_bus, event)?;
+                            }
+                        }
+                    }
+                    continue;
+                }
                 let outcome = runtime
                     .lock()
                     .map_err(|_| io::Error::other("runtime mutex was poisoned"))?
@@ -193,11 +218,7 @@ where
                 }
 
                 for event in outcome.events {
-                    if let Err(error) = event_log.append_event(&event) {
-                        eprintln!("cadisd log error: {error}");
-                    }
-                    event_bus.publish(event.clone());
-                    write_frame(&mut writer, &ServerFrame::Event(event))?;
+                    emit_event(&mut writer, &event_log, &event_bus, event)?;
                 }
             }
             Err(error) => {
@@ -215,6 +236,87 @@ where
     }
 
     Ok(())
+}
+
+fn serve_pending_message_generation<W: Write>(
+    writer: &mut W,
+    runtime: Arc<Mutex<Runtime>>,
+    event_log: &EventLog,
+    event_bus: &EventBus,
+    pending: PendingMessageGeneration,
+) -> Result<(), Box<dyn Error>> {
+    write_frame(writer, &ServerFrame::Response(pending.response.clone()))?;
+    for event in pending.initial_events.clone() {
+        emit_event(writer, event_log, event_bus, event)?;
+    }
+
+    let provider = Arc::clone(&pending.provider);
+    let mut invocation = None;
+    let mut final_content = String::new();
+    let mut emitted_delta = false;
+    let stream_result = provider.stream_chat(
+        ModelRequest::new(&pending.prompt).with_selected_model(pending.selected_model.as_deref()),
+        &mut |event| {
+            match event {
+                ModelStreamEvent::Started(started) | ModelStreamEvent::Completed(started) => {
+                    invocation = Some(started);
+                }
+                ModelStreamEvent::Delta(delta) => {
+                    final_content.push_str(&delta);
+                    emitted_delta = true;
+                    let event = runtime
+                        .lock()
+                        .map_err(|_| {
+                            ModelError::with_code(
+                                "runtime_lock_failed",
+                                "runtime mutex was poisoned",
+                                false,
+                            )
+                        })?
+                        .message_delta_event(&pending, delta, invocation.as_ref());
+                    emit_event(writer, event_log, event_bus, event).map_err(|error| {
+                        ModelError::with_code("event_write_failed", error.to_string(), false)
+                    })?;
+                }
+                ModelStreamEvent::Failed(_) => {}
+            }
+            Ok(())
+        },
+    );
+
+    let final_events = match stream_result {
+        Ok(response) => runtime
+            .lock()
+            .map_err(|_| io::Error::other("runtime mutex was poisoned"))?
+            .complete_message_generation(pending, response, final_content, emitted_delta),
+        Err(error) => runtime
+            .lock()
+            .map_err(|_| io::Error::other("runtime mutex was poisoned"))?
+            .fail_message_generation(pending, error),
+    };
+
+    for event in final_events {
+        emit_event(writer, event_log, event_bus, event)?;
+    }
+
+    Ok(())
+}
+
+fn emit_event<W: Write>(
+    writer: &mut W,
+    event_log: &EventLog,
+    event_bus: &EventBus,
+    event: EventEnvelope,
+) -> Result<(), Box<dyn Error>> {
+    publish_event(event_log, event_bus, &event);
+    write_frame(writer, &ServerFrame::Event(event))
+}
+
+fn publish_event(event_log: &EventLog, event_bus: &EventBus, event: &EventEnvelope) {
+    if let Err(error) = event_log.append_event(event) {
+        eprintln!("cadisd log error: {error}");
+    }
+    event_bus.publish(event.clone());
 }
 
 #[derive(Clone)]
@@ -364,7 +466,12 @@ fn bounded_replay(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cadis_protocol::{CadisEvent, EmptyPayload, SessionEventPayload, Timestamp};
+    use cadis_models::{ModelInvocation, ModelProvider, ModelResponse};
+    use cadis_protocol::{
+        CadisEvent, ClientId, ContentKind, DaemonResponse, EmptyPayload, MessageSendRequest,
+        RequestEnvelope, SessionEventPayload, Timestamp,
+    };
+    use std::sync::Condvar;
 
     #[test]
     fn bounded_replay_returns_events_after_retained_event_id() {
@@ -464,6 +571,136 @@ mod tests {
             .try_recv()
             .expect("subscriber should remain attached until a matching event");
         assert_eq!(received.event_id.as_str(), "evt_000002");
+    }
+
+    #[test]
+    fn pending_message_generation_leaves_runtime_mutex_available() {
+        let entered = Arc::new((Mutex::new(false), Condvar::new()));
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let runtime = Arc::new(Mutex::new(Runtime::new(
+            RuntimeOptions {
+                cadis_home: test_workspace("cadis-daemon-runtime-lock"),
+                profile_id: "default".to_owned(),
+                socket_path: None,
+                model_provider: "waiting".to_owned(),
+                ui_preferences: serde_json::json!({}),
+            },
+            Box::new(WaitingProvider {
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+            }),
+        )));
+        let pending = runtime
+            .lock()
+            .expect("runtime mutex should lock")
+            .begin_message_request(RequestEnvelope::new(
+                RequestId::from("req_chat"),
+                ClientId::from("cli_1"),
+                ClientRequest::MessageSend(MessageSendRequest {
+                    session_id: None,
+                    target_agent_id: None,
+                    content: "hello".to_owned(),
+                    content_kind: ContentKind::Chat,
+                }),
+            ))
+            .expect("message generation should be prepared");
+        let selected_model = pending.selected_model.clone();
+        let prompt = pending.prompt.clone();
+        let provider = Arc::clone(&pending.provider);
+        let worker = thread::spawn(move || {
+            provider
+                .stream_chat(
+                    ModelRequest::new(&prompt).with_selected_model(selected_model.as_deref()),
+                    &mut |_event| Ok(()),
+                )
+                .expect("waiting provider should complete")
+        });
+
+        wait_for_flag(&entered);
+        let status = runtime
+            .try_lock()
+            .expect("runtime mutex should not be held during provider generation")
+            .handle_request(RequestEnvelope::new(
+                RequestId::from("req_status"),
+                ClientId::from("cli_2"),
+                ClientRequest::DaemonStatus(EmptyPayload::default()),
+            ));
+        assert!(matches!(
+            status.response.response,
+            DaemonResponse::DaemonStatus(_)
+        ));
+
+        set_flag(&release);
+        let response = worker.join().expect("provider thread should not panic");
+        assert_eq!(response.deltas, vec!["done".to_owned()]);
+    }
+
+    #[derive(Clone, Debug)]
+    struct WaitingProvider {
+        entered: Arc<(Mutex<bool>, Condvar)>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl ModelProvider for WaitingProvider {
+        fn name(&self) -> &str {
+            "waiting"
+        }
+
+        fn chat(&self, _prompt: &str) -> Result<Vec<String>, ModelError> {
+            Ok(vec!["done".to_owned()])
+        }
+
+        fn stream_chat(
+            &self,
+            request: ModelRequest<'_>,
+            callback: &mut cadis_models::ModelStreamCallback<'_>,
+        ) -> Result<ModelResponse, ModelError> {
+            set_flag(&self.entered);
+            wait_for_flag(&self.release);
+            let invocation = ModelInvocation {
+                requested_model: request.selected_model.map(ToOwned::to_owned),
+                effective_provider: "waiting".to_owned(),
+                effective_model: "unit-test".to_owned(),
+                fallback: false,
+                fallback_reason: None,
+            };
+            callback(ModelStreamEvent::Started(invocation.clone()))?;
+            callback(ModelStreamEvent::Delta("done".to_owned()))?;
+            callback(ModelStreamEvent::Completed(invocation.clone()))?;
+            Ok(ModelResponse {
+                deltas: vec!["done".to_owned()],
+                invocation,
+            })
+        }
+    }
+
+    fn wait_for_flag(flag: &Arc<(Mutex<bool>, Condvar)>) {
+        let (lock, condvar) = &**flag;
+        let mut ready = lock.lock().expect("flag mutex should lock");
+        while !*ready {
+            ready = condvar
+                .wait(ready)
+                .expect("flag mutex should not be poisoned");
+        }
+    }
+
+    fn set_flag(flag: &Arc<(Mutex<bool>, Condvar)>) {
+        let (lock, condvar) = &**flag;
+        *lock.lock().expect("flag mutex should lock") = true;
+        condvar.notify_all();
+    }
+
+    fn test_workspace(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "{name}-{}-{}",
+            process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after unix epoch")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&path).expect("test workspace should be created");
+        path
     }
 
     fn session_event(event_id: &str, session_id: &str) -> EventEnvelope {

--- a/crates/cadis-hud/src/main.rs
+++ b/crates/cadis-hud/src/main.rs
@@ -1114,11 +1114,13 @@ fn slot_positions(rect: Rect) -> [Pos2; 12] {
 
 fn status_color(status: AgentStatus, theme: &Palette) -> Color32 {
     match status {
+        AgentStatus::Spawning => theme.warn,
         AgentStatus::Idle => theme.dim,
         AgentStatus::Running => theme.ok,
         AgentStatus::WaitingApproval => theme.warn,
         AgentStatus::Completed => theme.accent,
         AgentStatus::Failed => theme.err,
+        AgentStatus::Cancelled => theme.dim,
     }
 }
 

--- a/crates/cadis-models/README.md
+++ b/crates/cadis-models/README.md
@@ -6,3 +6,9 @@ The desktop MVP includes OpenAI, Ollama, and official Codex CLI adapters plus a
 local fallback provider that requires no credentials. The Codex CLI adapter uses
 `codex exec`; authenticate separately with the official CLI instead of storing
 ChatGPT tokens in CADIS.
+
+Providers stream normalized events through `ModelStreamCallback`. The callback
+returns `ModelStreamControl::Continue` to keep receiving events or
+`ModelStreamControl::Cancel` to request provider-boundary cancellation. A
+cancelled provider request returns the non-retryable `model_cancelled` error and
+emits `model.cancelled` when invocation metadata is available.

--- a/crates/cadis-models/src/lib.rs
+++ b/crates/cadis-models/src/lib.rs
@@ -3,12 +3,14 @@
 use std::env;
 use std::error::Error;
 use std::fmt;
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 use std::process::{Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+
+use reqwest::StatusCode;
 
 const CODEX_CLI_DEFAULT_BIN: &str = "codex";
 const CODEX_CLI_TIMEOUT: Duration = Duration::from_secs(300);
@@ -213,6 +215,29 @@ impl fmt::Display for ModelError {
 
 impl Error for ModelError {}
 
+fn provider_http_error(provider: &str, status: StatusCode) -> ModelError {
+    let is_auth_error = status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN;
+    let (code, retryable) = if is_auth_error {
+        ("model_auth_failed", false)
+    } else if status == StatusCode::TOO_MANY_REQUESTS {
+        ("provider_rate_limited", true)
+    } else if status == StatusCode::NOT_FOUND {
+        ("model_not_found", false)
+    } else if status.is_server_error() {
+        ("provider_unavailable", true)
+    } else if status.is_client_error() {
+        ("model_request_rejected", false)
+    } else {
+        ("provider_http_error", false)
+    };
+
+    ModelError::with_code(
+        code,
+        format!("{provider} returned HTTP status {status}"),
+        retryable,
+    )
+}
+
 /// Conservative provider readiness exposed by the model catalog.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProviderReadiness {
@@ -363,7 +388,13 @@ impl ModelProvider for OllamaProvider {
         let client = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(120))
             .build()
-            .map_err(|error| ModelError::new(format!("failed to create Ollama client: {error}")))?;
+            .map_err(|error| {
+                ModelError::with_code(
+                    "provider_client_error",
+                    format!("failed to create Ollama client: {error}"),
+                    false,
+                )
+            })?;
 
         let response = client
             .post(format!("{}/api/generate", self.endpoint))
@@ -373,21 +404,29 @@ impl ModelProvider for OllamaProvider {
                 stream: false,
             })
             .send()
-            .map_err(|error| ModelError::new(format!("Ollama request failed: {error}")))?;
+            .map_err(|_| {
+                ModelError::with_code("provider_unavailable", "Ollama request failed", true)
+            })?;
 
         let status = response.status();
         if !status.is_success() {
-            return Err(ModelError::new(format!(
-                "Ollama returned HTTP status {status}"
-            )));
+            return Err(provider_http_error("Ollama", status));
         }
 
-        let body = response
-            .json::<OllamaGenerateResponse>()
-            .map_err(|error| ModelError::new(format!("Ollama response was invalid: {error}")))?;
+        let body = response.json::<OllamaGenerateResponse>().map_err(|error| {
+            ModelError::with_code(
+                "provider_response_invalid",
+                format!("Ollama response was invalid: {error}"),
+                false,
+            )
+        })?;
 
         if let Some(error) = body.error {
-            return Err(ModelError::new(format!("Ollama error: {error}")));
+            return Err(ModelError::with_code(
+                "model_request_rejected",
+                format!("Ollama error: {error}"),
+                false,
+            ));
         }
 
         Ok(chunk_text(body.response.as_deref().unwrap_or_default()))
@@ -450,15 +489,23 @@ impl ModelProvider for OpenAiProvider {
 
     fn chat(&self, prompt: &str) -> Result<Vec<String>, ModelError> {
         if self.api_key.trim().is_empty() {
-            return Err(ModelError::new(
+            return Err(ModelError::with_code(
+                "model_auth_missing",
                 "OpenAI provider requires OPENAI_API_KEY or CADIS_OPENAI_API_KEY",
+                false,
             ));
         }
 
         let client = reqwest::blocking::Client::builder()
             .timeout(Duration::from_secs(120))
             .build()
-            .map_err(|_| ModelError::new("failed to create OpenAI client"))?;
+            .map_err(|_| {
+                ModelError::with_code(
+                    "provider_client_error",
+                    "failed to create OpenAI client",
+                    false,
+                )
+            })?;
 
         let response = client
             .post(format!("{}/chat/completions", self.base_url))
@@ -471,18 +518,22 @@ impl ModelProvider for OpenAiProvider {
                 }],
             })
             .send()
-            .map_err(|_| ModelError::new("OpenAI request failed"))?;
+            .map_err(|_| {
+                ModelError::with_code("provider_unavailable", "OpenAI request failed", true)
+            })?;
 
         let status = response.status();
         if !status.is_success() {
-            return Err(ModelError::new(format!(
-                "OpenAI returned HTTP status {status}"
-            )));
+            return Err(provider_http_error("OpenAI", status));
         }
 
-        let body = response
-            .json::<OpenAiChatResponse>()
-            .map_err(|_| ModelError::new("OpenAI response was invalid"))?;
+        let body = response.json::<OpenAiChatResponse>().map_err(|_| {
+            ModelError::with_code(
+                "provider_response_invalid",
+                "OpenAI response was invalid",
+                false,
+            )
+        })?;
         let content = body
             .choices
             .first()
@@ -490,7 +541,11 @@ impl ModelProvider for OpenAiProvider {
             .unwrap_or_default();
 
         if content.is_empty() {
-            return Err(ModelError::new("OpenAI response was empty"));
+            return Err(ModelError::with_code(
+                "provider_response_empty",
+                "OpenAI response was empty",
+                true,
+            ));
         }
 
         Ok(chunk_text(content))
@@ -554,7 +609,11 @@ impl ModelProvider for CodexCliProvider {
     fn chat(&self, prompt: &str) -> Result<Vec<String>, ModelError> {
         let output = run_codex_exec(&self.command, prompt, self.timeout)?;
         if !output.status.success() {
-            return Err(ModelError::new(format_codex_failure(&output)));
+            return Err(ModelError::with_code(
+                "codex_cli_failed",
+                format_codex_failure(&output),
+                false,
+            ));
         }
 
         Ok(chunk_text(output.stdout.trim()))
@@ -649,13 +708,21 @@ fn run_codex_exec(
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|error| {
-            if error.kind() == std::io::ErrorKind::NotFound {
-                ModelError::new(format!(
+            if error.kind() == ErrorKind::NotFound {
+                ModelError::with_code(
+                    "codex_cli_missing",
+                    format!(
                     "Codex CLI binary '{}' was not found. Install the official Codex CLI, run `codex login`, or set CADIS_CODEX_BIN.",
                     command.bin
-                ))
+                    ),
+                    false,
+                )
             } else {
-                ModelError::new(format!("failed to start Codex CLI '{}': {error}", command.bin))
+                ModelError::with_code(
+                    "codex_cli_start_failed",
+                    format!("failed to start Codex CLI '{}': {error}", command.bin),
+                    false,
+                )
             }
         })?;
 
@@ -666,30 +733,41 @@ fn run_codex_exec(
             Err(error) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                return Err(ModelError::new(format!(
-                    "failed to send prompt to Codex CLI: {error}"
-                )));
+                return Err(ModelError::with_code(
+                    "codex_cli_io_error",
+                    format!("failed to send prompt to Codex CLI: {error}"),
+                    false,
+                ));
             }
         }
     }
 
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| ModelError::new("failed to capture Codex CLI stdout"))?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| ModelError::new("failed to capture Codex CLI stderr"))?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        ModelError::with_code(
+            "codex_cli_io_error",
+            "failed to capture Codex CLI stdout",
+            false,
+        )
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        ModelError::with_code(
+            "codex_cli_io_error",
+            "failed to capture Codex CLI stderr",
+            false,
+        )
+    })?;
     let stdout_reader = read_pipe(stdout);
     let stderr_reader = read_pipe(stderr);
 
     let started = std::time::Instant::now();
     loop {
-        if let Some(status) = child
-            .try_wait()
-            .map_err(|error| ModelError::new(format!("failed to wait for Codex CLI: {error}")))?
-        {
+        if let Some(status) = child.try_wait().map_err(|error| {
+            ModelError::with_code(
+                "codex_cli_wait_failed",
+                format!("failed to wait for Codex CLI: {error}"),
+                false,
+            )
+        })? {
             let stderr = join_pipe(stderr_reader, "stderr")?;
             drop(stderr);
             return Ok(CodexCliOutput {
@@ -703,11 +781,15 @@ fn run_codex_exec(
             let _ = child.wait();
             let _ = join_pipe(stdout_reader, "stdout");
             let _ = join_pipe(stderr_reader, "stderr");
-            return Err(ModelError::new(format!(
-                "Codex CLI timed out after {} seconds while running `{} exec`.",
-                timeout.as_secs(),
-                command.bin
-            )));
+            return Err(ModelError::with_code(
+                "codex_cli_timeout",
+                format!(
+                    "Codex CLI timed out after {} seconds while running `{} exec`.",
+                    timeout.as_secs(),
+                    command.bin
+                ),
+                true,
+            ));
         }
 
         thread::sleep(Duration::from_millis(50));
@@ -731,8 +813,20 @@ fn join_pipe(
 ) -> Result<String, ModelError> {
     handle
         .join()
-        .map_err(|_| ModelError::new(format!("Codex CLI {label} reader panicked")))?
-        .map_err(|error| ModelError::new(format!("failed to read Codex CLI {label}: {error}")))
+        .map_err(|_| {
+            ModelError::with_code(
+                "codex_cli_io_error",
+                format!("Codex CLI {label} reader panicked"),
+                false,
+            )
+        })?
+        .map_err(|error| {
+            ModelError::with_code(
+                "codex_cli_io_error",
+                format!("failed to read Codex CLI {label}: {error}"),
+                false,
+            )
+        })
 }
 
 fn parse_extra_args(input: &str) -> Result<Vec<String>, ModelError> {
@@ -763,9 +857,11 @@ fn parse_extra_args(input: &str) -> Result<Vec<String>, ModelError> {
     }
 
     if let Some(active_quote) = quote {
-        return Err(ModelError::new(format!(
-            "CADIS_CODEX_EXTRA_ARGS has an unterminated {active_quote} quote"
-        )));
+        return Err(ModelError::with_code(
+            "codex_cli_args_invalid",
+            format!("CADIS_CODEX_EXTRA_ARGS has an unterminated {active_quote} quote"),
+            false,
+        ));
     }
 
     if !current.is_empty() {
@@ -795,9 +891,11 @@ fn validate_codex_extra_args(args: &[String]) -> Result<(), ModelError> {
             .iter()
             .any(|blocked| arg == blocked || arg.starts_with(&format!("{blocked}=")))
         {
-            return Err(ModelError::new(format!(
-                "CADIS_CODEX_EXTRA_ARGS contains unsupported unsafe option: {arg}"
-            )));
+            return Err(ModelError::with_code(
+                "codex_cli_args_unsafe",
+                format!("CADIS_CODEX_EXTRA_ARGS contains unsupported unsafe option: {arg}"),
+                false,
+            ));
         }
     }
     Ok(())
@@ -1235,6 +1333,41 @@ mod tests {
     }
 
     #[test]
+    fn ollama_connection_failure_has_structured_error() {
+        let provider = OllamaProvider::new("http://127.0.0.1:1", "llama3.2");
+
+        let error = provider
+            .chat_with_request(
+                ModelRequest::new("hello").with_selected_model(Some("ollama/llama3.2")),
+            )
+            .expect_err("closed localhost port should fail");
+
+        assert_eq!(error.code(), "provider_unavailable");
+        assert!(error.retryable());
+        assert_eq!(
+            error
+                .invocation()
+                .map(|invocation| invocation.effective_provider.as_str()),
+            Some("ollama")
+        );
+    }
+
+    #[test]
+    fn http_status_errors_are_structured() {
+        let auth_error = provider_http_error("OpenAI", StatusCode::UNAUTHORIZED);
+        assert_eq!(auth_error.code(), "model_auth_failed");
+        assert!(!auth_error.retryable());
+
+        let rate_limit = provider_http_error("OpenAI", StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(rate_limit.code(), "provider_rate_limited");
+        assert!(rate_limit.retryable());
+
+        let server_error = provider_http_error("Ollama", StatusCode::BAD_GATEWAY);
+        assert_eq!(server_error.code(), "provider_unavailable");
+        assert!(server_error.retryable());
+    }
+
+    #[test]
     fn router_uses_per_agent_echo_model_selection() {
         let provider = provider_from_config(
             "openai",
@@ -1337,6 +1470,8 @@ mod tests {
         let error =
             parse_extra_args("--sandbox danger-full-access").expect_err("unsafe arg should fail");
 
+        assert_eq!(error.code(), "codex_cli_args_unsafe");
+        assert!(!error.retryable());
         assert!(error
             .to_string()
             .contains("unsupported unsafe option: --sandbox"));
@@ -1352,6 +1487,8 @@ mod tests {
         let error =
             run_codex_exec(&command, "hello", Duration::from_millis(10)).expect_err("missing bin");
 
+        assert_eq!(error.code(), "codex_cli_missing");
+        assert!(!error.retryable());
         assert!(error.to_string().contains("Codex CLI binary"));
     }
 }

--- a/crates/cadis-models/src/lib.rs
+++ b/crates/cadis-models/src/lib.rs
@@ -272,27 +272,80 @@ pub struct ProviderCatalogEntry {
     pub fallback: bool,
 }
 
-/// Returns the conservative built-in provider catalog.
+/// Runtime configuration used to build the client-visible provider catalog.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModelCatalogConfig {
+    /// Default provider from `[model].provider`.
+    pub default_provider: String,
+    /// Configured Ollama model.
+    pub ollama_model: String,
+    /// Configured OpenAI model.
+    pub openai_model: String,
+    /// Whether an OpenAI API key is present in the daemon environment.
+    pub openai_api_key_configured: bool,
+}
+
+impl ModelCatalogConfig {
+    /// Creates catalog config from daemon model settings.
+    pub fn new(
+        default_provider: impl Into<String>,
+        ollama_model: impl Into<String>,
+        openai_model: impl Into<String>,
+        openai_api_key_configured: bool,
+    ) -> Self {
+        Self {
+            default_provider: normalize_provider_id(&default_provider.into()).to_owned(),
+            ollama_model: catalog_model_or_configured(ollama_model.into()),
+            openai_model: catalog_model_or_configured(openai_model.into()),
+            openai_api_key_configured,
+        }
+    }
+}
+
+impl Default for ModelCatalogConfig {
+    fn default() -> Self {
+        Self::new("auto", "llama3.2", "gpt-5.2", false)
+    }
+}
+
+/// Returns the conservative built-in provider catalog using default settings.
 pub fn provider_catalog() -> Vec<ProviderCatalogEntry> {
+    provider_catalog_for_config(&ModelCatalogConfig::default())
+}
+
+/// Returns the conservative built-in provider catalog for daemon settings.
+pub fn provider_catalog_for_config(config: &ModelCatalogConfig) -> Vec<ProviderCatalogEntry> {
+    let default_provider = normalize_provider_id(&config.default_provider);
+    let auto_readiness = if default_provider == "auto" {
+        ProviderReadiness::Fallback
+    } else {
+        ProviderReadiness::RequiresConfiguration
+    };
+    let openai_readiness = if config.openai_api_key_configured {
+        ProviderReadiness::Ready
+    } else {
+        ProviderReadiness::RequiresConfiguration
+    };
+
     vec![
         ProviderCatalogEntry {
             provider: "auto".to_owned(),
-            model: "ollama-or-echo".to_owned(),
-            display_name: "Auto (Ollama, then local fallback)".to_owned(),
+            model: config.ollama_model.clone(),
+            display_name: format!("Auto (Ollama {}, then local fallback)", config.ollama_model),
             capabilities: vec!["streaming".to_owned(), "local_fallback".to_owned()],
-            readiness: ProviderReadiness::Fallback,
+            readiness: auto_readiness,
             effective_provider: "ollama".to_owned(),
-            effective_model: "configured".to_owned(),
+            effective_model: config.ollama_model.clone(),
             fallback: true,
         },
         ProviderCatalogEntry {
             provider: "ollama".to_owned(),
-            model: "configured".to_owned(),
-            display_name: "Ollama local model".to_owned(),
+            model: config.ollama_model.clone(),
+            display_name: format!("Ollama {}", config.ollama_model),
             capabilities: vec!["streaming".to_owned(), "local_model".to_owned()],
             readiness: ProviderReadiness::RequiresConfiguration,
             effective_provider: "ollama".to_owned(),
-            effective_model: "configured".to_owned(),
+            effective_model: config.ollama_model.clone(),
             fallback: false,
         },
         ProviderCatalogEntry {
@@ -311,12 +364,12 @@ pub fn provider_catalog() -> Vec<ProviderCatalogEntry> {
         },
         ProviderCatalogEntry {
             provider: "openai".to_owned(),
-            model: "configured".to_owned(),
-            display_name: "OpenAI API model".to_owned(),
+            model: config.openai_model.clone(),
+            display_name: format!("OpenAI {}", config.openai_model),
             capabilities: vec!["api_key".to_owned()],
-            readiness: ProviderReadiness::RequiresConfiguration,
+            readiness: openai_readiness,
             effective_provider: "openai".to_owned(),
-            effective_model: "configured".to_owned(),
+            effective_model: config.openai_model.clone(),
             fallback: false,
         },
         ProviderCatalogEntry {
@@ -1192,6 +1245,15 @@ fn is_known_provider(provider: &str) -> bool {
     )
 }
 
+fn catalog_model_or_configured(model: String) -> String {
+    let model = model.trim();
+    if model.is_empty() {
+        CONFIGURED_MODEL.to_owned()
+    } else {
+        model.to_owned()
+    }
+}
+
 fn normalize_optional_model(model: Option<&str>) -> Option<String> {
     model
         .map(str::trim)
@@ -1297,6 +1359,34 @@ mod tests {
             .expect("ollama should be listed");
         assert_eq!(ollama.readiness, ProviderReadiness::RequiresConfiguration);
         assert!(!ollama.fallback);
+    }
+
+    #[test]
+    fn provider_catalog_uses_configured_models_and_openai_key_readiness() {
+        let catalog = provider_catalog_for_config(&ModelCatalogConfig::new(
+            "openai",
+            "qwen2.5-coder",
+            "gpt-5.4",
+            true,
+        ));
+
+        let auto = catalog
+            .iter()
+            .find(|entry| entry.provider == "auto")
+            .expect("auto should be listed");
+        assert_eq!(auto.model, "qwen2.5-coder");
+        assert_eq!(auto.effective_model, "qwen2.5-coder");
+        assert_eq!(auto.readiness, ProviderReadiness::RequiresConfiguration);
+        assert!(auto.fallback);
+
+        let openai = catalog
+            .iter()
+            .find(|entry| entry.provider == "openai")
+            .expect("openai should be listed");
+        assert_eq!(openai.model, "gpt-5.4");
+        assert_eq!(openai.effective_model, "gpt-5.4");
+        assert_eq!(openai.readiness, ProviderReadiness::Ready);
+        assert!(!openai.fallback);
     }
 
     #[test]

--- a/crates/cadis-models/src/lib.rs
+++ b/crates/cadis-models/src/lib.rs
@@ -52,15 +52,42 @@ pub trait ModelProvider: Send + Sync {
     ) -> Result<ModelResponse, ModelError> {
         match self.chat_with_request(request) {
             Ok(response) => {
-                callback(ModelStreamEvent::Started(response.invocation.clone()))?;
-                for delta in &response.deltas {
-                    callback(ModelStreamEvent::Delta(delta.clone()))?;
+                if emit_stream_event(
+                    callback,
+                    ModelStreamEvent::Started(response.invocation.clone()),
+                    &response.invocation,
+                )? == ModelStreamControl::Cancel
+                {
+                    return cancel_stream(callback, &response.invocation);
                 }
-                callback(ModelStreamEvent::Completed(response.invocation.clone()))?;
+                for delta in &response.deltas {
+                    if emit_stream_event(
+                        callback,
+                        ModelStreamEvent::Delta(delta.clone()),
+                        &response.invocation,
+                    )? == ModelStreamControl::Cancel
+                    {
+                        return cancel_stream(callback, &response.invocation);
+                    }
+                }
+                if emit_stream_event(
+                    callback,
+                    ModelStreamEvent::Completed(response.invocation.clone()),
+                    &response.invocation,
+                )? == ModelStreamControl::Cancel
+                {
+                    return cancel_stream(callback, &response.invocation);
+                }
                 Ok(response)
             }
             Err(error) => {
-                callback(ModelStreamEvent::Failed(ModelFailure {
+                if error.is_cancelled() {
+                    if let Some(invocation) = error.invocation.as_deref() {
+                        let _ = callback(ModelStreamEvent::Cancelled(invocation.clone()))?;
+                    }
+                    return Err(error);
+                }
+                let _ = callback(ModelStreamEvent::Failed(ModelFailure {
                     code: error.code.clone(),
                     message: error.message.clone(),
                     retryable: error.retryable,
@@ -73,7 +100,18 @@ pub trait ModelProvider: Send + Sync {
 }
 
 /// Callback used by providers to stream normalized model events.
-pub type ModelStreamCallback<'a> = dyn FnMut(ModelStreamEvent) -> Result<(), ModelError> + 'a;
+pub type ModelStreamCallback<'a> =
+    dyn FnMut(ModelStreamEvent) -> Result<ModelStreamControl, ModelError> + 'a;
+
+/// Callback control returned to a provider after each streamed event.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ModelStreamControl {
+    /// Continue streaming more provider events.
+    #[default]
+    Continue,
+    /// Stop the provider request and return a normalized cancellation error.
+    Cancel,
+}
 
 /// Model request context supplied by the runtime.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -135,6 +173,8 @@ pub enum ModelStreamEvent {
     Completed(ModelInvocation),
     /// Provider invocation failed.
     Failed(ModelFailure),
+    /// Provider invocation was cancelled before completion.
+    Cancelled(ModelInvocation),
 }
 
 /// Structured model failure metadata.
@@ -180,6 +220,11 @@ impl ModelError {
         }
     }
 
+    /// Creates a normalized provider cancellation error.
+    pub fn cancelled(message: impl Into<String>) -> Self {
+        Self::with_code("model_cancelled", message, false)
+    }
+
     /// Attaches provider/model invocation metadata.
     pub fn with_invocation(mut self, invocation: ModelInvocation) -> Self {
         self.invocation = Some(Box::new(invocation));
@@ -204,6 +249,18 @@ impl ModelError {
     /// Returns provider/model invocation metadata when available.
     pub fn invocation(&self) -> Option<&ModelInvocation> {
         self.invocation.as_deref()
+    }
+
+    /// Returns whether this error represents provider-boundary cancellation.
+    pub fn is_cancelled(&self) -> bool {
+        self.code == "model_cancelled"
+    }
+
+    fn with_invocation_if_missing(mut self, invocation: &ModelInvocation) -> Self {
+        if self.invocation.is_none() {
+            self.invocation = Some(Box::new(invocation.clone()));
+        }
+        self
     }
 }
 
@@ -236,6 +293,26 @@ fn provider_http_error(provider: &str, status: StatusCode) -> ModelError {
         format!("{provider} returned HTTP status {status}"),
         retryable,
     )
+}
+
+fn emit_stream_event(
+    callback: &mut ModelStreamCallback<'_>,
+    event: ModelStreamEvent,
+    invocation: &ModelInvocation,
+) -> Result<ModelStreamControl, ModelError> {
+    callback(event).map_err(|error| error.with_invocation_if_missing(invocation))
+}
+
+fn cancel_stream(
+    callback: &mut ModelStreamCallback<'_>,
+    invocation: &ModelInvocation,
+) -> Result<ModelResponse, ModelError> {
+    let _ = emit_stream_event(
+        callback,
+        ModelStreamEvent::Cancelled(invocation.clone()),
+        invocation,
+    )?;
+    Err(ModelError::cancelled("model request was cancelled").with_invocation(invocation.clone()))
 }
 
 /// Conservative provider readiness exposed by the model catalog.
@@ -1333,6 +1410,87 @@ struct OpenAiResponseMessage {
 mod tests {
     use super::*;
 
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct DeterministicStreamingProvider {
+        deltas: Vec<String>,
+    }
+
+    impl DeterministicStreamingProvider {
+        fn new(deltas: &[&str]) -> Self {
+            Self {
+                deltas: deltas.iter().map(|delta| (*delta).to_owned()).collect(),
+            }
+        }
+
+        fn invocation(request: ModelRequest<'_>) -> ModelInvocation {
+            ModelInvocation {
+                requested_model: request.selected_model.map(ToOwned::to_owned),
+                effective_provider: "deterministic-stream".to_owned(),
+                effective_model: "deterministic-test-model".to_owned(),
+                fallback: false,
+                fallback_reason: None,
+            }
+        }
+    }
+
+    impl ModelProvider for DeterministicStreamingProvider {
+        fn name(&self) -> &str {
+            "deterministic-stream"
+        }
+
+        fn chat(&self, _prompt: &str) -> Result<Vec<String>, ModelError> {
+            panic!("deterministic streaming provider should emit deltas through stream_chat")
+        }
+
+        fn chat_with_request(
+            &self,
+            request: ModelRequest<'_>,
+        ) -> Result<ModelResponse, ModelError> {
+            Ok(ModelResponse {
+                deltas: self.deltas.clone(),
+                invocation: Self::invocation(request),
+            })
+        }
+
+        fn stream_chat(
+            &self,
+            request: ModelRequest<'_>,
+            callback: &mut ModelStreamCallback<'_>,
+        ) -> Result<ModelResponse, ModelError> {
+            let response = self.chat_with_request(request)?;
+            if emit_stream_event(
+                callback,
+                ModelStreamEvent::Started(response.invocation.clone()),
+                &response.invocation,
+            )? == ModelStreamControl::Cancel
+            {
+                return cancel_stream(callback, &response.invocation);
+            }
+
+            for delta in &response.deltas {
+                if emit_stream_event(
+                    callback,
+                    ModelStreamEvent::Delta(delta.clone()),
+                    &response.invocation,
+                )? == ModelStreamControl::Cancel
+                {
+                    return cancel_stream(callback, &response.invocation);
+                }
+            }
+
+            if emit_stream_event(
+                callback,
+                ModelStreamEvent::Completed(response.invocation.clone()),
+                &response.invocation,
+            )? == ModelStreamControl::Cancel
+            {
+                return cancel_stream(callback, &response.invocation);
+            }
+
+            Ok(response)
+        }
+    }
+
     #[test]
     fn echo_provider_returns_deltas() {
         let deltas = EchoProvider.chat("hello").expect("echo should not fail");
@@ -1498,7 +1656,7 @@ mod tests {
         let response = provider
             .stream_chat(ModelRequest::new("stream please"), &mut |event| {
                 events.push(event);
-                Ok(())
+                Ok(ModelStreamControl::Continue)
             })
             .expect("echo stream should succeed");
 
@@ -1515,6 +1673,86 @@ mod tests {
             })
             .collect::<String>();
         assert_eq!(streamed, response.deltas.join(""));
+    }
+
+    #[test]
+    fn provider_can_emit_token_deltas_through_callback() {
+        let provider = DeterministicStreamingProvider::new(&["hel", "lo", " stream"]);
+        let mut events = Vec::new();
+
+        let response = provider
+            .stream_chat(
+                ModelRequest::new("ignored by deterministic provider")
+                    .with_selected_model(Some("deterministic-stream/test")),
+                &mut |event| {
+                    events.push(event);
+                    Ok(ModelStreamControl::Continue)
+                },
+            )
+            .expect("streaming provider should succeed");
+
+        assert_eq!(response.deltas, vec!["hel", "lo", " stream"]);
+        assert_eq!(
+            response.invocation.requested_model.as_deref(),
+            Some("deterministic-stream/test")
+        );
+        assert!(matches!(events.first(), Some(ModelStreamEvent::Started(_))));
+        assert!(matches!(
+            events.last(),
+            Some(ModelStreamEvent::Completed(_))
+        ));
+        let streamed = events
+            .into_iter()
+            .filter_map(|event| match event {
+                ModelStreamEvent::Delta(delta) => Some(delta),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(streamed, vec!["hel", "lo", " stream"]);
+    }
+
+    #[test]
+    fn callback_cancellation_emits_cancelled_and_stops_streaming() {
+        let provider = DeterministicStreamingProvider::new(&["first", "second", "third"]);
+        let mut events = Vec::new();
+
+        let error = provider
+            .stream_chat(
+                ModelRequest::new("cancel after first delta"),
+                &mut |event| {
+                    let should_cancel = matches!(event, ModelStreamEvent::Delta(_));
+                    events.push(event);
+                    if should_cancel {
+                        Ok(ModelStreamControl::Cancel)
+                    } else {
+                        Ok(ModelStreamControl::Continue)
+                    }
+                },
+            )
+            .expect_err("callback cancellation should stop the provider");
+
+        assert_eq!(error.code(), "model_cancelled");
+        assert!(!error.retryable());
+        assert_eq!(
+            error
+                .invocation()
+                .map(|invocation| invocation.effective_provider.as_str()),
+            Some("deterministic-stream")
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ModelStreamEvent::Delta(_)))
+                .count(),
+            1
+        );
+        assert!(matches!(
+            events.last(),
+            Some(ModelStreamEvent::Cancelled(_))
+        ));
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, ModelStreamEvent::Completed(_))));
     }
 
     #[test]

--- a/crates/cadis-protocol/src/lib.rs
+++ b/crates/cadis-protocol/src/lib.rs
@@ -76,6 +76,10 @@ string_id!(
     AgentId
 );
 string_id!(
+    /// CADIS per-route agent runtime session identifier.
+    AgentSessionId
+);
+string_id!(
     /// CADIS registered workspace identifier.
     WorkspaceId
 );
@@ -748,6 +752,21 @@ pub enum CadisEvent {
     /// Agent completed a task.
     #[serde(rename = "agent.completed")]
     AgentCompleted(AgentEventPayload),
+    /// Agent runtime session started.
+    #[serde(rename = "agent.session.started")]
+    AgentSessionStarted(AgentSessionEventPayload),
+    /// Agent runtime session state changed.
+    #[serde(rename = "agent.session.updated")]
+    AgentSessionUpdated(AgentSessionEventPayload),
+    /// Agent runtime session completed.
+    #[serde(rename = "agent.session.completed")]
+    AgentSessionCompleted(AgentSessionEventPayload),
+    /// Agent runtime session failed.
+    #[serde(rename = "agent.session.failed")]
+    AgentSessionFailed(AgentSessionEventPayload),
+    /// Agent runtime session was cancelled.
+    #[serde(rename = "agent.session.cancelled")]
+    AgentSessionCancelled(AgentSessionEventPayload),
     /// Workspace registry snapshot.
     #[serde(rename = "workspace.list.response")]
     WorkspaceListResponse(WorkspaceListPayload),
@@ -944,6 +963,44 @@ pub struct AgentStatusChangedPayload {
     /// Optional current task summary.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task: Option<String>,
+}
+
+/// Agent runtime session lifecycle payload.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct AgentSessionEventPayload {
+    /// Per-route agent runtime session ID.
+    pub agent_session_id: AgentSessionId,
+    /// Owning CADIS user session ID.
+    pub session_id: SessionId,
+    /// Route identifier that caused this agent session.
+    pub route_id: String,
+    /// Agent running the task.
+    pub agent_id: AgentId,
+    /// Parent agent for tree display and spawn accounting.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_agent_id: Option<AgentId>,
+    /// Current task summary.
+    pub task: String,
+    /// Runtime state machine status.
+    pub status: AgentSessionStatus,
+    /// Absolute timeout deadline.
+    pub timeout_at: Timestamp,
+    /// Step budget for this session.
+    pub budget_steps: u32,
+    /// Consumed step count.
+    pub steps_used: u32,
+    /// Redacted result summary for terminal success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+    /// Stable error code for terminal failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    /// Redacted error summary for terminal failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Cancellation request timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancellation_requested_at: Option<Timestamp>,
 }
 
 /// Workspace registry snapshot payload.
@@ -1387,6 +1444,8 @@ pub enum ApprovalDecision {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentStatus {
+    /// Agent is being created.
+    Spawning,
     /// Agent is idle.
     Idle,
     /// Agent is running.
@@ -1397,6 +1456,28 @@ pub enum AgentStatus {
     Completed,
     /// Agent failed.
     Failed,
+    /// Agent was cancelled.
+    Cancelled,
+}
+
+/// Agent runtime session status.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentSessionStatus {
+    /// Session was created and assigned.
+    Started,
+    /// Session is actively working.
+    Running,
+    /// Session completed successfully.
+    Completed,
+    /// Session failed.
+    Failed,
+    /// Session was cancelled.
+    Cancelled,
+    /// Session exceeded its timeout.
+    TimedOut,
+    /// Session exceeded its configured step budget.
+    BudgetExceeded,
 }
 
 /// Test status.
@@ -1792,6 +1873,59 @@ mod tests {
             }
             other => panic!("unexpected event: {other:?}"),
         }
+    }
+
+    #[test]
+    fn agent_session_event_serializes_runtime_metadata() {
+        let envelope = EventEnvelope::new(
+            EventId::from("evt_4"),
+            Timestamp::new_utc("2026-04-26T00:00:00Z").expect("timestamp should be UTC"),
+            "cadisd",
+            Some(SessionId::from("ses_1")),
+            CadisEvent::AgentSessionStarted(AgentSessionEventPayload {
+                agent_session_id: AgentSessionId::from("ags_000001"),
+                session_id: SessionId::from("ses_1"),
+                route_id: "route_000001".to_owned(),
+                agent_id: AgentId::from("coder"),
+                parent_agent_id: Some(AgentId::from("main")),
+                task: "run focused tests".to_owned(),
+                status: AgentSessionStatus::Running,
+                timeout_at: Timestamp::new_utc("2026-04-26T00:15:00Z")
+                    .expect("timestamp should be UTC"),
+                budget_steps: 1,
+                steps_used: 0,
+                result: None,
+                error_code: None,
+                error: None,
+                cancellation_requested_at: None,
+            }),
+        );
+
+        let value = serde_json::to_value(&envelope).expect("event should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "protocol_version": CURRENT_PROTOCOL_VERSION,
+                "event_id": "evt_4",
+                "timestamp": "2026-04-26T00:00:00Z",
+                "source": "cadisd",
+                "session_id": "ses_1",
+                "type": "agent.session.started",
+                "payload": {
+                    "agent_session_id": "ags_000001",
+                    "session_id": "ses_1",
+                    "route_id": "route_000001",
+                    "agent_id": "coder",
+                    "parent_agent_id": "main",
+                    "task": "run focused tests",
+                    "status": "running",
+                    "timeout_at": "2026-04-26T00:15:00Z",
+                    "budget_steps": 1,
+                    "steps_used": 0
+                }
+            })
+        );
     }
 
     #[test]

--- a/crates/cadis-protocol/src/lib.rs
+++ b/crates/cadis-protocol/src/lib.rs
@@ -1475,6 +1475,34 @@ mod tests {
     }
 
     #[test]
+    fn worker_tail_request_matches_documented_shape() {
+        let envelope = RequestEnvelope::new(
+            RequestId::from("req_1"),
+            ClientId::from("cli_1"),
+            ClientRequest::WorkerTail(WorkerTailRequest {
+                worker_id: "worker_000001".to_owned(),
+                lines: Some(20),
+            }),
+        );
+
+        let value = serde_json::to_value(&envelope).expect("request should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "protocol_version": CURRENT_PROTOCOL_VERSION,
+                "request_id": "req_1",
+                "client_id": "cli_1",
+                "type": "worker.tail",
+                "payload": {
+                    "worker_id": "worker_000001",
+                    "lines": 20
+                }
+            })
+        );
+    }
+
+    #[test]
     fn tool_call_request_matches_documented_shape() {
         let envelope = RequestEnvelope::new(
             RequestId::from("req_1"),

--- a/crates/cadis-protocol/src/lib.rs
+++ b/crates/cadis-protocol/src/lib.rs
@@ -381,7 +381,7 @@ pub enum ClientRequest {
     SessionCancel(SessionTargetRequest),
     /// Subscribe to a session stream.
     #[serde(rename = "session.subscribe")]
-    SessionSubscribe(SessionTargetRequest),
+    SessionSubscribe(SessionSubscriptionRequest),
     /// Unsubscribe from a session stream.
     #[serde(rename = "session.unsubscribe")]
     SessionUnsubscribe(SessionTargetRequest),
@@ -495,6 +495,22 @@ pub struct SessionCreateRequest {
 pub struct SessionTargetRequest {
     /// Target session ID.
     pub session_id: SessionId,
+}
+
+/// Payload for subscribing to one session's event stream.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct SessionSubscriptionRequest {
+    /// Target session ID.
+    pub session_id: SessionId,
+    /// Optional event ID. Buffered replay starts after this ID when still retained.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub since_event_id: Option<EventId>,
+    /// Maximum buffered matching events to replay before live events.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_limit: Option<u32>,
+    /// Whether the daemon should send the current session state before replay.
+    #[serde(default = "default_true")]
+    pub include_snapshot: bool,
 }
 
 /// Payload for a user message.
@@ -1475,6 +1491,38 @@ mod tests {
     }
 
     #[test]
+    fn session_subscription_request_matches_documented_shape() {
+        let envelope = RequestEnvelope::new(
+            RequestId::from("req_1"),
+            ClientId::from("cli_1"),
+            ClientRequest::SessionSubscribe(SessionSubscriptionRequest {
+                session_id: SessionId::from("ses_1"),
+                since_event_id: Some(EventId::from("evt_000010")),
+                replay_limit: Some(16),
+                include_snapshot: true,
+            }),
+        );
+
+        let value = serde_json::to_value(&envelope).expect("request should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "protocol_version": CURRENT_PROTOCOL_VERSION,
+                "request_id": "req_1",
+                "client_id": "cli_1",
+                "type": "session.subscribe",
+                "payload": {
+                    "session_id": "ses_1",
+                    "since_event_id": "evt_000010",
+                    "replay_limit": 16,
+                    "include_snapshot": true
+                }
+            })
+        );
+    }
+
+    #[test]
     fn tool_call_request_matches_documented_shape() {
         let envelope = RequestEnvelope::new(
             RequestId::from("req_1"),
@@ -1608,6 +1656,32 @@ mod tests {
         match envelope.request {
             ClientRequest::EventsSubscribe(payload) => {
                 assert!(payload.include_snapshot);
+                assert_eq!(payload.since_event_id, None);
+                assert_eq!(payload.replay_limit, None);
+            }
+            other => panic!("unexpected request: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_subscription_defaults_include_snapshot() {
+        let value = json!({
+            "protocol_version": CURRENT_PROTOCOL_VERSION,
+            "request_id": "req_1",
+            "client_id": "cli_1",
+            "type": "session.subscribe",
+            "payload": {
+                "session_id": "ses_1"
+            }
+        });
+
+        let envelope =
+            serde_json::from_value::<RequestEnvelope>(value).expect("request should parse");
+
+        match envelope.request {
+            ClientRequest::SessionSubscribe(payload) => {
+                assert!(payload.include_snapshot);
+                assert_eq!(payload.session_id.as_str(), "ses_1");
                 assert_eq!(payload.since_event_id, None);
                 assert_eq!(payload.replay_limit, None);
             }

--- a/crates/cadis-protocol/src/lib.rs
+++ b/crates/cadis-protocol/src/lib.rs
@@ -302,6 +302,7 @@ pub enum ServerFrame {
 }
 
 /// Immediate response returned for request handling failures or acknowledgements.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "type", content = "payload")]
 pub enum DaemonResponse {
@@ -343,6 +344,9 @@ pub struct DaemonStatusPayload {
     pub model_provider: String,
     /// Daemon uptime in seconds.
     pub uptime_seconds: u64,
+    /// Daemon-visible voice capability status.
+    #[serde(default)]
+    pub voice: VoiceStatusPayload,
 }
 
 /// Machine-readable error payload for responses and error events.
@@ -436,6 +440,15 @@ pub enum ClientRequest {
     /// Patch daemon-owned UI preferences.
     #[serde(rename = "ui.preferences.set")]
     UiPreferencesSet(UiPreferencesSetRequest),
+    /// Request daemon-visible voice capability status.
+    #[serde(rename = "voice.status")]
+    VoiceStatus(EmptyPayload),
+    /// Run daemon-visible voice diagnostics.
+    #[serde(rename = "voice.doctor")]
+    VoiceDoctor(VoiceDoctorRequest),
+    /// Report local HUD bridge preflight checks to the daemon.
+    #[serde(rename = "voice.preflight")]
+    VoicePreflight(VoicePreflightRequest),
     /// Preview voice output.
     #[serde(rename = "voice.preview")]
     VoicePreview(VoicePreviewRequest),
@@ -699,6 +712,36 @@ pub struct VoicePreferences {
     pub volume: i16,
 }
 
+/// Request payload for daemon-visible voice diagnostics.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct VoiceDoctorRequest {
+    /// Include the last local bridge preflight in the result when available.
+    #[serde(default = "default_true")]
+    pub include_bridge: bool,
+}
+
+impl Default for VoiceDoctorRequest {
+    fn default() -> Self {
+        Self {
+            include_bridge: true,
+        }
+    }
+}
+
+/// Request payload used by a local bridge to publish preflight results.
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+pub struct VoicePreflightRequest {
+    /// Client or bridge that performed the checks, for example `cadis-hud`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub surface: Option<String>,
+    /// Optional bridge-generated summary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    /// Local capture/playback checks performed outside the daemon.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub checks: Vec<VoiceDoctorCheck>,
+}
+
 /// Daemon events emitted by protocol version 0.1.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "type", content = "payload")]
@@ -769,6 +812,15 @@ pub enum CadisEvent {
     /// UI preferences changed.
     #[serde(rename = "ui.preferences.updated")]
     UiPreferencesUpdated(UiPreferencesPayload),
+    /// Voice capability status changed or was requested.
+    #[serde(rename = "voice.status.updated")]
+    VoiceStatusUpdated(VoiceStatusPayload),
+    /// Voice diagnostics result.
+    #[serde(rename = "voice.doctor.response")]
+    VoiceDoctorResponse(VoiceDoctorPayload),
+    /// Local bridge voice preflight was recorded by the daemon.
+    #[serde(rename = "voice.preflight.response")]
+    VoicePreflightResponse(VoiceDoctorPayload),
     /// Orchestrator routed a user request to an agent.
     #[serde(rename = "orchestrator.route")]
     OrchestratorRoute(OrchestratorRoutePayload),
@@ -1072,6 +1124,94 @@ pub enum ModelReadiness {
 pub struct UiPreferencesPayload {
     /// Full or partial preference object.
     pub preferences: serde_json::Value,
+}
+
+/// Daemon-visible voice capability state.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VoiceRuntimeState {
+    /// Voice is disabled in daemon-owned preferences.
+    Disabled,
+    /// Voice has no known blocking or warning diagnostics.
+    Ready,
+    /// Voice is usable but has warnings.
+    Degraded,
+    /// Voice has a blocking diagnostic.
+    Blocked,
+    /// The daemon has not seen enough information yet.
+    #[default]
+    Unknown,
+}
+
+/// Current daemon-visible voice status.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct VoiceStatusPayload {
+    /// Whether voice output is enabled in daemon-owned preferences.
+    pub enabled: bool,
+    /// Overall voice readiness.
+    pub state: VoiceRuntimeState,
+    /// Configured TTS provider.
+    pub provider: String,
+    /// Configured TTS voice identifier.
+    pub voice_id: String,
+    /// Configured STT language or `auto`.
+    pub stt_language: String,
+    /// Maximum characters eligible for direct speech output.
+    pub max_spoken_chars: usize,
+    /// Required local bridge mode for platform media APIs.
+    pub bridge: String,
+    /// Last local bridge preflight recorded by `voice.preflight`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_preflight: Option<VoicePreflightSummary>,
+}
+
+impl Default for VoiceStatusPayload {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            state: VoiceRuntimeState::Unknown,
+            provider: "edge".to_owned(),
+            voice_id: "id-ID-GadisNeural".to_owned(),
+            stt_language: "auto".to_owned(),
+            max_spoken_chars: 800,
+            bridge: "hud-local".to_owned(),
+            last_preflight: None,
+        }
+    }
+}
+
+/// One daemon or local bridge voice diagnostic check.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct VoiceDoctorCheck {
+    /// Stable check name.
+    pub name: String,
+    /// Result status, normally `ok`, `warn`, or `error`.
+    pub status: String,
+    /// Human-readable result.
+    #[serde(alias = "detail")]
+    pub message: String,
+}
+
+/// Summary of the last local bridge voice preflight.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct VoicePreflightSummary {
+    /// Client or bridge that performed the preflight.
+    pub surface: String,
+    /// Aggregated preflight status.
+    pub status: String,
+    /// Redacted human-readable summary.
+    pub summary: String,
+    /// UTC timestamp when the daemon recorded the preflight.
+    pub checked_at: Timestamp,
+}
+
+/// Voice diagnostics response payload.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct VoiceDoctorPayload {
+    /// Current daemon-visible voice status.
+    pub status: VoiceStatusPayload,
+    /// Checks performed or remembered by the daemon.
+    pub checks: Vec<VoiceDoctorCheck>,
 }
 
 /// Orchestrator routing decision payload.
@@ -1767,6 +1907,46 @@ mod tests {
     }
 
     #[test]
+    fn voice_preflight_request_matches_documented_shape() {
+        let envelope = RequestEnvelope::new(
+            RequestId::from("req_voice"),
+            ClientId::from("hud_1"),
+            ClientRequest::VoicePreflight(VoicePreflightRequest {
+                surface: Some("cadis-hud".to_owned()),
+                summary: Some("ready".to_owned()),
+                checks: vec![VoiceDoctorCheck {
+                    name: "microphone".to_owned(),
+                    status: "ok".to_owned(),
+                    message: "1 input visible".to_owned(),
+                }],
+            }),
+        );
+
+        let value = serde_json::to_value(&envelope).expect("request should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "protocol_version": CURRENT_PROTOCOL_VERSION,
+                "request_id": "req_voice",
+                "client_id": "hud_1",
+                "type": "voice.preflight",
+                "payload": {
+                    "surface": "cadis-hud",
+                    "summary": "ready",
+                    "checks": [
+                        {
+                            "name": "microphone",
+                            "status": "ok",
+                            "message": "1 input visible"
+                        }
+                    ]
+                }
+            })
+        );
+    }
+
+    #[test]
     fn server_response_frame_matches_transport_shape() {
         let frame = ServerFrame::Response(ResponseEnvelope::new(
             RequestId::from("req_1"),
@@ -1779,6 +1959,7 @@ mod tests {
                 sessions: 0,
                 model_provider: "echo".to_owned(),
                 uptime_seconds: 3,
+                voice: VoiceStatusPayload::default(),
             }),
         ));
 
@@ -1800,7 +1981,16 @@ mod tests {
                         "socket_path": "/run/user/1000/cadis/cadisd.sock",
                         "sessions": 0,
                         "model_provider": "echo",
-                        "uptime_seconds": 3
+                        "uptime_seconds": 3,
+                        "voice": {
+                            "enabled": false,
+                            "state": "unknown",
+                            "provider": "edge",
+                            "voice_id": "id-ID-GadisNeural",
+                            "stt_language": "auto",
+                            "max_spoken_chars": 800,
+                            "bridge": "hud-local"
+                        }
                     }
                 }
             })

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -80,8 +80,12 @@ impl Default for HudConfig {
 pub struct VoiceConfig {
     /// Whether voice output is enabled.
     pub enabled: bool,
+    /// TTS provider identifier.
+    pub provider: String,
     /// Voice identifier.
     pub voice_id: String,
+    /// STT language, usually `auto` or an ISO 639-1 language code.
+    pub stt_language: String,
     /// Speaking rate adjustment.
     pub rate: i16,
     /// Pitch adjustment.
@@ -90,17 +94,22 @@ pub struct VoiceConfig {
     pub volume: i16,
     /// Whether completed assistant messages should be spoken.
     pub auto_speak: bool,
+    /// Maximum response length eligible for direct speech.
+    pub max_spoken_chars: usize,
 }
 
 impl Default for VoiceConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            provider: "edge".to_owned(),
             voice_id: "id-ID-GadisNeural".to_owned(),
+            stt_language: "auto".to_owned(),
             rate: 0,
             pitch: 0,
             volume: 0,
             auto_speak: false,
+            max_spoken_chars: 800,
         }
     }
 }
@@ -228,11 +237,14 @@ impl CadisConfig {
             },
             "voice": {
                 "enabled": self.voice.enabled,
+                "provider": self.voice.provider,
                 "voice_id": self.voice.voice_id,
+                "stt_language": self.voice.stt_language,
                 "rate": self.voice.rate,
                 "pitch": self.voice.pitch,
                 "volume": self.voice.volume,
-                "auto_speak": self.voice.auto_speak
+                "auto_speak": self.voice.auto_speak,
+                "max_spoken_chars": self.voice.max_spoken_chars
             },
             "agent_spawn": {
                 "max_depth": self.agent_spawn.max_depth,
@@ -1598,6 +1610,34 @@ mod tests {
         assert_eq!(
             config.ui_preferences()["agent_spawn"]["max_children_per_parent"],
             serde_json::json!(2)
+        );
+    }
+
+    #[test]
+    fn parses_daemon_owned_voice_config() {
+        let config = toml::from_str::<CadisConfig>(
+            r#"
+            [voice]
+            enabled = true
+            provider = "system"
+            voice_id = "en-US-AvaNeural"
+            stt_language = "id"
+            rate = 5
+            pitch = -5
+            volume = 10
+            auto_speak = true
+            max_spoken_chars = 500
+            "#,
+        )
+        .expect("voice config should parse");
+
+        assert!(config.voice.enabled);
+        assert_eq!(config.voice.provider, "system");
+        assert_eq!(config.voice.stt_language, "id");
+        assert_eq!(config.voice.max_spoken_chars, 500);
+        assert_eq!(
+            config.ui_preferences()["voice"]["provider"],
+            serde_json::json!("system")
         );
     }
 

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -11,8 +11,8 @@ use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use cadis_protocol::{
-    AgentId, ApprovalDecision, ApprovalId, EventEnvelope, RiskClass, SessionId, Timestamp,
-    ToolCallId,
+    AgentId, AgentSessionId, ApprovalDecision, ApprovalId, EventEnvelope, RiskClass, SessionId,
+    Timestamp, ToolCallId,
 };
 use regex::Regex;
 use serde::de::DeserializeOwned;
@@ -981,6 +981,7 @@ pub fn ensure_layout(config: &CadisConfig) -> Result<(), StoreError> {
         "state",
         "state/sessions",
         "state/agents",
+        "state/agent-sessions",
         "state/workers",
         "state/approvals",
     ] {
@@ -1065,6 +1066,11 @@ impl StateStore {
         self.metadata_path(StateKind::Agent, agent_id.as_str())
     }
 
+    /// Returns the AgentSession metadata file path for an AgentSession ID.
+    pub fn agent_session_path(&self, agent_session_id: &AgentSessionId) -> PathBuf {
+        self.metadata_path(StateKind::AgentSession, agent_session_id.as_str())
+    }
+
     /// Returns the worker metadata file path for a worker ID.
     pub fn worker_path(&self, worker_id: &str) -> PathBuf {
         self.metadata_path(StateKind::Worker, worker_id)
@@ -1091,6 +1097,15 @@ impl StateStore {
         metadata: &T,
     ) -> Result<(), StoreError> {
         self.write_metadata(StateKind::Agent, agent_id.as_str(), metadata)
+    }
+
+    /// Atomically writes one redacted AgentSession metadata JSON file.
+    pub fn write_agent_session_metadata<T: Serialize>(
+        &self,
+        agent_session_id: &AgentSessionId,
+        metadata: &T,
+    ) -> Result<(), StoreError> {
+        self.write_metadata(StateKind::AgentSession, agent_session_id.as_str(), metadata)
     }
 
     /// Atomically writes one redacted worker metadata JSON file.
@@ -1121,6 +1136,14 @@ impl StateStore {
         self.remove_metadata(StateKind::Agent, agent_id.as_str())
     }
 
+    /// Removes one persisted AgentSession metadata JSON file when present.
+    pub fn remove_agent_session_metadata(
+        &self,
+        agent_session_id: &AgentSessionId,
+    ) -> Result<(), StoreError> {
+        self.remove_metadata(StateKind::AgentSession, agent_session_id.as_str())
+    }
+
     /// Removes one persisted worker metadata JSON file when present.
     pub fn remove_worker_metadata(&self, worker_id: &str) -> Result<(), StoreError> {
         self.remove_metadata(StateKind::Worker, worker_id)
@@ -1143,6 +1166,13 @@ impl StateStore {
         &self,
     ) -> Result<StateRecovery<T>, StoreError> {
         self.recover_metadata(StateKind::Agent)
+    }
+
+    /// Recovers valid AgentSession metadata files and reports invalid files as diagnostics.
+    pub fn recover_agent_session_metadata<T: DeserializeOwned>(
+        &self,
+    ) -> Result<StateRecovery<T>, StoreError> {
+        self.recover_metadata(StateKind::AgentSession)
     }
 
     /// Recovers valid worker metadata files and reports invalid files as diagnostics.
@@ -1303,19 +1333,27 @@ pub struct StateRecoveryDiagnostic {
 enum StateKind {
     Session,
     Agent,
+    AgentSession,
     Worker,
     Approval,
 }
 
 impl StateKind {
-    fn all() -> [Self; 4] {
-        [Self::Session, Self::Agent, Self::Worker, Self::Approval]
+    fn all() -> [Self; 5] {
+        [
+            Self::Session,
+            Self::Agent,
+            Self::AgentSession,
+            Self::Worker,
+            Self::Approval,
+        ]
     }
 
     fn dir_name(self) -> &'static str {
         match self {
             Self::Session => "sessions",
             Self::Agent => "agents",
+            Self::AgentSession => "agent-sessions",
             Self::Worker => "workers",
             Self::Approval => "approvals",
         }
@@ -1325,6 +1363,7 @@ impl StateKind {
         match self {
             Self::Session => "session",
             Self::Agent => "agent",
+            Self::AgentSession => "AgentSession",
             Self::Worker => "worker",
             Self::Approval => "approval",
         }
@@ -1757,6 +1796,7 @@ mod tests {
             config.cadis_home.join("state/sessions/ses____1.json")
         );
         assert!(config.cadis_home.join("state/agents").is_dir());
+        assert!(config.cadis_home.join("state/agent-sessions").is_dir());
         assert!(config.cadis_home.join("state/workers").is_dir());
         assert!(config.cadis_home.join("state/approvals").is_dir());
     }
@@ -1827,6 +1867,71 @@ mod tests {
         assert!(recovered.diagnostics[0]
             .reason
             .contains("invalid session metadata JSON"));
+    }
+
+    #[test]
+    fn agent_session_metadata_round_trips_from_dedicated_state_dir() {
+        let config = test_config("agent-session-write");
+        let store = StateStore::new(&config);
+        let agent_session_id = AgentSessionId::from("ags/../1");
+        let metadata = TestMetadata {
+            id: "ags/../1".to_owned(),
+            status: "running".to_owned(),
+            api_key: None,
+        };
+
+        store
+            .write_agent_session_metadata(&agent_session_id, &metadata)
+            .expect("AgentSession metadata should write");
+
+        assert_eq!(
+            store.agent_session_path(&agent_session_id),
+            config.cadis_home.join("state/agent-sessions/ags____1.json")
+        );
+
+        let recovered = store
+            .recover_agent_session_metadata::<TestMetadata>()
+            .expect("AgentSession metadata should recover");
+        assert_eq!(recovered.diagnostics, Vec::new());
+        assert_eq!(recovered.records.len(), 1);
+        assert_eq!(recovered.records[0].id, "ags____1");
+        assert_eq!(recovered.records[0].metadata, metadata);
+    }
+
+    #[test]
+    fn agent_session_recovery_skips_corrupt_json_and_partial_temp_files() {
+        let config = test_config("agent-session-recover");
+        let store = StateStore::new(&config);
+        let agent_session_id = AgentSessionId::from("ags_1");
+        let metadata = TestMetadata {
+            id: "ags_1".to_owned(),
+            status: "running".to_owned(),
+            api_key: None,
+        };
+
+        store
+            .write_agent_session_metadata(&agent_session_id, &metadata)
+            .expect("AgentSession metadata should write");
+        let agent_sessions_dir = config.cadis_home.join("state/agent-sessions");
+        fs::write(agent_sessions_dir.join("corrupt.json"), "{")
+            .expect("corrupt AgentSession state should write");
+        fs::write(agent_sessions_dir.join(".ags_2.json.tmp.1"), "{")
+            .expect("partial AgentSession temp state should write");
+
+        let recovered = store
+            .recover_agent_session_metadata::<TestMetadata>()
+            .expect("AgentSession recovery should fail safe");
+
+        assert_eq!(recovered.records.len(), 1);
+        assert_eq!(recovered.records[0].id, "ags_1");
+        assert_eq!(recovered.records[0].metadata, metadata);
+        assert_eq!(recovered.diagnostics.len(), 1);
+        assert!(recovered.diagnostics[0]
+            .path
+            .ends_with("state/agent-sessions/corrupt.json"));
+        assert!(recovered.diagnostics[0]
+            .reason
+            .contains("invalid AgentSession metadata JSON"));
     }
 
     #[test]

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -397,6 +397,11 @@ impl ProfileHome {
             .join(safe_file_stem(agent_id.as_ref()))
     }
 
+    /// Returns a persistent agent-home resolver.
+    pub fn agent(&self, agent_id: impl AsRef<str>) -> AgentHome {
+        AgentHome::new(self.clone(), agent_id)
+    }
+
     /// Returns the profile workspace metadata directory.
     pub fn workspaces_dir(&self) -> PathBuf {
         self.root.join("workspaces")
@@ -466,6 +471,47 @@ impl ProfileHome {
         Ok(())
     }
 
+    /// Initializes one persistent agent home without overwriting user edits.
+    pub fn init_agent(&self, template: &AgentHomeTemplate) -> Result<AgentHome, StoreError> {
+        let agent = self.agent(template.agent_id.as_str());
+        agent.init_template(template)?;
+        Ok(agent)
+    }
+
+    /// Runs lightweight profile and agent-home diagnostics.
+    pub fn agent_doctor_diagnostics(
+        &self,
+        options: AgentHomeDoctorOptions,
+    ) -> Result<Vec<AgentHomeDiagnostic>, StoreError> {
+        self.ensure_layout()?;
+
+        let agents_dir = self.root.join("agents");
+        let mut diagnostics = Vec::new();
+        let mut count = 0usize;
+        for entry in fs::read_dir(&agents_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            count += 1;
+            let agent_id = path
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or("unknown");
+            diagnostics.extend(AgentHome::from_root(agent_id.to_owned(), path).doctor(&options));
+        }
+
+        diagnostics.push(AgentHomeDiagnostic {
+            name: "profile.agents".to_owned(),
+            status: if count == 0 { "warn" } else { "ok" }.to_owned(),
+            message: format!("{count} agent home(s) found"),
+        });
+
+        Ok(diagnostics)
+    }
+
     /// Creates a workspace registry helper for this profile.
     pub fn workspace_registry(&self) -> WorkspaceRegistryStore {
         WorkspaceRegistryStore::new(self.clone())
@@ -475,6 +521,505 @@ impl ProfileHome {
     pub fn workspace_grants(&self) -> WorkspaceGrantStore {
         WorkspaceGrantStore::new(self.clone())
     }
+}
+
+/// Persistent agent-home resolver rooted under a profile.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentHome {
+    agent_id: String,
+    root: PathBuf,
+}
+
+impl AgentHome {
+    /// Creates an agent-home resolver for a profile.
+    pub fn new(profile_home: ProfileHome, agent_id: impl AsRef<str>) -> Self {
+        let agent_id = safe_file_stem(agent_id.as_ref());
+        Self {
+            root: profile_home.agent_home(&agent_id),
+            agent_id,
+        }
+    }
+
+    fn from_root(agent_id: String, root: PathBuf) -> Self {
+        Self { agent_id, root }
+    }
+
+    /// Returns the safe profile-local agent ID component.
+    pub fn agent_id(&self) -> &str {
+        &self.agent_id
+    }
+
+    /// Returns the agent-home root.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Returns the path to `AGENT.toml`.
+    pub fn agent_toml_path(&self) -> PathBuf {
+        self.root.join("AGENT.toml")
+    }
+
+    /// Returns the path to `POLICY.toml`.
+    pub fn policy_toml_path(&self) -> PathBuf {
+        self.root.join("POLICY.toml")
+    }
+
+    /// Ensures the agent-home directory skeleton exists with private permissions.
+    pub fn ensure_layout(&self) -> Result<(), StoreError> {
+        create_private_dir(&self.root)?;
+        for path in ["skills", "memory", "memory/daily", "prompts", "sessions"] {
+            create_private_dir(&self.root.join(path))?;
+        }
+        Ok(())
+    }
+
+    /// Initializes agent templates without overwriting user edits.
+    pub fn init_template(&self, template: &AgentHomeTemplate) -> Result<(), StoreError> {
+        self.ensure_layout()?;
+        write_template_file_if_missing(&self.agent_toml_path(), &agent_toml_template(template)?)?;
+        write_template_file_if_missing(&self.root.join("PERSONA.md"), &persona_template(template))?;
+        write_template_file_if_missing(
+            &self.root.join("INSTRUCTIONS.md"),
+            &instructions_template(template),
+        )?;
+        write_template_file_if_missing(&self.root.join("USER.md"), user_template())?;
+        write_template_file_if_missing(&self.root.join("MEMORY.md"), memory_template())?;
+        write_template_file_if_missing(&self.root.join("TOOLS.md"), tools_template())?;
+        write_template_file_if_missing(&self.policy_toml_path(), &agent_policy_toml_template()?)?;
+        write_template_file_if_missing(
+            &self.root.join("SKILL_POLICY.toml"),
+            &skill_policy_toml_template()?,
+        )?;
+        write_template_file_if_missing(&self.root.join("README.md"), agent_readme_template())?;
+        write_template_file_if_missing(&self.root.join("memory/decisions.md"), "# Decisions\n")?;
+        write_template_file_if_missing(&self.root.join("memory/delegation.md"), "# Delegation\n")?;
+        Ok(())
+    }
+
+    /// Loads typed `AGENT.toml` metadata.
+    pub fn load_metadata(&self) -> Result<AgentMetadataToml, StoreError> {
+        let content = fs::read_to_string(self.agent_toml_path())?;
+        Ok(toml::from_str::<AgentMetadataToml>(&content)?)
+    }
+
+    /// Loads typed `POLICY.toml` metadata.
+    pub fn load_policy(&self) -> Result<AgentPolicyToml, StoreError> {
+        let content = fs::read_to_string(self.policy_toml_path())?;
+        Ok(toml::from_str::<AgentPolicyToml>(&content)?)
+    }
+
+    /// Runs missing/corrupt/oversized checks for this agent home.
+    pub fn doctor(&self, options: &AgentHomeDoctorOptions) -> Vec<AgentHomeDiagnostic> {
+        let mut diagnostics = Vec::new();
+        diagnostics.extend(self.toml_check(
+            "agent.AGENT.toml",
+            &self.agent_toml_path(),
+            options.max_agent_toml_bytes,
+            |content| toml::from_str::<AgentMetadataToml>(content).map(|_| ()),
+        ));
+        diagnostics.extend(self.toml_check(
+            "agent.POLICY.toml",
+            &self.policy_toml_path(),
+            options.max_policy_toml_bytes,
+            |content| toml::from_str::<AgentPolicyToml>(content).map(|_| ()),
+        ));
+        diagnostics.extend(self.toml_check(
+            "agent.SKILL_POLICY.toml",
+            &self.root.join("SKILL_POLICY.toml"),
+            options.max_policy_toml_bytes,
+            |content| toml::from_str::<SkillPolicyToml>(content).map(|_| ()),
+        ));
+
+        for file_name in ["PERSONA.md", "INSTRUCTIONS.md", "USER.md", "TOOLS.md"] {
+            diagnostics.push(self.text_file_check(
+                &format!("agent.{file_name}"),
+                &self.root.join(file_name),
+                options.max_text_file_bytes,
+            ));
+        }
+        diagnostics.push(self.text_file_check(
+            "agent.MEMORY.md",
+            &self.root.join("MEMORY.md"),
+            options.max_memory_file_bytes,
+        ));
+        diagnostics.push(self.text_file_check(
+            "agent.memory.decisions",
+            &self.root.join("memory/decisions.md"),
+            options.max_memory_file_bytes,
+        ));
+        diagnostics.push(self.text_file_check(
+            "agent.memory.delegation",
+            &self.root.join("memory/delegation.md"),
+            options.max_memory_file_bytes,
+        ));
+
+        diagnostics
+    }
+
+    fn toml_check(
+        &self,
+        name: &str,
+        path: &Path,
+        max_bytes: u64,
+        parse: impl FnOnce(&str) -> Result<(), toml::de::Error>,
+    ) -> Vec<AgentHomeDiagnostic> {
+        let mut diagnostics = Vec::new();
+        match fs::metadata(path) {
+            Ok(metadata) if !metadata.is_file() => {
+                diagnostics.push(self.diagnostic(
+                    name,
+                    "error",
+                    format!("{} is not a file", path.display()),
+                ));
+                return diagnostics;
+            }
+            Ok(metadata) => {
+                if metadata.len() > max_bytes {
+                    diagnostics.push(self.diagnostic(
+                        name,
+                        "warn",
+                        format!(
+                            "{} is {} bytes; limit is {max_bytes}",
+                            path.display(),
+                            metadata.len()
+                        ),
+                    ));
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                diagnostics.push(self.diagnostic(
+                    name,
+                    "error",
+                    format!("{} is missing", path.display()),
+                ));
+                return diagnostics;
+            }
+            Err(error) => {
+                diagnostics.push(self.diagnostic(
+                    name,
+                    "error",
+                    format!("could not stat {}: {error}", path.display()),
+                ));
+                return diagnostics;
+            }
+        }
+
+        match fs::read_to_string(path) {
+            Ok(content) => match parse(&content) {
+                Ok(()) => diagnostics.push(self.diagnostic(
+                    name,
+                    "ok",
+                    format!("{} is valid", path.display()),
+                )),
+                Err(error) => diagnostics.push(self.diagnostic(
+                    name,
+                    "error",
+                    format!("{} is invalid TOML: {error}", path.display()),
+                )),
+            },
+            Err(error) => diagnostics.push(self.diagnostic(
+                name,
+                "error",
+                format!("could not read {}: {error}", path.display()),
+            )),
+        }
+        diagnostics
+    }
+
+    fn text_file_check(&self, name: &str, path: &Path, max_bytes: u64) -> AgentHomeDiagnostic {
+        match fs::metadata(path) {
+            Ok(metadata) if !metadata.is_file() => {
+                self.diagnostic(name, "error", format!("{} is not a file", path.display()))
+            }
+            Ok(metadata) if metadata.len() > max_bytes => self.diagnostic(
+                name,
+                "warn",
+                format!(
+                    "{} is {} bytes; limit is {max_bytes}",
+                    path.display(),
+                    metadata.len()
+                ),
+            ),
+            Ok(_) => self.diagnostic(name, "ok", format!("{} exists", path.display())),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                self.diagnostic(name, "warn", format!("{} is missing", path.display()))
+            }
+            Err(error) => self.diagnostic(
+                name,
+                "error",
+                format!("could not stat {}: {error}", path.display()),
+            ),
+        }
+    }
+
+    fn diagnostic(
+        &self,
+        name: &str,
+        status: impl Into<String>,
+        message: impl Into<String>,
+    ) -> AgentHomeDiagnostic {
+        AgentHomeDiagnostic {
+            name: format!("{}/{}", self.agent_id, name),
+            status: status.into(),
+            message: message.into(),
+        }
+    }
+}
+
+/// Template metadata used to initialize an agent home.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentHomeTemplate {
+    /// Stable agent ID.
+    pub agent_id: AgentId,
+    /// User-visible agent name.
+    pub display_name: String,
+    /// Agent role.
+    pub role: String,
+    /// Parent agent ID when this is a child/subagent.
+    pub parent_agent_id: Option<AgentId>,
+    /// Default model selection.
+    pub model: String,
+}
+
+impl AgentHomeTemplate {
+    /// Creates a template descriptor.
+    pub fn new(
+        agent_id: AgentId,
+        display_name: impl Into<String>,
+        role: impl Into<String>,
+        parent_agent_id: Option<AgentId>,
+        model: impl Into<String>,
+    ) -> Self {
+        Self {
+            agent_id,
+            display_name: display_name.into(),
+            role: role.into(),
+            parent_agent_id,
+            model: model.into(),
+        }
+    }
+}
+
+/// Typed `AGENT.toml` metadata.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AgentMetadataToml {
+    /// Agent identity and display metadata.
+    pub agent: AgentIdentityToml,
+    /// Conventional files inside the agent home.
+    pub files: AgentFilesToml,
+}
+
+/// Identity section for `AGENT.toml`.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AgentIdentityToml {
+    /// Stable agent ID.
+    pub id: String,
+    /// User-visible agent name.
+    pub display_name: String,
+    /// Runtime role.
+    pub role: String,
+    /// Optional parent agent ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_agent_id: Option<String>,
+    /// Default model selection.
+    pub model: String,
+}
+
+impl Default for AgentIdentityToml {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            display_name: String::new(),
+            role: String::new(),
+            parent_agent_id: None,
+            model: "auto".to_owned(),
+        }
+    }
+}
+
+/// Conventional file paths section for `AGENT.toml`.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AgentFilesToml {
+    /// Persona markdown path.
+    pub persona: PathBuf,
+    /// Runtime instructions markdown path.
+    pub instructions: PathBuf,
+    /// User preferences markdown path.
+    pub user: PathBuf,
+    /// Agent memory markdown path.
+    pub memory: PathBuf,
+    /// Tool guidance markdown path.
+    pub tools: PathBuf,
+    /// Machine-readable policy TOML path.
+    pub policy: PathBuf,
+    /// Machine-readable skill policy TOML path.
+    pub skill_policy: PathBuf,
+}
+
+impl Default for AgentFilesToml {
+    fn default() -> Self {
+        Self {
+            persona: PathBuf::from("PERSONA.md"),
+            instructions: PathBuf::from("INSTRUCTIONS.md"),
+            user: PathBuf::from("USER.md"),
+            memory: PathBuf::from("MEMORY.md"),
+            tools: PathBuf::from("TOOLS.md"),
+            policy: PathBuf::from("POLICY.toml"),
+            skill_policy: PathBuf::from("SKILL_POLICY.toml"),
+        }
+    }
+}
+
+/// Typed `POLICY.toml` metadata. Runtime enforcement remains daemon/policy-owned.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AgentPolicyToml {
+    /// Policy capability defaults.
+    pub policy: AgentPolicyDefaultsToml,
+    /// Sandbox path defaults.
+    pub sandbox: AgentSandboxToml,
+    /// File-size guardrails for profile/agent doctor checks.
+    pub limits: AgentPolicyLimitsToml,
+}
+
+/// Policy defaults section for `POLICY.toml`.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AgentPolicyDefaultsToml {
+    /// Schema version for future migrations.
+    pub version: u32,
+    /// Default workspace access metadata.
+    pub default_workspace_access: Vec<WorkspaceAccess>,
+    /// Whether network-capable tools are allowed without additional policy.
+    pub allow_network: bool,
+    /// Whether secret access is allowed without additional policy.
+    pub allow_secret_access: bool,
+    /// Whether system-changing tools are allowed without additional policy.
+    pub allow_system_change: bool,
+    /// Whether non-safe actions require approval.
+    pub approval_required: bool,
+}
+
+impl Default for AgentPolicyDefaultsToml {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            default_workspace_access: vec![WorkspaceAccess::Read],
+            allow_network: false,
+            allow_secret_access: false,
+            allow_system_change: false,
+            approval_required: true,
+        }
+    }
+}
+
+/// Sandbox defaults section for `POLICY.toml`.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AgentSandboxToml {
+    /// Default sandbox mode label.
+    pub default: String,
+    /// Metadata denied paths. Track D/tool runtime owns enforcement.
+    pub denied_paths: Vec<PathBuf>,
+}
+
+impl Default for AgentSandboxToml {
+    fn default() -> Self {
+        Self {
+            default: "workspace".to_owned(),
+            denied_paths: default_agent_denied_paths(),
+        }
+    }
+}
+
+/// Doctor guardrail limits section for `POLICY.toml`.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AgentPolicyLimitsToml {
+    /// Maximum `AGENT.toml` size.
+    pub max_agent_toml_bytes: u64,
+    /// Maximum `POLICY.toml` size.
+    pub max_policy_toml_bytes: u64,
+    /// Maximum persona/instruction/user/tool guidance file size.
+    pub max_text_file_bytes: u64,
+    /// Maximum memory markdown file size.
+    pub max_memory_file_bytes: u64,
+}
+
+impl Default for AgentPolicyLimitsToml {
+    fn default() -> Self {
+        Self {
+            max_agent_toml_bytes: 64 * 1024,
+            max_policy_toml_bytes: 64 * 1024,
+            max_text_file_bytes: 128 * 1024,
+            max_memory_file_bytes: 1024 * 1024,
+        }
+    }
+}
+
+/// Typed `SKILL_POLICY.toml` metadata.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct SkillPolicyToml {
+    /// Whether agent-local skills are active.
+    pub enabled: bool,
+    /// Skill precedence labels for this agent home.
+    pub precedence: Vec<String>,
+    /// Whether generated skill candidates require review.
+    pub require_review: bool,
+}
+
+impl Default for SkillPolicyToml {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            precedence: vec![
+                "agent".to_owned(),
+                "workspace".to_owned(),
+                "profile".to_owned(),
+            ],
+            require_review: true,
+        }
+    }
+}
+
+/// Agent-home doctor options.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AgentHomeDoctorOptions {
+    /// Maximum `AGENT.toml` size.
+    pub max_agent_toml_bytes: u64,
+    /// Maximum `POLICY.toml` size.
+    pub max_policy_toml_bytes: u64,
+    /// Maximum persona/instruction/user/tool guidance file size.
+    pub max_text_file_bytes: u64,
+    /// Maximum memory markdown file size.
+    pub max_memory_file_bytes: u64,
+}
+
+impl Default for AgentHomeDoctorOptions {
+    fn default() -> Self {
+        let limits = AgentPolicyLimitsToml::default();
+        Self {
+            max_agent_toml_bytes: limits.max_agent_toml_bytes,
+            max_policy_toml_bytes: limits.max_policy_toml_bytes,
+            max_text_file_bytes: limits.max_text_file_bytes,
+            max_memory_file_bytes: limits.max_memory_file_bytes,
+        }
+    }
+}
+
+/// One profile/agent-home doctor diagnostic.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentHomeDiagnostic {
+    /// Check name.
+    pub name: String,
+    /// `ok`, `warn`, or `error`.
+    pub status: String,
+    /// Human-readable diagnostic.
+    pub message: String,
 }
 
 /// Profile-local workspace registry stored as TOML.
@@ -1509,8 +2054,91 @@ fn profile_gitignore_template() -> &'static str {
     ".env\nsecrets/\nchannels/\nsessions/\nworkers/\ncheckpoints/\nsandboxes/\nlogs/\nlocks/\nrun/\n*.key\n*.pem\n*.token\n*.sqlite-wal\n*.sqlite-shm\n"
 }
 
+fn agent_toml_template(template: &AgentHomeTemplate) -> Result<String, StoreError> {
+    let metadata = AgentMetadataToml {
+        agent: AgentIdentityToml {
+            id: template.agent_id.to_string(),
+            display_name: template.display_name.clone(),
+            role: template.role.clone(),
+            parent_agent_id: template.parent_agent_id.as_ref().map(ToString::to_string),
+            model: template.model.clone(),
+        },
+        files: AgentFilesToml::default(),
+    };
+    let mut toml = redact(&toml::to_string_pretty(&metadata)?);
+    if !toml.ends_with('\n') {
+        toml.push('\n');
+    }
+    Ok(toml)
+}
+
+fn agent_policy_toml_template() -> Result<String, StoreError> {
+    let mut toml = toml::to_string_pretty(&AgentPolicyToml::default())?;
+    if !toml.ends_with('\n') {
+        toml.push('\n');
+    }
+    Ok(toml)
+}
+
+fn skill_policy_toml_template() -> Result<String, StoreError> {
+    let mut toml = toml::to_string_pretty(&SkillPolicyToml::default())?;
+    if !toml.ends_with('\n') {
+        toml.push('\n');
+    }
+    Ok(toml)
+}
+
+fn persona_template(template: &AgentHomeTemplate) -> String {
+    format!(
+        "# Persona\n\n{} is a CADIS agent with the {} role.\n",
+        template.display_name, template.role
+    )
+}
+
+fn instructions_template(template: &AgentHomeTemplate) -> String {
+    format!(
+        "# Instructions\n\nFollow CADIS daemon-owned policy and workspace grants for the {} role.\n",
+        template.role
+    )
+}
+
+fn user_template() -> &'static str {
+    "# User\n\nProfile-specific user preferences may be summarized here.\n"
+}
+
+fn memory_template() -> &'static str {
+    "# Memory\n\nDurable agent memory notes may be promoted here after review.\n"
+}
+
+fn tools_template() -> &'static str {
+    "# Tools\n\nThis file is guidance only. Hard permissions belong in POLICY.toml and daemon policy.\n"
+}
+
+fn agent_readme_template() -> &'static str {
+    "# Agent Home\n\nThis directory stores persistent agent identity, instructions, memory, skills, and policy metadata. It is not a project workspace.\n"
+}
+
 fn project_gitignore_template() -> &'static str {
     "worktrees/\nartifacts/\ntmp/\nlogs/\n*.key\n*.pem\n*.token\n.env\n"
+}
+
+fn default_agent_denied_paths() -> Vec<PathBuf> {
+    [
+        "~/.ssh",
+        "~/.aws",
+        "~/.gnupg",
+        "~/.config/gcloud",
+        "~/.cadis/profiles/*/.env",
+        "~/.cadis/profiles/*/secrets",
+        "~/.cadis/profiles/*/channels/*/tokens",
+        "/etc",
+        "/dev",
+        "/proc",
+        "/sys",
+    ]
+    .into_iter()
+    .map(PathBuf::from)
+    .collect()
 }
 
 fn expand_home(path: &Path) -> PathBuf {
@@ -1951,6 +2579,93 @@ mod tests {
         let registry =
             fs::read_to_string(profile.workspace_registry_path()).expect("registry should exist");
         assert_eq!(registry, "workspace = []\n");
+    }
+
+    #[test]
+    fn agent_home_initializes_typed_templates() {
+        let config = test_config("agent-home");
+        let profile = CadisHome::new(&config.cadis_home)
+            .init_profile("default")
+            .expect("profile should initialize");
+        let template = AgentHomeTemplate::new(
+            AgentId::from("coder/main"),
+            "Coder",
+            "Coding",
+            Some(AgentId::from("main")),
+            "echo",
+        );
+
+        let agent = profile
+            .init_agent(&template)
+            .expect("agent home should initialize");
+
+        assert!(agent.root().ends_with("agents/coder_main"));
+        assert!(agent.root().join("PERSONA.md").is_file());
+        assert!(agent.root().join("INSTRUCTIONS.md").is_file());
+        assert!(agent.root().join("MEMORY.md").is_file());
+        assert!(agent.root().join("TOOLS.md").is_file());
+        assert!(agent.root().join("SKILL_POLICY.toml").is_file());
+        assert!(agent.root().join("memory/daily").is_dir());
+        assert!(agent.root().join("memory/decisions.md").is_file());
+
+        let metadata = agent.load_metadata().expect("AGENT.toml should parse");
+        assert_eq!(metadata.agent.id, "coder/main");
+        assert_eq!(metadata.agent.display_name, "Coder");
+        assert_eq!(metadata.agent.role, "Coding");
+        assert_eq!(metadata.agent.parent_agent_id.as_deref(), Some("main"));
+        assert_eq!(metadata.files.policy, PathBuf::from("POLICY.toml"));
+
+        let policy = agent.load_policy().expect("POLICY.toml should parse");
+        assert_eq!(policy.policy.version, 1);
+        assert_eq!(
+            policy.policy.default_workspace_access,
+            vec![WorkspaceAccess::Read]
+        );
+        assert!(policy
+            .sandbox
+            .denied_paths
+            .contains(&PathBuf::from("~/.ssh")));
+        assert!(policy.policy.approval_required);
+    }
+
+    #[test]
+    fn agent_doctor_reports_corrupt_and_oversized_files() {
+        let config = test_config("agent-doctor");
+        let profile = CadisHome::new(&config.cadis_home)
+            .init_profile("default")
+            .expect("profile should initialize");
+        let agent = profile
+            .init_agent(&AgentHomeTemplate::new(
+                AgentId::from("main"),
+                "CADIS",
+                "Orchestrator",
+                None,
+                "echo",
+            ))
+            .expect("agent home should initialize");
+
+        fs::write(agent.policy_toml_path(), "[policy\n").expect("corrupt policy should write");
+        fs::write(agent.root().join("PERSONA.md"), "x".repeat(128))
+            .expect("oversized persona should write");
+
+        let diagnostics = profile
+            .agent_doctor_diagnostics(AgentHomeDoctorOptions {
+                max_agent_toml_bytes: 1024,
+                max_policy_toml_bytes: 1024,
+                max_text_file_bytes: 16,
+                max_memory_file_bytes: 1024,
+            })
+            .expect("agent doctor should run");
+
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.name == "main/agent.POLICY.toml" && diagnostic.status == "error"
+        }));
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.name == "main/agent.PERSONA.md" && diagnostic.status == "warn"
+        }));
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.name == "profile.agents" && diagnostic.message == "1 agent home(s) found"
+        }));
     }
 
     #[test]

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -422,6 +422,26 @@ impl ProfileHome {
         self.workspaces_dir().join("grants.jsonl")
     }
 
+    /// Returns the profile worker artifact root.
+    pub fn worker_artifacts_dir(&self) -> PathBuf {
+        self.root.join("artifacts").join("workers")
+    }
+
+    /// Returns conventional artifact paths for one worker.
+    pub fn worker_artifact_paths(&self, worker_id: impl AsRef<str>) -> WorkerArtifactPathSet {
+        WorkerArtifactPathSet::new(self.worker_artifacts_dir(), worker_id)
+    }
+
+    /// Ensures the artifact root for one worker exists.
+    pub fn ensure_worker_artifact_layout(
+        &self,
+        worker_id: impl AsRef<str>,
+    ) -> Result<WorkerArtifactPathSet, StoreError> {
+        let paths = self.worker_artifact_paths(worker_id);
+        create_private_dir(&paths.root)?;
+        Ok(paths)
+    }
+
     /// Ensures the profile directory skeleton exists with private permissions.
     pub fn ensure_layout(&self) -> Result<(), StoreError> {
         create_private_dir(&self.root)?;
@@ -1022,6 +1042,38 @@ pub struct AgentHomeDiagnostic {
     pub message: String,
 }
 
+/// Conventional worker artifact paths under a profile home.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WorkerArtifactPathSet {
+    /// Worker artifact root.
+    pub root: PathBuf,
+    /// Patch/diff artifact path.
+    pub patch: PathBuf,
+    /// Test report artifact path.
+    pub test_report: PathBuf,
+    /// Worker summary artifact path.
+    pub summary: PathBuf,
+    /// Changed-files manifest path.
+    pub changed_files: PathBuf,
+    /// Memory candidate JSONL path.
+    pub memory_candidates: PathBuf,
+}
+
+impl WorkerArtifactPathSet {
+    /// Creates conventional artifact paths below `artifacts/workers/<worker-id>`.
+    pub fn new(root: impl AsRef<Path>, worker_id: impl AsRef<str>) -> Self {
+        let root = root.as_ref().join(safe_file_stem(worker_id.as_ref()));
+        Self {
+            patch: root.join("patch.diff"),
+            test_report: root.join("test-report.json"),
+            summary: root.join("summary.md"),
+            changed_files: root.join("changed-files.json"),
+            memory_candidates: root.join("memory-candidates.jsonl"),
+            root,
+        }
+    }
+}
+
 /// Profile-local workspace registry stored as TOML.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct WorkspaceRegistry {
@@ -1236,10 +1288,40 @@ impl ProjectWorkspaceStore {
         self.cadis_dir().join("workspace.toml")
     }
 
+    /// Returns the project worktree root from metadata or the default convention.
+    pub fn worktree_root(&self, metadata: Option<&ProjectWorkspaceMetadata>) -> PathBuf {
+        let root = metadata
+            .map(|metadata| metadata.worktree_root.as_path())
+            .unwrap_or_else(|| Path::new(".cadis/worktrees"));
+        self.project_relative_path(root)
+    }
+
+    /// Returns the project-local worktree metadata directory.
+    pub fn worktree_metadata_dir(&self, metadata: Option<&ProjectWorkspaceMetadata>) -> PathBuf {
+        self.worktree_root(metadata).join(".metadata")
+    }
+
+    /// Returns worker-specific worktree and metadata paths.
+    pub fn worker_worktree_paths(
+        &self,
+        worker_id: impl AsRef<str>,
+        metadata: Option<&ProjectWorkspaceMetadata>,
+    ) -> ProjectWorkerWorktreePaths {
+        let worker_id = safe_file_stem(worker_id.as_ref());
+        let worktree_root = self.worktree_root(metadata);
+        let metadata_dir = self.worktree_metadata_dir(metadata);
+        ProjectWorkerWorktreePaths {
+            worker_id: worker_id.clone(),
+            worktree_root: worktree_root.clone(),
+            worktree_path: worktree_root.join(&worker_id),
+            metadata_path: metadata_dir.join(format!("{worker_id}.toml")),
+        }
+    }
+
     /// Ensures the non-secret project `.cadis` metadata skeleton exists.
     pub fn ensure_layout(&self) -> Result<(), StoreError> {
         fs::create_dir_all(self.cadis_dir())?;
-        for path in ["worktrees", "artifacts", "media"] {
+        for path in ["worktrees", "worktrees/.metadata", "artifacts", "media"] {
             fs::create_dir_all(self.cadis_dir().join(path))?;
         }
         write_template_file_if_missing(
@@ -1269,6 +1351,199 @@ impl ProjectWorkspaceStore {
         }
         atomic_write_private_file(&self.workspace_toml_path(), toml.as_bytes())
     }
+
+    /// Writes one project-local worker worktree metadata file.
+    pub fn save_worker_worktree_metadata(
+        &self,
+        metadata: &ProjectWorkerWorktreeMetadata,
+    ) -> Result<(), StoreError> {
+        let workspace_metadata = self.load()?;
+        let paths = self.worker_worktree_paths(&metadata.worker_id, workspace_metadata.as_ref());
+        let mut toml = redact(&toml::to_string_pretty(metadata)?);
+        if !toml.ends_with('\n') {
+            toml.push('\n');
+        }
+        atomic_write_private_file(&paths.metadata_path, toml.as_bytes())
+    }
+
+    /// Loads one project-local worker worktree metadata file.
+    pub fn load_worker_worktree_metadata(
+        &self,
+        worker_id: impl AsRef<str>,
+    ) -> Result<Option<ProjectWorkerWorktreeMetadata>, StoreError> {
+        let workspace_metadata = self.load()?;
+        let paths = self.worker_worktree_paths(worker_id, workspace_metadata.as_ref());
+        if !paths.metadata_path.exists() {
+            return Ok(None);
+        }
+
+        let content = fs::read_to_string(paths.metadata_path)?;
+        Ok(Some(toml::from_str::<ProjectWorkerWorktreeMetadata>(
+            &content,
+        )?))
+    }
+
+    /// Recovers project-local worker worktree metadata and reports invalid TOML.
+    pub fn recover_worker_worktree_metadata(
+        &self,
+    ) -> Result<ProjectWorkerWorktreeRecovery, StoreError> {
+        let workspace_metadata = self.load()?;
+        let metadata_dir = self.worktree_metadata_dir(workspace_metadata.as_ref());
+        if !metadata_dir.exists() {
+            return Ok(ProjectWorkerWorktreeRecovery::default());
+        }
+
+        let mut records = Vec::new();
+        let mut diagnostics = Vec::new();
+        for entry in fs::read_dir(metadata_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_file() || path.extension().and_then(|value| value.to_str()) != Some("toml")
+            {
+                continue;
+            }
+
+            match fs::read_to_string(&path) {
+                Ok(content) => match toml::from_str::<ProjectWorkerWorktreeMetadata>(&content) {
+                    Ok(metadata) => records.push(ProjectWorkerWorktreeRecord { path, metadata }),
+                    Err(error) => diagnostics.push(ProjectWorktreeDiagnostic {
+                        name: "workspace.worktrees.metadata".to_owned(),
+                        status: "error".to_owned(),
+                        message: format!("{} is invalid TOML: {error}", path.display()),
+                    }),
+                },
+                Err(error) => diagnostics.push(ProjectWorktreeDiagnostic {
+                    name: "workspace.worktrees.metadata".to_owned(),
+                    status: "error".to_owned(),
+                    message: format!("could not read {}: {error}", path.display()),
+                }),
+            }
+        }
+
+        Ok(ProjectWorkerWorktreeRecovery {
+            records,
+            diagnostics,
+        })
+    }
+
+    /// Runs stale project worktree metadata and artifact-root diagnostics.
+    pub fn worker_worktree_diagnostics(
+        &self,
+    ) -> Result<Vec<ProjectWorktreeDiagnostic>, StoreError> {
+        let mut recovery = self.recover_worker_worktree_metadata()?;
+        let mut diagnostics = Vec::new();
+        diagnostics.append(&mut recovery.diagnostics);
+
+        diagnostics.push(ProjectWorktreeDiagnostic {
+            name: "workspace.worktrees.metadata".to_owned(),
+            status: "ok".to_owned(),
+            message: format!(
+                "{} worker worktree metadata record(s)",
+                recovery.records.len()
+            ),
+        });
+
+        for record in recovery.records {
+            let worker_id = safe_file_stem(&record.metadata.worker_id);
+            let worktree_path = self.project_relative_path(&record.metadata.worktree_path);
+            diagnostics.push(path_diagnostic(
+                &format!("workspace.worktrees.{worker_id}.path"),
+                &worktree_path,
+                format!("worker worktree path from {}", record.path.display()),
+            ));
+
+            let artifact_root = self.project_relative_path(&record.metadata.artifact_root);
+            diagnostics.push(path_diagnostic(
+                &format!("workspace.worktrees.{worker_id}.artifacts"),
+                &artifact_root,
+                "worker artifact root".to_owned(),
+            ));
+        }
+
+        Ok(diagnostics)
+    }
+
+    fn project_relative_path(&self, path: &Path) -> PathBuf {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            self.root.join(path)
+        }
+    }
+}
+
+/// Worker-specific project worktree path set.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectWorkerWorktreePaths {
+    /// Redaction-safe worker ID path component.
+    pub worker_id: String,
+    /// Root directory where CADIS project worktrees live.
+    pub worktree_root: PathBuf,
+    /// Worker-specific worktree directory.
+    pub worktree_path: PathBuf,
+    /// Project-local metadata TOML path for this worker.
+    pub metadata_path: PathBuf,
+}
+
+/// Project-local worker worktree metadata stored below `.cadis/worktrees/.metadata/`.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct ProjectWorkerWorktreeMetadata {
+    /// Worker ID.
+    pub worker_id: String,
+    /// Workspace registry ID.
+    pub workspace_id: String,
+    /// Planned or actual worktree path. Relative paths resolve against the project root.
+    pub worktree_path: PathBuf,
+    /// Intended or actual branch name.
+    pub branch_name: String,
+    /// Base ref for branch creation, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_ref: Option<String>,
+    /// Current worktree metadata lifecycle state.
+    pub state: ProjectWorkerWorktreeState,
+    /// Profile-scoped worker artifact root. Relative paths resolve against the project root.
+    pub artifact_root: PathBuf,
+}
+
+/// Project-local worker worktree metadata lifecycle state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectWorkerWorktreeState {
+    /// Worktree has been planned but not created.
+    Planned,
+    /// Worktree exists and is assigned to the worker.
+    Ready,
+    /// Worktree has been removed while metadata remains for diagnostics/audit.
+    Removed,
+}
+
+/// Recovered project worker worktree metadata.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ProjectWorkerWorktreeRecovery {
+    /// Valid metadata records.
+    pub records: Vec<ProjectWorkerWorktreeRecord>,
+    /// Invalid TOML diagnostics.
+    pub diagnostics: Vec<ProjectWorktreeDiagnostic>,
+}
+
+/// One recovered project worker worktree metadata record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectWorkerWorktreeRecord {
+    /// Metadata TOML path.
+    pub path: PathBuf,
+    /// Parsed metadata.
+    pub metadata: ProjectWorkerWorktreeMetadata,
+}
+
+/// Project worktree doctor diagnostic.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectWorktreeDiagnostic {
+    /// Check name.
+    pub name: String,
+    /// `ok`, `warn`, or `error`.
+    pub status: String,
+    /// Human-readable diagnostic.
+    pub message: String,
 }
 
 /// Workspace access level granted to an agent or worker.
@@ -2122,6 +2397,22 @@ fn project_gitignore_template() -> &'static str {
     "worktrees/\nartifacts/\ntmp/\nlogs/\n*.key\n*.pem\n*.token\n.env\n"
 }
 
+fn path_diagnostic(name: &str, path: &Path, label: String) -> ProjectWorktreeDiagnostic {
+    if path.is_dir() {
+        ProjectWorktreeDiagnostic {
+            name: name.to_owned(),
+            status: "ok".to_owned(),
+            message: format!("{label} exists at {}", path.display()),
+        }
+    } else {
+        ProjectWorktreeDiagnostic {
+            name: name.to_owned(),
+            status: "warn".to_owned(),
+            message: format!("{label} is stale or missing at {}", path.display()),
+        }
+    }
+}
+
 fn default_agent_denied_paths() -> Vec<PathBuf> {
     [
         "~/.ssh",
@@ -2741,6 +3032,96 @@ mod tests {
             .expect("project metadata should load")
             .expect("project metadata should exist");
         assert_eq!(loaded, metadata);
+    }
+
+    #[test]
+    fn worker_artifact_paths_are_profile_scoped() {
+        let config = test_config("worker-artifacts");
+        let profile = CadisHome::new(&config.cadis_home)
+            .init_profile("default")
+            .expect("profile should initialize");
+
+        let paths = profile
+            .ensure_worker_artifact_layout("worker/1")
+            .expect("worker artifact layout should initialize");
+
+        assert_eq!(
+            paths.root,
+            profile.root().join("artifacts/workers/worker_1")
+        );
+        assert_eq!(paths.patch, paths.root.join("patch.diff"));
+        assert!(paths.root.is_dir());
+    }
+
+    #[test]
+    fn project_worker_worktree_metadata_round_trips_and_reports_stale_paths() {
+        let config = test_config("project-worker-worktree");
+        let root = config.cadis_home.join("project");
+        fs::create_dir_all(&root).expect("project root should be created");
+        let store = ProjectWorkspaceStore::new(&root);
+        store
+            .save(&ProjectWorkspaceMetadata {
+                workspace_id: "example-project".to_owned(),
+                kind: WorkspaceKind::Project,
+                vcs: WorkspaceVcs::Git,
+                worktree_root: PathBuf::from(".cadis/worktrees"),
+                artifact_root: PathBuf::from(".cadis/artifacts"),
+                media_root: PathBuf::from(".cadis/media"),
+            })
+            .expect("project metadata should save");
+
+        let paths = store.worker_worktree_paths("worker/1", store.load().unwrap().as_ref());
+        let metadata = ProjectWorkerWorktreeMetadata {
+            worker_id: "worker/1".to_owned(),
+            workspace_id: "example-project".to_owned(),
+            worktree_path: PathBuf::from(".cadis/worktrees/worker_1"),
+            branch_name: "cadis/worker_1/example".to_owned(),
+            base_ref: Some("HEAD".to_owned()),
+            state: ProjectWorkerWorktreeState::Planned,
+            artifact_root: config
+                .cadis_home
+                .join("profiles/default/artifacts/workers/worker_1"),
+        };
+
+        store
+            .save_worker_worktree_metadata(&metadata)
+            .expect("worker worktree metadata should save");
+
+        assert!(paths.metadata_path.is_file());
+        let loaded = store
+            .load_worker_worktree_metadata("worker/1")
+            .expect("worker worktree metadata should load")
+            .expect("worker worktree metadata should exist");
+        assert_eq!(loaded, metadata);
+
+        let diagnostics = store
+            .worker_worktree_diagnostics()
+            .expect("worker worktree diagnostics should run");
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.name == "workspace.worktrees.worker_1.path" && diagnostic.status == "warn"
+        }));
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.name == "workspace.worktrees.worker_1.artifacts"
+                && diagnostic.status == "warn"
+        }));
+
+        fs::create_dir_all(root.join(".cadis/worktrees/worker_1"))
+            .expect("worktree dir should be created");
+        fs::create_dir_all(
+            config
+                .cadis_home
+                .join("profiles/default/artifacts/workers/worker_1"),
+        )
+        .expect("artifact root should be created");
+        let diagnostics = store
+            .worker_worktree_diagnostics()
+            .expect("worker worktree diagnostics should run");
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.name == "workspace.worktrees.worker_1.path" && diagnostic.status == "ok"
+        }));
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.name == "workspace.worktrees.worker_1.artifacts" && diagnostic.status == "ok"
+        }));
     }
 
     #[test]

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -127,6 +127,25 @@ impl Default for AgentSpawnConfig {
     }
 }
 
+/// Daemon-owned Agent Runtime settings.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AgentRuntimeConfig {
+    /// Default per-route AgentSession timeout.
+    pub default_timeout_sec: i64,
+    /// Maximum state-machine steps per AgentSession.
+    pub max_steps_per_session: u32,
+}
+
+impl Default for AgentRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            default_timeout_sec: 900,
+            max_steps_per_session: 1,
+        }
+    }
+}
+
 /// Daemon-owned orchestration settings.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(default)]
@@ -180,6 +199,8 @@ pub struct CadisConfig {
     pub voice: VoiceConfig,
     /// Request-driven agent spawn limits.
     pub agent_spawn: AgentSpawnConfig,
+    /// Per-route AgentSession runtime limits.
+    pub agent_runtime: AgentRuntimeConfig,
     /// Daemon-owned orchestrator settings.
     pub orchestrator: OrchestratorConfig,
     /// Profile-home selection and profile layout settings.
@@ -196,6 +217,7 @@ impl Default for CadisConfig {
             hud: HudConfig::default(),
             voice: VoiceConfig::default(),
             agent_spawn: AgentSpawnConfig::default(),
+            agent_runtime: AgentRuntimeConfig::default(),
             orchestrator: OrchestratorConfig::default(),
             profile: ProfileConfig::default(),
         }
@@ -238,6 +260,10 @@ impl CadisConfig {
                 "max_depth": self.agent_spawn.max_depth,
                 "max_children_per_parent": self.agent_spawn.max_children_per_parent,
                 "max_total_agents": self.agent_spawn.max_total_agents
+            },
+            "agent_runtime": {
+                "default_timeout_sec": self.agent_runtime.default_timeout_sec,
+                "max_steps_per_session": self.agent_runtime.max_steps_per_session
             },
             "orchestrator": {
                 "worker_delegation_enabled": self.orchestrator.worker_delegation_enabled,
@@ -1598,6 +1624,25 @@ mod tests {
         assert_eq!(
             config.ui_preferences()["agent_spawn"]["max_children_per_parent"],
             serde_json::json!(2)
+        );
+    }
+
+    #[test]
+    fn parses_agent_runtime_limits() {
+        let config = toml::from_str::<CadisConfig>(
+            r#"
+            [agent_runtime]
+            default_timeout_sec = 60
+            max_steps_per_session = 3
+            "#,
+        )
+        .expect("agent runtime config should parse");
+
+        assert_eq!(config.agent_runtime.default_timeout_sec, 60);
+        assert_eq!(config.agent_runtime.max_steps_per_session, 3);
+        assert_eq!(
+            config.ui_preferences()["agent_runtime"]["max_steps_per_session"],
+            serde_json::json!(3)
         );
     }
 

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -631,6 +631,101 @@ impl WorkspaceRegistryStore {
     }
 }
 
+/// Project-local `.cadis/workspace.toml` metadata.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ProjectWorkspaceMetadata {
+    /// Workspace ID expected to match the profile registry entry.
+    pub workspace_id: String,
+    /// Workspace category.
+    pub kind: WorkspaceKind,
+    /// Version-control backend.
+    pub vcs: WorkspaceVcs,
+    /// Relative directory for CADIS worker worktrees.
+    pub worktree_root: PathBuf,
+    /// Relative directory for workspace-local artifacts.
+    pub artifact_root: PathBuf,
+    /// Relative directory for project-scoped media assets.
+    pub media_root: PathBuf,
+}
+
+impl Default for ProjectWorkspaceMetadata {
+    fn default() -> Self {
+        Self {
+            workspace_id: String::new(),
+            kind: WorkspaceKind::Project,
+            vcs: WorkspaceVcs::None,
+            worktree_root: PathBuf::from(".cadis/worktrees"),
+            artifact_root: PathBuf::from(".cadis/artifacts"),
+            media_root: PathBuf::from(".cadis/media"),
+        }
+    }
+}
+
+/// Project-local `.cadis/` metadata helper.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectWorkspaceStore {
+    root: PathBuf,
+}
+
+impl ProjectWorkspaceStore {
+    /// Creates a project metadata helper rooted at a project workspace.
+    pub fn new(root: impl AsRef<Path>) -> Self {
+        Self {
+            root: root.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Returns the project root.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Returns the project `.cadis` directory path.
+    pub fn cadis_dir(&self) -> PathBuf {
+        self.root.join(".cadis")
+    }
+
+    /// Returns the project `workspace.toml` path.
+    pub fn workspace_toml_path(&self) -> PathBuf {
+        self.cadis_dir().join("workspace.toml")
+    }
+
+    /// Ensures the non-secret project `.cadis` metadata skeleton exists.
+    pub fn ensure_layout(&self) -> Result<(), StoreError> {
+        fs::create_dir_all(self.cadis_dir())?;
+        for path in ["worktrees", "artifacts", "media"] {
+            fs::create_dir_all(self.cadis_dir().join(path))?;
+        }
+        write_template_file_if_missing(
+            &self.cadis_dir().join(".gitignore"),
+            project_gitignore_template(),
+        )?;
+        Ok(())
+    }
+
+    /// Loads project-local workspace metadata. Missing metadata returns `Ok(None)`.
+    pub fn load(&self) -> Result<Option<ProjectWorkspaceMetadata>, StoreError> {
+        let path = self.workspace_toml_path();
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let content = fs::read_to_string(path)?;
+        Ok(Some(toml::from_str::<ProjectWorkspaceMetadata>(&content)?))
+    }
+
+    /// Writes project-local workspace metadata with redaction and atomic replace.
+    pub fn save(&self, metadata: &ProjectWorkspaceMetadata) -> Result<(), StoreError> {
+        self.ensure_layout()?;
+        let mut toml = redact(&toml::to_string_pretty(metadata)?);
+        if !toml.ends_with('\n') {
+            toml.push('\n');
+        }
+        atomic_write_private_file(&self.workspace_toml_path(), toml.as_bytes())
+    }
+}
+
 /// Workspace access level granted to an agent or worker.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -1414,6 +1509,10 @@ fn profile_gitignore_template() -> &'static str {
     ".env\nsecrets/\nchannels/\nsessions/\nworkers/\ncheckpoints/\nsandboxes/\nlogs/\nlocks/\nrun/\n*.key\n*.pem\n*.token\n*.sqlite-wal\n*.sqlite-shm\n"
 }
 
+fn project_gitignore_template() -> &'static str {
+    "worktrees/\nartifacts/\ntmp/\nlogs/\n*.key\n*.pem\n*.token\n.env\n"
+}
+
 fn expand_home(path: &Path) -> PathBuf {
     let Some(value) = path.to_str() else {
         return path.to_path_buf();
@@ -1896,6 +1995,37 @@ mod tests {
             loaded.workspace[0].aliases[0].aliases,
             vec!["example", "demo"]
         );
+    }
+
+    #[test]
+    fn project_workspace_metadata_round_trips_and_initializes_layout() {
+        let config = test_config("project-workspace-metadata");
+        let root = config.cadis_home.join("project");
+        fs::create_dir_all(&root).expect("project root should be created");
+        let store = ProjectWorkspaceStore::new(&root);
+        let metadata = ProjectWorkspaceMetadata {
+            workspace_id: "example-project".to_owned(),
+            kind: WorkspaceKind::Project,
+            vcs: WorkspaceVcs::Git,
+            worktree_root: PathBuf::from(".cadis/worktrees"),
+            artifact_root: PathBuf::from(".cadis/artifacts"),
+            media_root: PathBuf::from(".cadis/media"),
+        };
+
+        assert_eq!(store.load().expect("missing metadata should load"), None);
+        store.save(&metadata).expect("project metadata should save");
+
+        assert!(store.workspace_toml_path().is_file());
+        assert!(root.join(".cadis/worktrees").is_dir());
+        assert!(root.join(".cadis/artifacts").is_dir());
+        assert!(root.join(".cadis/media").is_dir());
+        assert!(root.join(".cadis/.gitignore").is_file());
+
+        let loaded = store
+            .load()
+            .expect("project metadata should load")
+            .expect("project metadata should exist");
+        assert_eq!(loaded, metadata);
     }
 
     #[test]

--- a/docs/05_ARCHITECTURE.md
+++ b/docs/05_ARCHITECTURE.md
@@ -253,9 +253,11 @@ The desktop MVP now wraps each routed task in an in-memory daemon-owned
 summary, timeout deadline, step budget, cancellation timestamp, target agent,
 and parent agent. Clients observe it through `agent.session.started`,
 `agent.session.updated`, and terminal `agent.session.completed`,
-`agent.session.failed`, or `agent.session.cancelled` events. These records are a
-runtime boundary only; provider/tool-loop execution, durable AgentSession
-recovery, and implicit model-driven spawning remain later work.
+`agent.session.failed`, or `agent.session.cancelled` events. AgentSession
+metadata is also written atomically under `~/.cadis/state/agent-sessions/` and
+loaded on daemon start so `events.snapshot` can replay recovered records.
+Provider/tool-loop execution and implicit model-driven spawning remain later
+work.
 
 ## 10. Model Provider Layer
 

--- a/docs/05_ARCHITECTURE.md
+++ b/docs/05_ARCHITECTURE.md
@@ -101,6 +101,7 @@ sequenceDiagram
   D->>B: SessionStarted
   B->>C: SessionStarted
   B->>L: append event
+  D->>B: OrchestratorRoute / AgentStatusChanged
   D->>M: stream response
   M-->>D: delta
   D->>B: MessageDelta
@@ -109,6 +110,11 @@ sequenceDiagram
   M-->>D: complete
   D->>B: MessageCompleted
 ```
+
+`cadisd` prepares message routing and session state under the runtime mutex, but
+model provider generation runs outside that mutex. The daemon reacquires the
+runtime only to create authoritative event envelopes, so unrelated status and
+agent-list requests can proceed while a slow provider is generating.
 
 ## 5. Approval Flow
 

--- a/docs/05_ARCHITECTURE.md
+++ b/docs/05_ARCHITECTURE.md
@@ -248,6 +248,15 @@ default_timeout_sec = 900
 allow_recursive_spawn = false
 ```
 
+The desktop MVP now wraps each routed task in an in-memory daemon-owned
+`AgentSession`. The record carries the route ID, task summary, result/error
+summary, timeout deadline, step budget, cancellation timestamp, target agent,
+and parent agent. Clients observe it through `agent.session.started`,
+`agent.session.updated`, and terminal `agent.session.completed`,
+`agent.session.failed`, or `agent.session.cancelled` events. These records are a
+runtime boundary only; provider/tool-loop execution, durable AgentSession
+recovery, and implicit model-driven spawning remain later work.
+
 ## 10. Model Provider Layer
 
 Provider interface responsibilities:

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -178,6 +178,9 @@ Tasks:
   `MediaRecorder` emits zero chunks even though analyser input is live.
 - Promote the current HUD-local voice doctor results into daemon-visible status
   once voice becomes daemon-owned.
+- Green slice: expose `voice.status`, `voice.doctor`, and `voice.preflight`
+  so CLI/HUD can see daemon-owned voice status while HUD/Tauri remains the
+  local capture/playback bridge.
 - Handle daemon voice events in HUD.
 
 Exit criteria:

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -250,7 +250,8 @@ Tasks:
 - Extend the implemented workspace registry/grants with full alias management,
   richer expiry UX, and denied-path checks for mutating tools.
 - Add project `.cadis/workspace.toml`, `.cadis/worktrees/`, `.cadis/artifacts/`,
-  and `.cadis/media/` conventions.
+  and `.cadis/media/` conventions. Store-level `.cadis/workspace.toml` support
+  and doctor checks for metadata mismatch now exist.
 - Route coding workers into git worktrees and persist worker artifacts under the
   profile home.
 - Add doctor checks for duplicated roots, broad grants, symlink escapes, secret
@@ -571,6 +572,8 @@ Tasks:
 - W7: integrate workspace, grant, worker, checkpoint, and rollback events.
 - W8: add deterministic channel and cwd/project routing.
 - W9: add doctor and migration checks for the full layout.
+  Baseline complete for duplicate registered roots, missing project metadata,
+  and registry/metadata ID mismatch.
 
 ## 14. P11 - Telegram Adapter
 

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -110,6 +110,10 @@ Tasks:
 Exit criteria:
 
 - HUD receives visible progress before model completion.
+  Completed by the HUD live-progress acceptance fixture, which renders live
+  `session.started`, `orchestrator.route`, `agent.status.changed`,
+  `message.delta`, and `message.completed` frames through the React HUD before
+  final completion.
 - CLI can subscribe to a live session.
 - One slow request does not block unrelated status or agent list requests.
 

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -93,8 +93,12 @@ Tasks:
 - Add a daemon event bus with fan-out to connected clients.
 - Add a persistent `session.subscribe` stream for HUD and CLI clients.
   Baseline now supports session-filtered replay and live fan-out over the
-  daemon socket; model-generation-time progressive publishing remains pending.
+  daemon socket. The daemon now publishes route/status progress before provider
+  generation returns and fans out model deltas as provider callbacks arrive.
 - Stop holding the runtime mutex while model providers are generating.
+  Baseline now prepares daemon-owned message generation under the runtime mutex,
+  releases it for provider work, and reacquires it only to mint authoritative
+  event envelopes.
 - Emit `session.started`, `orchestrator.route`, `agent.status.changed`,
   `message.delta`, and `message.completed` as they happen.
 - Add integration tests for two clients receiving the same session events.

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -102,6 +102,10 @@ Tasks:
 - Emit `session.started`, `orchestrator.route`, `agent.status.changed`,
   `message.delta`, and `message.completed` as they happen.
 - Add integration tests for two clients receiving the same session events.
+  Baseline now includes a real Unix socket integration test with two
+  `session.subscribe` clients receiving the same route/status/message events
+  while a separate client receives `daemon.status` and `agent.list` responses
+  during a deliberately paused provider generation.
 
 Exit criteria:
 

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -181,6 +181,9 @@ Tasks:
 - Green slice: expose `voice.status`, `voice.doctor`, and `voice.preflight`
   so CLI/HUD can see daemon-owned voice status while HUD/Tauri remains the
   local capture/playback bridge.
+- Green slice: define the daemon TTS provider trait, local provider stubs for
+  `edge`, `openai`, and `system`, and speech policy that blocks code, diffs,
+  terminal logs, and long raw tool/test output before provider dispatch.
 - Handle daemon voice events in HUD.
 
 Exit criteria:

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -121,6 +121,9 @@ Tasks:
 - Route agent-selected model IDs into provider selection instead of treating
   `agent.model.set` as UI-only state.
 - Add streaming callback support for providers that can stream.
+- Provider-boundary cancellation is defined as callback `Cancel` control,
+  `model.cancelled`, and a non-retryable `model_cancelled` error; native
+  upstream cancellation still needs per-provider integration.
 - Keep echo provider available only as an explicit fallback state.
 
 Exit criteria:

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -92,6 +92,8 @@ Tasks:
 
 - Add a daemon event bus with fan-out to connected clients.
 - Add a persistent `session.subscribe` stream for HUD and CLI clients.
+  Baseline now supports session-filtered replay and live fan-out over the
+  daemon socket; model-generation-time progressive publishing remains pending.
 - Stop holding the runtime mutex while model providers are generating.
 - Emit `session.started`, `orchestrator.route`, `agent.status.changed`,
   `message.delta`, and `message.completed` as they happen.

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -49,9 +49,10 @@ Implemented in the first runnable baseline:
 - Orchestrator baseline: daemon-owned `@agent` routing, `orchestrator.route`
   events, route-time `agent.status.changed` events, request-driven
   `agent.spawn`, and spawn limits.
-- Agent Runtime baseline: in-memory per-route `AgentSession` records with route,
+- Agent Runtime baseline: durable per-route `AgentSession` records with route,
   task, result, timeout deadline, step budget, cancellation, and parent-child
-  metadata exposed through `agent.session.*` lifecycle events.
+  metadata exposed through `agent.session.*` lifecycle events and replayed in
+  snapshot responses after daemon restart.
 - Track C worker baseline: in-memory daemon worker registry, route-time
   `worker.log.delta` lifecycle logs, `events.snapshot` worker lifecycle
   snapshots, and one-shot `worker.tail` replay.
@@ -74,10 +75,11 @@ Still pending:
 
 - Native mutating file/shell tools.
 - Agent runtime beyond the current route-and-answer path: async cancellation,
-  model-driven spawn, multi-step budgets, durable AgentSession recovery, and a
-  provider/tool-call loop remain future work.
-- Daemon startup wiring for durable session, agent, worker, and approval
-  recovery. The store-level atomic write and fail-safe recovery helpers exist.
+  model-driven spawn, multi-step budgets, and a provider/tool-call loop remain
+  future work.
+- Daemon startup wiring for durable worker recovery and Track D approval
+  recovery. Session, agent, and AgentSession metadata recovery now has daemon
+  integration on the AgentSession baseline.
 - Worker execution lifecycle, isolated worktrees, Telegram/mobile adapters,
   daemon-owned production voice output, and code work window.
 - Agent home manager, denied-path enforcement for all mutating tools,
@@ -204,12 +206,14 @@ Owner: store/recovery agents.
 
 Tasks:
 
-- Store session metadata, agent metadata, worker metadata, and approval metadata
-  with atomic writes. Store-level helpers are implemented under
-  `~/.cadis/state`; daemon runtime integration remains pending.
-- Load durable state on daemon start.
+- Store session metadata, agent metadata, AgentSession metadata, worker
+  metadata, and approval metadata with atomic writes. Store-level helpers are
+  implemented under `~/.cadis/state`; AgentSession records use
+  `state/agent-sessions/<agent-session-id>.json`.
+- Load durable session, agent, and AgentSession state on daemon start.
 - Keep append-only JSONL as audit log, not the only runtime state.
-- Add recovery tests for partial writes and stale worker/session records.
+- Add recovery tests for partial writes, corrupt AgentSession files, and stale
+  worker/session records.
 
 Exit criteria:
 
@@ -502,9 +506,11 @@ Tasks:
 - Append JSONL event logs.
 - Provide store-level durable metadata files:
   `state/sessions/<session-id>.json`, `state/agents/<agent-id>.json`,
+  `state/agent-sessions/<agent-session-id>.json`,
   `state/workers/<worker-id>.json`, and
   `state/approvals/<approval-id>.json`.
 - Store session metadata.
+- Store AgentSession metadata.
 - Store approval metadata.
 - Implement redaction.
 - Use atomic writes for state.
@@ -512,6 +518,7 @@ Tasks:
 Exit criteria:
 
 - Session events survive daemon restart as logs.
+- AgentSession snapshots survive daemon restart as durable state.
 - Secret redaction tests pass.
 - Store-level partial and corrupt state recovery tests pass.
 

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -49,6 +49,9 @@ Implemented in the first runnable baseline:
 - Orchestrator baseline: daemon-owned `@agent` routing, `orchestrator.route`
   events, route-time `agent.status.changed` events, request-driven
   `agent.spawn`, and spawn limits.
+- Agent Runtime baseline: in-memory per-route `AgentSession` records with route,
+  task, result, timeout deadline, step budget, cancellation, and parent-child
+  metadata exposed through `agent.session.*` lifecycle events.
 - Track C worker baseline: in-memory daemon worker registry, route-time
   `worker.log.delta` lifecycle logs, `events.snapshot` worker lifecycle
   snapshots, and one-shot `worker.tail` replay.
@@ -70,8 +73,9 @@ Implemented in the first runnable baseline:
 Still pending:
 
 - Native mutating file/shell tools.
-- Agent runtime beyond the current route-and-answer path; existing
-  `agent.spawn` is client-requested, not agent-driven.
+- Agent runtime beyond the current route-and-answer path: async cancellation,
+  model-driven spawn, multi-step budgets, durable AgentSession recovery, and a
+  provider/tool-call loop remain future work.
 - Daemon startup wiring for durable session, agent, worker, and approval
   recovery. The store-level atomic write and fail-safe recovery helpers exist.
 - Worker execution lifecycle, isolated worktrees, Telegram/mobile adapters,
@@ -132,17 +136,21 @@ Owner: agent-runtime and worker agents.
 Tasks:
 
 - Introduce an `AgentSession` state machine with route, task, result, timeout,
-  budget, cancellation, and parent-child metadata.
+  budget, cancellation, and parent-child metadata. Initial baseline is
+  in-memory and wraps the existing synchronous route-and-answer path.
 - Extend the current request-driven spawn limits into agent-driven spawn:
   max depth, max children per agent, and global agent cap.
 - Implement agent-driven spawn as a daemon-authorized action, not HUD logic.
+  The current safe slice supports explicit daemon-owned `/worker` and `/spawn`
+  orchestration through the same core spawn path; implicit model-driven spawn is
+  still reserved for later runtime work.
 - Add a worker registry with `worker.started`, `worker.log.delta`,
   `worker.completed`, `worker.failed`, and `worker.cancelled`.
 - Implement `worker.tail` from daemon-owned worker logs.
 
 Exit criteria:
 
-- An agent can request a subagent through the orchestrator and the daemon enforces
+- An explicit orchestrator action can request a subagent and the daemon enforces
   limits.
 - HUD worker tree is driven by daemon worker events.
 - Worker logs can be tailed from CLI and HUD.
@@ -517,8 +525,8 @@ Tasks:
 - Define agent roles.
 - Define task input and result.
 - Add lifecycle events.
-- Add budget and timeout.
-- Add cancellation.
+- Add budget and timeout metadata.
+- Add cancellation metadata.
 - Add basic tool-call loop if provider supports tool calls.
 - Add text protocol fallback for models without native tool calls later.
 

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -69,8 +69,9 @@ Still pending:
 - Native mutating file/shell tools.
 - Agent runtime beyond the current route-and-answer path; existing
   `agent.spawn` is client-requested, not agent-driven.
-- Daemon startup wiring for durable session, agent, worker, and approval
-  recovery. The store-level atomic write and fail-safe recovery helpers exist.
+- Daemon startup wiring for pending approval recovery. Store-level atomic write
+  and fail-safe recovery helpers exist, and the daemon now recovers durable
+  session, agent, and worker metadata.
 - Worker lifecycle, isolated worktrees, Telegram/mobile adapters, daemon-owned
   production voice output, and code work window.
 - Agent home manager, denied-path enforcement for all mutating tools,
@@ -494,6 +495,9 @@ Tasks:
   `state/workers/<worker-id>.json`, and
   `state/approvals/<approval-id>.json`.
 - Store session metadata.
+- Store worker metadata for the current daemon-planned worker delegation
+  baseline and recover stale non-terminal worker records as failed on daemon
+  restart.
 - Store approval metadata.
 - Implement redaction.
 - Use atomic writes for state.

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -63,6 +63,10 @@ Implemented in the first runnable baseline:
   grants.
 - Voice debug baseline: HUD-local mic doctor, WebAudio analyser telemetry, and
   WebAudio PCM fallback when WebKit `MediaRecorder` produces zero audio chunks.
+- Model readiness/routing baseline: `models.list` exposes configured
+  provider/model IDs, conservative readiness, effective provider/model metadata,
+  and fallback flags; `agent.model.set` selections are used by daemon provider
+  routing for message generation instead of remaining HUD-only state.
 
 Still pending:
 
@@ -78,6 +82,9 @@ Still pending:
 - Future daemon-owned memory architecture from `25_MEMORY_CONCEPT.md`, including
   memory records, scoped retrieval, provenance ledger, candidate promotion, and
   memory capsules.
+- Native provider streaming for providers that support token streams directly;
+  the current provider trait can stream normalized events, but OpenAI/Ollama
+  still use non-streaming request paths.
 
 ## 2.2 Next Execution Plan
 

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -49,6 +49,9 @@ Implemented in the first runnable baseline:
 - Orchestrator baseline: daemon-owned `@agent` routing, `orchestrator.route`
   events, route-time `agent.status.changed` events, request-driven
   `agent.spawn`, and spawn limits.
+- Track C worker baseline: in-memory daemon worker registry, route-time
+  `worker.log.delta` lifecycle logs, `events.snapshot` worker lifecycle
+  snapshots, and one-shot `worker.tail` replay.
 - P13 HUD subset: Tauri + React `apps/cadis-hud` desktop app, orbital shell,
   chat command panel, agent cards, mention picker, config dialog, six themes,
   model controls, rename dialog, local mic debug, HUD-local voice doctor,
@@ -71,8 +74,8 @@ Still pending:
   `agent.spawn` is client-requested, not agent-driven.
 - Daemon startup wiring for durable session, agent, worker, and approval
   recovery. The store-level atomic write and fail-safe recovery helpers exist.
-- Worker lifecycle, isolated worktrees, Telegram/mobile adapters, daemon-owned
-  production voice output, and code work window.
+- Worker execution lifecycle, isolated worktrees, Telegram/mobile adapters,
+  daemon-owned production voice output, and code work window.
 - Agent home manager, denied-path enforcement for all mutating tools,
   checkpoint/rollback manager, and media asset manifests.
 - Future daemon-owned memory architecture from `25_MEMORY_CONCEPT.md`, including

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -253,13 +253,17 @@ Tasks:
   richer expiry UX, and denied-path checks for mutating tools.
 - Add project `.cadis/workspace.toml`, `.cadis/worktrees/`, `.cadis/artifacts/`,
   and `.cadis/media/` conventions. Store-level `.cadis/workspace.toml` support
-  and doctor checks for metadata mismatch now exist.
+  and doctor checks for metadata mismatch now exist. Store-level worker worktree
+  path/metadata helpers under project `.cadis/worktrees/` now exist.
 - Route coding workers into git worktrees and persist worker artifacts under the
-  profile home.
+  profile home. Profile-scoped worker artifact path helpers now point at
+  `profiles/<profile>/artifacts/workers/`; actual artifact production remains
+  future work.
 - Add doctor checks for duplicated roots, broad grants, symlink escapes, secret
   paths, stale worktrees, corrupt JSONL, and oversized memory/persona files.
   Workspace doctor now includes a baseline for missing, corrupt, and oversized
-  agent-home files.
+  agent-home files plus stale project worker worktree metadata and missing
+  artifact roots.
 
 Exit criteria:
 

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -58,9 +58,10 @@ Implemented in the first runnable baseline:
   renderer-neutral avatar modes, gestures, face-tracking privacy state, renderer
   backend intent, and renderable frame contracts.
 - Workspace architecture baseline: profile layout initialization, persistent
-  workspace registry/grants, workspace protocol/CLI commands, workspace doctor,
-  agent-scoped `tool.call` grants, and safe-read tool execution behind active
-  grants.
+  daemon-known agent home initialization, persistent workspace registry/grants,
+  workspace protocol/CLI commands, workspace doctor with profile/agent file
+  diagnostics, agent-scoped `tool.call` grants, and safe-read tool execution
+  behind active grants.
 - Voice debug baseline: HUD-local mic doctor, WebAudio analyser telemetry, and
   WebAudio PCM fallback when WebKit `MediaRecorder` produces zero audio chunks.
 
@@ -73,8 +74,8 @@ Still pending:
   recovery. The store-level atomic write and fail-safe recovery helpers exist.
 - Worker lifecycle, isolated worktrees, Telegram/mobile adapters, daemon-owned
   production voice output, and code work window.
-- Agent home manager, denied-path enforcement for all mutating tools,
-  checkpoint/rollback manager, and media asset manifests.
+- Denied-path enforcement for all mutating tools, checkpoint/rollback manager,
+  dedicated profile/agent doctor commands, and media asset manifests.
 - Future daemon-owned memory architecture from `25_MEMORY_CONCEPT.md`, including
   memory records, scoped retrieval, provenance ledger, candidate promotion, and
   memory capsules.
@@ -246,7 +247,8 @@ Tasks:
   layout in `27_WORKSPACE_ARCHITECTURE.md`. Baseline profile home initialization
   now exists for the default profile.
 - Add agent homes with `AGENT.toml`, persona/instruction/memory files, and
-  machine-enforced `POLICY.toml`.
+  machine-enforced `POLICY.toml`. Baseline templates and typed policy metadata
+  now exist for daemon-known agents.
 - Extend the implemented workspace registry/grants with full alias management,
   richer expiry UX, and denied-path checks for mutating tools.
 - Add project `.cadis/workspace.toml`, `.cadis/worktrees/`, `.cadis/artifacts/`,
@@ -256,6 +258,8 @@ Tasks:
   profile home.
 - Add doctor checks for duplicated roots, broad grants, symlink escapes, secret
   paths, stale worktrees, corrupt JSONL, and oversized memory/persona files.
+  Workspace doctor now includes a baseline for missing, corrupt, and oversized
+  agent-home files.
 
 Exit criteria:
 

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -109,10 +109,10 @@
 - [x] Add daemon config loader.
 - [x] Add daemon health status.
 - [x] Add local transport listener.
-- [ ] Add event bus.
-- [ ] Add event fan-out to multiple clients.
+- [x] Add event bus.
+- [x] Add event fan-out to multiple clients.
 - [x] Add `session.subscribe` protocol/request baseline.
-- [ ] Add live persistent `session.subscribe` stream.
+- [x] Add live persistent `session.subscribe` stream.
 - [ ] Avoid blocking daemon mutex during model generation.
 - [x] Add session registry.
 - [ ] Add shutdown handling.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -197,19 +197,21 @@
 
 ## 11. Agent Runtime
 
-- [ ] Define `AgentSession`.
+- [x] Define `AgentSession`.
 - [ ] Define agent roles.
-- [ ] Define agent lifecycle.
+- [x] Define AgentSession lifecycle event baseline.
 - [ ] Implement main agent.
 - [x] Implement daemon-owned `@agent` routing baseline.
 - [x] Implement client-driven `agent.spawn` baseline.
-- [ ] Add agent-driven spawn through daemon-approved action.
+- [x] Add daemon-owned explicit `/worker` and `/spawn` orchestration through the core spawn path.
+- [ ] Add implicit model-driven spawn through daemon-approved action.
 - [x] Add request-driven spawn max depth, max children, and global cap.
 - [x] Add route-time agent status events baseline.
 - [ ] Add full lifecycle agent status events.
-- [ ] Add budget limits.
-- [ ] Add timeout limits.
-- [ ] Add cancellation.
+- [x] Add per-route AgentSession step budget baseline.
+- [x] Add per-route AgentSession timeout deadline baseline.
+- [x] Add session-cancel AgentSession cancellation baseline.
+- [ ] Add async provider/tool cancellation.
 - [ ] Add tool-call loop.
 - [ ] Add model fallback behavior.
 
@@ -308,6 +310,9 @@
 - [ ] Track A: daemon event bus and live session subscription.
 - [ ] Track B: provider readiness, effective model metadata, and provider streaming.
 - [ ] Track C: `AgentSession`, agent-driven spawn, limits, and worker registry.
+  Baselines landed: AgentSession state/events, explicit daemon-owned spawn,
+  spawn limits, worker registry, and worker tail. Remaining: implicit
+  model-driven spawn, worker failed/cancelled events, and executable workers.
 - [ ] Track D: policy-backed tools and approval persistence.
 - [ ] Track E: daemon-owned voice provider path, STT language setting, and voice doctor.
 - [ ] Track F: durable metadata and restart recovery for sessions, agents, workers, and approvals.
@@ -354,11 +359,11 @@
 ## 17. Multi-Agent Tree
 
 - [ ] Define tree data model.
-- [ ] Enforce max depth.
-- [ ] Enforce max children.
-- [ ] Enforce max global agents.
-- [ ] Enforce budget.
-- [ ] Support spawn.
+- [x] Enforce max depth.
+- [x] Enforce max children.
+- [x] Enforce max global agents.
+- [x] Enforce budget baseline.
+- [x] Support spawn baseline.
 - [ ] Support kill.
 - [ ] Support tail.
 - [ ] Support result collection.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -272,7 +272,7 @@
 - [x] Show chat stream.
 - [x] Show agent tree.
 - [x] Add `@agent` mention picker baseline.
-- [ ] Show worker progress.
+- [x] Show worker progress from daemon `agent.session.*` and `worker.*` events.
 - [x] Show approval cards.
 - [x] Add voice controls.
 - [x] Add local mic debug telemetry.
@@ -283,7 +283,7 @@
 - [x] Add status bar.
 - [x] Add desktop packaging notes.
 - [ ] Validate HUD prototype against RamaClaw adaptation contract.
-- [ ] Render HUD from a mock CADIS daemon event stream.
+- [x] Render HUD worker progress from a mock CADIS daemon event stream fixture.
 - [x] Confirm HUD is protocol-client only and does not execute tools directly.
 - [ ] Confirm durable HUD preferences are daemon-backed, not browser/local UI storage.
 - [x] Confirm disconnected state references CADIS daemon, not OpenClaw.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -285,7 +285,7 @@
 - [x] Add status bar.
 - [x] Add desktop packaging notes.
 - [ ] Validate HUD prototype against RamaClaw adaptation contract.
-- [ ] Render HUD from a mock CADIS daemon event stream.
+- [x] Render HUD from a mock CADIS daemon event stream.
 - [x] Confirm HUD is protocol-client only and does not execute tools directly.
 - [ ] Confirm durable HUD preferences are daemon-backed, not browser/local UI storage.
 - [x] Confirm disconnected state references CADIS daemon, not OpenClaw.
@@ -310,6 +310,8 @@
 ## 15.1 Next Multi-Agent Execution Tracks
 
 - [x] Track A: daemon event bus, live session subscription, and non-blocking generation path.
+- [x] Track A HUD acceptance: live session, route, agent status, delta, and
+  completion frames render visible progress before model completion.
 - [ ] Track B: provider readiness, effective model metadata, and provider streaming.
 - [ ] Track C: `AgentSession`, agent-driven spawn, limits, and worker registry.
 - [ ] Track D: policy-backed tools and approval persistence.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -184,6 +184,7 @@
 - [x] Load `config.toml`.
 - [x] Write session metadata.
 - [x] Write agent metadata.
+- [x] Write AgentSession metadata.
 - [ ] Write worker metadata.
 - [x] Write JSONL event logs.
 - [ ] Write approval state.
@@ -194,6 +195,8 @@
 - [x] Add redaction tests.
 - [x] Add store-level recovery tests for partial and corrupt metadata files.
 - [x] Add daemon persistence integration tests for session/agent restart recovery.
+- [x] Add daemon persistence integration tests for AgentSession restart snapshot recovery.
+- [x] Add corrupt/partial AgentSession state fail-safe tests.
 
 ## 11. Agent Runtime
 
@@ -315,9 +318,10 @@
   model-driven spawn, worker failed/cancelled events, and executable workers.
 - [ ] Track D: policy-backed tools and approval persistence.
 - [ ] Track E: daemon-owned voice provider path, STT language setting, and voice doctor.
-- [ ] Track F: durable metadata and restart recovery for sessions, agents, workers, and approvals.
+- [ ] Track F: durable metadata and restart recovery for sessions, agents, AgentSessions, workers, and approvals.
 - [x] Track F store baseline: atomic JSON helpers and fail-safe metadata recovery.
 - [x] Track F daemon baseline: session/agent metadata survives runtime restart and cancelled sessions are removed.
+- [x] Track F AgentSession baseline: per-route AgentSession metadata survives runtime restart, snapshots replay recovered records, and corrupt final JSON reports daemon diagnostics while partial temp files are ignored.
 - [ ] Track G: CADIS-native Wulan avatar engine.
 - [ ] Track H: profile homes, agent homes, workspace registry, grants, and worker worktrees.
 - [x] Track H baseline: default profile layout plus persistent workspace registry/grants.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -120,7 +120,8 @@
 - [ ] Add shutdown handling.
 - [x] Add structured logging.
 - [x] Add focused daemon runtime mutex regression test.
-- [ ] Add full daemon socket integration test.
+- [x] Add full daemon socket integration test for two session subscribers and
+  non-blocked status/agent-list requests during in-flight generation.
 
 ## 6. CLI
 
@@ -308,7 +309,7 @@
 
 ## 15.1 Next Multi-Agent Execution Tracks
 
-- [ ] Track A: daemon event bus, live session subscription, and non-blocking generation path.
+- [x] Track A: daemon event bus, live session subscription, and non-blocking generation path.
 - [ ] Track B: provider readiness, effective model metadata, and provider streaming.
 - [ ] Track C: `AgentSession`, agent-driven spawn, limits, and worker registry.
 - [ ] Track D: policy-backed tools and approval persistence.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -332,11 +332,12 @@
 - [x] Implement workspace grants with expiry baseline.
 - [ ] Enforce denied paths across file, shell, git, and worker tools.
 - [x] Reject broad workspace roots and enforce safe-read workspace path guards.
-- [ ] Implement project `.cadis/workspace.toml` support.
+- [x] Implement project `.cadis/workspace.toml` store support.
 - [ ] Implement worker worktree creation under project `.cadis/worktrees/`.
 - [ ] Persist worker artifacts under profile `artifacts/workers/`.
 - [ ] Add project `.cadis/media/` manifests for generated media.
-- [ ] Add workspace/profile/agent doctor checks.
+- [x] Add workspace doctor checks for project metadata mismatch and duplicate roots.
+- [ ] Add profile/agent doctor checks.
 
 ## 16. Code Work Window
 

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -113,11 +113,14 @@
 - [x] Add event fan-out to multiple clients.
 - [x] Add `session.subscribe` protocol/request baseline.
 - [x] Add live persistent `session.subscribe` stream.
-- [ ] Avoid blocking daemon mutex during model generation.
+- [x] Avoid blocking daemon mutex during model generation.
+- [x] Publish daemon-owned route/status progress before model completion.
+- [x] Publish `message.delta` events from provider stream callbacks.
 - [x] Add session registry.
 - [ ] Add shutdown handling.
 - [x] Add structured logging.
-- [ ] Add daemon integration test.
+- [x] Add focused daemon runtime mutex regression test.
+- [ ] Add full daemon socket integration test.
 
 ## 6. CLI
 
@@ -305,7 +308,7 @@
 
 ## 15.1 Next Multi-Agent Execution Tracks
 
-- [ ] Track A: daemon event bus and live session subscription.
+- [ ] Track A: daemon event bus, live session subscription, and non-blocking generation path.
 - [ ] Track B: provider readiness, effective model metadata, and provider streaming.
 - [ ] Track C: `AgentSession`, agent-driven spawn, limits, and worker registry.
 - [ ] Track D: policy-backed tools and approval persistence.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -217,8 +217,8 @@
 
 - [ ] Define worker scheduler.
 - [ ] Define worker state.
-- [ ] Implement daemon worker registry.
-- [ ] Implement `worker.tail`.
+- [x] Implement daemon worker registry.
+- [x] Implement `worker.tail`.
 - [ ] Create git worktree.
 - [ ] Stream worker logs.
 - [ ] Add worker cancellation.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -326,8 +326,8 @@
 - [x] Document project `.cadis/media/` asset convention.
 - [x] Define workspace protocol/types.
 - [x] Implement `CADIS_HOME` and default `CADIS_PROFILE_HOME` resolver.
-- [ ] Implement profile home manager.
-- [ ] Implement agent home manager and templates.
+- [x] Implement profile home manager baseline.
+- [x] Implement agent home manager and templates.
 - [x] Implement workspace registry and aliases baseline.
 - [x] Implement workspace grants with expiry baseline.
 - [ ] Enforce denied paths across file, shell, git, and worker tools.
@@ -337,7 +337,7 @@
 - [ ] Persist worker artifacts under profile `artifacts/workers/`.
 - [ ] Add project `.cadis/media/` manifests for generated media.
 - [x] Add workspace doctor checks for project metadata mismatch and duplicate roots.
-- [ ] Add profile/agent doctor checks.
+- [x] Add profile/agent doctor checks for missing, corrupt, and oversized agent-home files.
 
 ## 16. Code Work Window
 

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -245,22 +245,22 @@
 
 ## 14. Voice Output
 
-- [ ] Define TTS provider trait.
-- [ ] Define speech policy.
-- [ ] Add voice on/off config.
-- [ ] Add explicit TTS provider config (`edge`, `openai`, `system`).
+- [x] Define TTS provider trait.
+- [x] Define speech policy.
+- [x] Add voice on/off config.
+- [x] Add explicit TTS provider config (`edge`, `openai`, `system`).
 - [x] Separate HUD STT language from TTS voice.
 - [x] Add HUD-local voice doctor/preflight.
 - [x] Add WebAudio PCM fallback for WebKit MediaRecorder zero-chunk mic capture.
-- [ ] Promote voice doctor/preflight into daemon-visible status.
+- [x] Promote voice doctor/preflight into daemon-visible status.
 - [ ] Handle daemon voice events in HUD.
-- [ ] Add provider stub.
+- [x] Add provider stub.
 - [ ] Implement first provider.
-- [ ] Speak short normal answers.
+- [x] Speak short normal answers.
 - [ ] Summarize long answers.
-- [ ] Block code/diff/log speech.
+- [x] Block code/diff/log speech.
 - [ ] Speak approval risk summary.
-- [ ] Add speech routing tests.
+- [x] Add speech routing tests.
 
 ## 15. HUD
 

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -333,10 +333,13 @@
 - [ ] Enforce denied paths across file, shell, git, and worker tools.
 - [x] Reject broad workspace roots and enforce safe-read workspace path guards.
 - [x] Implement project `.cadis/workspace.toml` store support.
+- [x] Add project `.cadis/worktrees/` worker path and metadata helpers.
+- [x] Add profile `artifacts/workers/` worker artifact path helpers.
 - [ ] Implement worker worktree creation under project `.cadis/worktrees/`.
 - [ ] Persist worker artifacts under profile `artifacts/workers/`.
 - [ ] Add project `.cadis/media/` manifests for generated media.
 - [x] Add workspace doctor checks for project metadata mismatch and duplicate roots.
+- [x] Add workspace doctor checks for stale worker worktree metadata and missing artifact roots.
 - [x] Add profile/agent doctor checks for missing, corrupt, and oversized agent-home files.
 
 ## 16. Code Work Window

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -135,11 +135,11 @@
 ## 7. Model Provider Layer
 
 - [x] Define `ModelProvider` trait.
-- [ ] Define provider capabilities.
+- [x] Define provider capabilities.
 - [x] Define streaming event type.
 - [ ] Add real provider streaming callback support.
-- [ ] Add provider readiness and effective model metadata.
-- [ ] Apply per-agent model selection to provider routing.
+- [x] Add provider readiness and effective model metadata.
+- [x] Apply per-agent model selection to provider routing.
 - [ ] Define cancellation behavior.
 - [x] Define provider error mapping.
 - [x] Implement first provider.
@@ -306,7 +306,7 @@
 ## 15.1 Next Multi-Agent Execution Tracks
 
 - [ ] Track A: daemon event bus and live session subscription.
-- [ ] Track B: provider readiness, effective model metadata, and provider streaming.
+- [ ] Track B: provider readiness, effective model metadata, selected-model routing, and provider streaming.
 - [ ] Track C: `AgentSession`, agent-driven spawn, limits, and worker registry.
 - [ ] Track D: policy-backed tools and approval persistence.
 - [ ] Track E: daemon-owned voice provider path, STT language setting, and voice doctor.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -140,10 +140,11 @@
 - [ ] Add real provider streaming callback support.
 - [x] Add provider readiness and effective model metadata.
 - [x] Apply per-agent model selection to provider routing.
-- [ ] Define cancellation behavior.
+- [x] Define provider-boundary cancellation behavior.
 - [x] Define provider error mapping.
 - [x] Implement first provider.
-- [ ] Add provider conformance tests.
+- [x] Add provider callback/cancellation conformance tests.
+- [ ] Add full live-provider conformance tests.
 - [x] Add provider config docs.
 - [ ] Add second provider.
 

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -184,16 +184,18 @@
 - [x] Load `config.toml`.
 - [x] Write session metadata.
 - [x] Write agent metadata.
-- [ ] Write worker metadata.
+- [x] Write worker metadata for daemon-planned worker delegations.
 - [x] Write JSONL event logs.
 - [ ] Write approval state.
 - [x] Add store-level atomic JSON state helpers under `~/.cadis/state`.
 - [x] Implement atomic writes for store-level JSON metadata.
 - [x] Implement redaction.
 - [x] Add crash recovery metadata for daemon session/agent metadata.
+- [x] Add daemon recovery for stale non-terminal worker metadata.
 - [x] Add redaction tests.
 - [x] Add store-level recovery tests for partial and corrupt metadata files.
 - [x] Add daemon persistence integration tests for session/agent restart recovery.
+- [x] Add daemon persistence integration tests for worker restart recovery.
 
 ## 11. Agent Runtime
 
@@ -313,6 +315,7 @@
 - [ ] Track F: durable metadata and restart recovery for sessions, agents, workers, and approvals.
 - [x] Track F store baseline: atomic JSON helpers and fail-safe metadata recovery.
 - [x] Track F daemon baseline: session/agent metadata survives runtime restart and cancelled sessions are removed.
+- [x] Track F daemon worker baseline: worker metadata survives runtime restart and stale running workers recover as failed.
 - [ ] Track G: CADIS-native Wulan avatar engine.
 - [ ] Track H: profile homes, agent homes, workspace registry, grants, and worker worktrees.
 - [x] Track H baseline: default profile layout plus persistent workspace registry/grants.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -293,13 +293,13 @@
 - [x] Confirm avatar style changes route through `ui.preferences.set`.
 - [x] Define renderer-neutral Wulan avatar render state.
 - [ ] Connect native Wulan renderer to `cadis-avatar` frames.
-- [ ] Spike focused Rust/wgpu Wulan renderer.
+- [x] Spike focused Rust/wgpu Wulan renderer contract as feature-gated render plans.
 - [ ] Reconsider Bevy only through a decision record if wgpu is insufficient.
 - [ ] Port Wulan portrait shader, particles, reticles, eye overlay, and mouth overlay from the Three.js prototype.
 - [ ] Add Wulan body gesture set: idle breath, listening lean, nod, gaze shift, approval hand cue, speaking emphasis, coding focus, thinking scan, and error recoil.
-- [ ] Add reduced-motion behavior for Wulan gestures.
+- [x] Add reduced-motion behavior for Wulan gestures and wgpu render plans.
 - [ ] Keep optional face tracking off by default, local-only, permission-gated, and visibly indicated when active.
-- [ ] Confirm Wulan native renderer failure falls back to the CADIS orb.
+- [x] Confirm Wulan native renderer failure falls back to the CADIS orb in avatar crate tests.
 - [ ] Capture HUD screenshot parity at 1200x760, 1600x1000, and 1920x1080.
 - [ ] Confirm no overlapping cards, status text, chat panel, approval stack, or central orb text.
 

--- a/docs/12_TEST_STRATEGY.md
+++ b/docs/12_TEST_STRATEGY.md
@@ -144,7 +144,7 @@ frontend dependency failure is visible:
 
 - repository hygiene checks required public files
 - Rust checks run `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all-targets --all-features`
-- native avatar checks are covered by workspace Rust checks; `cargo test -p cadis-avatar` is the focused local check for avatar-only changes
+- native avatar checks are covered by workspace Rust checks; `cargo test -p cadis-avatar` is the focused local check for avatar-only changes, and `cargo test -p cadis-avatar --all-features` also covers the feature-gated wgpu render-plan spike
 - HUD checks run from `apps/cadis-hud` with pnpm: `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build`
 - HUD native shell check runs `cargo check --manifest-path apps/cadis-hud/src-tauri/Cargo.toml --locked`
 - browser preview and Playwright E2E are local or later-stage checks until stable enough for required CI

--- a/docs/12_TEST_STRATEGY.md
+++ b/docs/12_TEST_STRATEGY.md
@@ -108,7 +108,7 @@ Performance tests should run locally first and become CI benchmarks later only i
 - HUD voice doctor preflight can report missing `whisper-cli`, missing model,
   blocked mic, Node helper, and audio player states without secrets
 - `cadis-avatar` unit tests cover mode-to-gesture mapping, face-tracking privacy,
-  reduced-motion behavior, and renderer frame shape
+  reduced-motion behavior, renderer fallback state, and renderer frame shape
 
 ### v0.2
 

--- a/docs/12_TEST_STRATEGY.md
+++ b/docs/12_TEST_STRATEGY.md
@@ -149,5 +149,5 @@ frontend dependency failure is visible:
 - HUD native shell check runs `cargo check --manifest-path apps/cadis-hud/src-tauri/Cargo.toml --locked`
 - browser preview and Playwright E2E are local or later-stage checks until stable enough for required CI
 - current orchestrator coverage should include route events, agent status events,
-  request-driven spawn limits, and the fact that live `session.subscribe`
-  fan-out is not implemented yet
+  request-driven spawn limits, and live `session.subscribe` fan-out to multiple
+  session-filtered subscribers

--- a/docs/12_TEST_STRATEGY.md
+++ b/docs/12_TEST_STRATEGY.md
@@ -151,3 +151,6 @@ frontend dependency failure is visible:
 - current orchestrator coverage should include route events, agent status events,
   request-driven spawn limits, and live `session.subscribe` fan-out to multiple
   session-filtered subscribers
+- current daemon socket coverage should include two clients receiving the same
+  session events and unrelated `daemon.status` / `agent.list` requests
+  completing while message generation is in flight

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -591,6 +591,11 @@ remains the local capture/playback bridge for microphone permissions,
 `MediaRecorder`, WebAudio PCM fallback, whisper execution, and native audio
 playback.
 
+Supported daemon-visible TTS provider IDs are `edge`, `openai`, and `system`.
+The `stub` provider is available for deterministic tests. In this slice all
+provider implementations are daemon-local stubs: they validate policy and emit
+voice lifecycle events without calling external APIs or reading secrets.
+
 ```json
 {
   "type": "voice.preflight",
@@ -610,6 +615,12 @@ playback.
   ]
 }
 ```
+
+The daemon applies speech policy before provider dispatch. Final assistant
+messages may emit `voice.started` and `voice.completed` only after
+`message.completed`, only when `enabled` and `auto_speak` are true, and only for
+speakable content. Code, diffs, terminal logs, and long raw tool or test output
+must not produce voice playback events.
 
 `status` values are `ok`, `warn`, or `error`. The daemon also accepts HUD-local
 aliases such as `pass` and `fail` and normalizes them before emitting

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -400,6 +400,12 @@ Model-backed `message.delta` and `message.completed` payloads may include a
 actually served the request. When fallback occurs, `fallback` is true and
 `fallback_reason` may contain a redacted reason suitable for logs and clients.
 
+For `message.send`, `cadisd` first publishes daemon-owned session, route, and
+agent status events, then runs provider generation outside the runtime mutex.
+Providers with stream callbacks cause `message.delta` events to be fanned out
+as callbacks arrive; providers without native streaming still produce the same
+typed events after their blocking response returns.
+
 ## 5. Content Kind
 
 ```text

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -129,8 +129,30 @@ Example:
 
 `events.snapshot` is a one-shot request for daemon-owned state. The desktop MVP
 snapshot is represented as normal event frames, currently including
-`agent.list.response`, `ui.preferences.updated`, and `session.updated` for known
-sessions.
+`agent.list.response`, `ui.preferences.updated`, `session.updated` for known
+sessions, and worker lifecycle snapshots for workers known to the in-memory
+daemon worker registry.
+
+`worker.tail` is a one-shot request for recent daemon-owned worker log lines.
+The desktop MVP replays log lines from the in-memory worker registry as
+`worker.log.delta` events. `lines` is optional; when absent the daemon returns
+up to 64 recent lines, capped at 1000. Unknown workers are rejected with
+`worker_not_found`.
+
+Example:
+
+```json
+{
+  "protocol_version": "0.1",
+  "request_id": "req_...",
+  "client_id": "cli_...",
+  "type": "worker.tail",
+  "payload": {
+    "worker_id": "worker_000001",
+    "lines": 20
+  }
+}
+```
 
 `tool.call` requests daemon-owned native tool execution. Tool calls must resolve
 a registered workspace and an active workspace grant before execution or

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -335,6 +335,16 @@ voice.completed
 {
   "models": [
     {
+      "provider": "auto",
+      "model": "llama3.2",
+      "display_name": "Auto (Ollama llama3.2, then local fallback)",
+      "capabilities": ["streaming", "local_fallback"],
+      "readiness": "fallback",
+      "effective_provider": "ollama",
+      "effective_model": "llama3.2",
+      "fallback": true
+    },
+    {
       "provider": "echo",
       "model": "cadis-local-fallback",
       "display_name": "CADIS local fallback",
@@ -350,9 +360,11 @@ voice.completed
 
 `readiness` is one of `ready`, `fallback`, `requires_configuration`, or
 `unavailable`. `fallback: true` means the entry is not a real model provider.
-For `auto`, CADIS reports the primary effective provider as `ollama` and marks
-the entry as fallback-capable because runtime requests can still fall back to
-`echo` if Ollama is not ready.
+For `auto`, CADIS reports the configured Ollama model as the primary effective
+model and marks the entry as fallback-capable because runtime requests can still
+fall back to `echo` if Ollama is not ready. `models.list` uses daemon config so
+clients can display the configured Ollama/OpenAI model IDs instead of generic
+placeholders.
 
 Model-backed `message.delta` and `message.completed` payloads may include a
 `model` object:

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -132,6 +132,29 @@ snapshot is represented as normal event frames, currently including
 `agent.list.response`, `ui.preferences.updated`, and `session.updated` for known
 sessions.
 
+`session.subscribe` keeps the connection open after the immediate
+`request.accepted` response. The daemon sends the current `session.updated`
+snapshot when `include_snapshot` is true, then bounded replay and live events
+whose event envelope has the requested `session_id`. It does not deliver
+daemon-global events such as agent rosters or UI preferences.
+
+Example:
+
+```json
+{
+  "protocol_version": "0.1",
+  "request_id": "req_...",
+  "client_id": "cli_...",
+  "type": "session.subscribe",
+  "payload": {
+    "session_id": "ses_...",
+    "since_event_id": "evt_000120",
+    "replay_limit": 128,
+    "include_snapshot": true
+  }
+}
+```
+
 `tool.call` requests daemon-owned native tool execution. Tool calls must resolve
 a registered workspace and an active workspace grant before execution or
 approval flow proceeds. `agent_id` is optional; when present, it lets daemon tool
@@ -445,6 +468,7 @@ Initial:
 
 - Unix socket NDJSON request/response frames
 - `events.subscribe` over the same socket for long-lived local event streams
+- `session.subscribe` over the same socket for session-filtered event streams
 
 The desktop daemon keeps an in-memory bounded replay buffer for recent runtime
 events. The baseline buffer is process-local and is not a durable event store.

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -277,6 +277,11 @@ agent.renamed
 agent.model.changed
 agent.status.changed
 agent.completed
+agent.session.started
+agent.session.updated
+agent.session.completed
+agent.session.failed
+agent.session.cancelled
 workspace.list.response
 workspace.registered
 workspace.grant.created
@@ -304,6 +309,35 @@ voice.completed
 ```
 
 `models.list.response` payloads include conservative provider readiness metadata:
+
+`agent.session.*` events are emitted by the daemon-owned Agent Runtime baseline
+for each routed agent task. They are in-memory for the desktop MVP and carry the
+route, task, result, timeout, budget, cancellation, and parent-child metadata
+needed by clients to render lifecycle state without owning orchestration:
+
+```json
+{
+  "type": "agent.session.started",
+  "agent_session_id": "ags_000001",
+  "session_id": "ses_...",
+  "route_id": "route_000001",
+  "agent_id": "coder",
+  "parent_agent_id": "main",
+  "task": "run focused tests",
+  "status": "running",
+  "timeout_at": "2026-04-26T00:15:00Z",
+  "budget_steps": 1,
+  "steps_used": 0
+}
+```
+
+Allowed AgentSession statuses are `started`, `running`, `completed`, `failed`,
+`cancelled`, `timed_out`, and `budget_exceeded`. `agent.session.completed` adds
+an optional redacted `result`. Terminal failure/cancellation events add optional
+`error_code`, `error`, and `cancellation_requested_at` fields as applicable.
+The current baseline enforces a per-route step budget before provider execution
+and records timeout deadlines; model/tool-loop cancellation and async interrupt
+remain later runtime work.
 
 `workspace.list.response` payload:
 
@@ -563,6 +597,9 @@ The daemon assigns the new `agent_id` and confirms with `agent.spawned`.
 Client-requested spawning and explicit `/worker` or `/spawn` orchestration are
 bounded by daemon config. The desktop MVP defaults allow child depth 2, 4 direct
 children per parent, and 32 total registered agents including built-in agents.
+Explicit orchestration is daemon-owned: `/worker` and `/spawn` requests create
+an AgentSession, call the same core spawn path as `agent.spawn`, and enforce the
+same depth, child, and global caps before any provider response is produced.
 Rejections use:
 
 - `agent_spawn_depth_limit_exceeded`

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -377,6 +377,25 @@ Model-backed `message.delta` and `message.completed` payloads may include a
 actually served the request. When fallback occurs, `fallback` is true and
 `fallback_reason` may contain a redacted reason suitable for logs and clients.
 
+Model provider failures use the normal `ErrorPayload` shape on `session.failed`
+events:
+
+```json
+{
+  "code": "provider_unavailable",
+  "message": "Ollama request failed",
+  "retryable": true
+}
+```
+
+Clients should treat `code` and `retryable` as the machine-readable fields.
+Provider error messages are for display only and must be redacted before they
+reach protocol events or logs. Common Track B provider codes are
+`model_auth_missing`, `model_auth_failed`, `provider_client_error`,
+`provider_unavailable`, `provider_rate_limited`, `provider_http_error`,
+`model_not_found`, `model_request_rejected`, `provider_response_invalid`,
+`provider_response_empty`, and `codex_cli_*`.
+
 ## 5. Content Kind
 
 ```text

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -130,8 +130,11 @@ Example:
 `events.snapshot` is a one-shot request for daemon-owned state. The desktop MVP
 snapshot is represented as normal event frames, currently including
 `agent.list.response`, `ui.preferences.updated`, `session.updated` for known
-sessions, and worker lifecycle snapshots for workers known to the in-memory
-daemon worker registry.
+sessions, `agent.session.*` snapshots for recovered or in-memory per-route
+AgentSession records, and worker lifecycle snapshots for workers known to the
+in-memory daemon worker registry. If durable AgentSession recovery skipped a
+corrupt final JSON file, the snapshot also includes a redacted `daemon.error`
+diagnostic; partial temporary files are ignored and do not produce events.
 
 `worker.tail` is a one-shot request for recent daemon-owned worker log lines.
 The desktop MVP replays log lines from the in-memory worker registry as
@@ -336,8 +339,10 @@ Allowed AgentSession statuses are `started`, `running`, `completed`, `failed`,
 an optional redacted `result`. Terminal failure/cancellation events add optional
 `error_code`, `error`, and `cancellation_requested_at` fields as applicable.
 The current baseline enforces a per-route step budget before provider execution
-and records timeout deadlines; model/tool-loop cancellation and async interrupt
-remain later runtime work.
+and records timeout deadlines. AgentSession metadata is written atomically under
+`state/agent-sessions/` and recovered on daemon restart so snapshots can replay
+the current AgentSession state. Model/tool-loop cancellation and async
+interrupt remain later runtime work.
 
 `workspace.list.response` payload:
 

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -129,8 +129,9 @@ Example:
 
 `events.snapshot` is a one-shot request for daemon-owned state. The desktop MVP
 snapshot is represented as normal event frames, currently including
-`agent.list.response`, `ui.preferences.updated`, and `session.updated` for known
-sessions.
+`agent.list.response`, `ui.preferences.updated`, `session.updated` for known
+sessions, recovered worker lifecycle events, and `daemon.error` diagnostics for
+corrupt or skipped durable metadata.
 
 `tool.call` requests daemon-owned native tool execution. Tool calls must resolve
 a registered workspace and an active workspace grant before execution or

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -99,6 +99,9 @@ worker.tail
 models.list
 ui.preferences.get
 ui.preferences.set
+voice.status
+voice.doctor
+voice.preflight
 voice.preview
 voice.stop
 config.reload
@@ -233,7 +236,16 @@ daemon.status.response
   "socket_path": "/run/user/1000/cadis/cadisd.sock",
   "sessions": 0,
   "model_provider": "auto",
-  "uptime_seconds": 3
+  "uptime_seconds": 3,
+  "voice": {
+    "enabled": false,
+    "state": "disabled",
+    "provider": "edge",
+    "voice_id": "id-ID-GadisNeural",
+    "stt_language": "auto",
+    "max_spoken_chars": 800,
+    "bridge": "hud-local"
+  }
 }
 ```
 
@@ -262,6 +274,9 @@ workspace.grant.revoked
 workspace.doctor.response
 models.list.response
 ui.preferences.updated
+voice.status.updated
+voice.doctor.response
+voice.preflight.response
 orchestrator.route
 tool.requested
 tool.started
@@ -563,6 +578,42 @@ Implicit model-driven spawning is reserved for a later runtime track.
   }
 }
 ```
+
+### `voice.status`, `voice.doctor`, and `voice.preflight`
+
+`voice.status` returns the daemon-visible voice state as a
+`voice.status.updated` event. `voice.doctor` returns `voice.doctor.response`
+with daemon checks plus the last local bridge preflight when one has been
+reported.
+
+The daemon remains the owner of voice preferences and policy state. HUD/Tauri
+remains the local capture/playback bridge for microphone permissions,
+`MediaRecorder`, WebAudio PCM fallback, whisper execution, and native audio
+playback.
+
+```json
+{
+  "type": "voice.preflight",
+  "surface": "cadis-hud",
+  "summary": "ready",
+  "checks": [
+    {
+      "name": "microphone",
+      "status": "ok",
+      "message": "1 input visible"
+    },
+    {
+      "name": "webaudio.pcm_fallback",
+      "status": "ok",
+      "message": "PCM fallback available when MediaRecorder emits zero chunks"
+    }
+  ]
+}
+```
+
+`status` values are `ok`, `warn`, or `error`. The daemon also accepts HUD-local
+aliases such as `pass` and `fail` and normalizes them before emitting
+`voice.preflight.response`.
 
 ### `voice.preview`
 

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -44,6 +44,8 @@ first run:
 |   |   `-- <session-id>.json
 |   |-- agents/
 |   |   `-- <agent-id>.json
+|   |-- agent-sessions/
+|   |   `-- <agent-session-id>.json
 |   |-- workers/
 |   |   `-- <worker-id>.json
 |   `-- approvals/
@@ -382,6 +384,7 @@ The store crate provides atomic JSON helpers for these exact durable files:
 ```text
 ~/.cadis/state/sessions/<session-id>.json
 ~/.cadis/state/agents/<agent-id>.json
+~/.cadis/state/agent-sessions/<agent-session-id>.json
 ~/.cadis/state/workers/<worker-id>.json
 ~/.cadis/state/approvals/<approval-id>.json
 ```
@@ -400,3 +403,9 @@ The store writes redacted pretty JSON, syncs the temporary file, renames it over
 the target `.json`, and syncs the parent directory. Recovery only reads final
 `.json` files. Partial temp files are ignored, and corrupt final JSON files are
 skipped with diagnostics instead of becoming trusted runtime state.
+
+The daemon persists per-route `AgentSession` records in
+`state/agent-sessions/` on lifecycle transitions. On restart, valid records are
+replayed through `events.snapshot` as `agent.session.*` events. Corrupt final
+AgentSession JSON is skipped and surfaced as a redacted `daemon.error`
+diagnostic; partial `.tmp` files are ignored.

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -105,11 +105,14 @@ always_on_top = false
 
 [voice]
 enabled = false
+provider = "edge"
 voice_id = "id-ID-GadisNeural"
+stt_language = "auto"
 rate = 0
 pitch = 0
 volume = 0
 auto_speak = false
+max_spoken_chars = 800
 
 [agent_spawn]
 # Applies to client-requested agent.spawn and explicit orchestrator /worker actions.
@@ -347,6 +350,12 @@ shared client override, and `XDG_RUNTIME_DIR` for the default daemon socket
 under `$XDG_RUNTIME_DIR/cadis/cadisd.sock`. `VITE_CADIS_SOCKET_PATH` is a
 development-only renderer seed for the browser preview; daemon state remains
 authoritative.
+
+Daemon-owned voice preferences read `[voice].provider`, `[voice].voice_id`,
+`[voice].stt_language`, and `[voice].max_spoken_chars` for status, doctor, and
+preflight reporting. The current green slice supports `edge`, `openai`, and
+`system` provider labels at the protocol/config layer; HUD/Tauri still performs
+local capture and playback.
 
 HUD voice input reads `CADIS_WHISPER_CLI`, `WHISPER_CLI`,
 `CADIS_WHISPER_MODEL`, `WHISPER_MODEL`, `CADIS_WHISPER_LANGUAGE`, and

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -19,6 +19,19 @@ first run:
 |       |-- profile.toml
 |       |-- .gitignore
 |       |-- agents/
+|       |   `-- <agent>/
+|       |       |-- AGENT.toml
+|       |       |-- PERSONA.md
+|       |       |-- INSTRUCTIONS.md
+|       |       |-- USER.md
+|       |       |-- MEMORY.md
+|       |       |-- TOOLS.md
+|       |       |-- POLICY.toml
+|       |       |-- SKILL_POLICY.toml
+|       |       |-- skills/
+|       |       |-- memory/
+|       |       |-- prompts/
+|       |       `-- sessions/
 |       |-- memory/
 |       |-- skills/
 |       |-- workspaces/
@@ -67,6 +80,10 @@ workspace registry metadata, worker records, session records, artifacts,
 checkpoints, event logs, channels, and secrets. The store crate keeps creating
 the existing top-level paths so current daemon/core/CLI code continues to work
 while profile-aware runtime pieces are added.
+
+When `cadisd` starts, daemon-known agents get non-destructive agent-home
+templates under `profiles/<profile>/agents/<agent>/`. Existing files are not
+overwritten.
 
 ## 2. Desktop MVP Config
 
@@ -162,6 +179,81 @@ initialization is non-destructive: existing profile files are not overwritten.
 The profile home is not an execution workspace and is not a sandbox. Project
 roots must be registered separately in the workspace registry before
 profile-aware tool/runtime code grants file, shell, git, or worker access.
+
+## 3.1 Agent Home Layout
+
+The store crate provides an `AgentHome` helper. The daemon initializes homes for
+agents it knows about:
+
+```text
+~/.cadis/profiles/<profile>/agents/<agent>/
+|-- AGENT.toml
+|-- PERSONA.md
+|-- INSTRUCTIONS.md
+|-- USER.md
+|-- MEMORY.md
+|-- TOOLS.md
+|-- POLICY.toml
+|-- SKILL_POLICY.toml
+|-- skills/
+|-- memory/
+|   |-- daily/
+|   |-- decisions.md
+|   `-- delegation.md
+|-- prompts/
+|-- sessions/
+`-- README.md
+```
+
+`AGENT.toml` records stable identity and conventional file names:
+
+```toml
+[agent]
+id = "main"
+display_name = "CADIS"
+role = "Orchestrator"
+model = "auto"
+
+[files]
+persona = "PERSONA.md"
+instructions = "INSTRUCTIONS.md"
+user = "USER.md"
+memory = "MEMORY.md"
+tools = "TOOLS.md"
+policy = "POLICY.toml"
+skill_policy = "SKILL_POLICY.toml"
+```
+
+`POLICY.toml` has a machine-readable structure that doctor checks parse as
+typed TOML:
+
+```toml
+[policy]
+version = 1
+default_workspace_access = ["read"]
+allow_network = false
+allow_secret_access = false
+allow_system_change = false
+approval_required = true
+
+[sandbox]
+default = "workspace"
+denied_paths = ["~/.ssh", "~/.aws", "~/.gnupg", "~/.config/gcloud", "/etc", "/dev", "/proc", "/sys"]
+
+[limits]
+max_agent_toml_bytes = 65536
+max_policy_toml_bytes = 65536
+max_text_file_bytes = 131072
+max_memory_file_bytes = 1048576
+```
+
+This file is policy metadata for the agent home. Runtime authorization remains
+daemon and policy-engine owned; Track D owns enforcement across mutating tool
+execution.
+
+`workspace doctor` currently includes profile/agent-home diagnostics for
+missing, invalid TOML, and oversized agent files. Dedicated `profile doctor` and
+`agent doctor` commands remain future work.
 
 ## 4. Workspace Registry
 

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -41,6 +41,7 @@ first run:
 |       |-- workers/
 |       |-- sessions/
 |       |-- artifacts/
+|       |   `-- workers/
 |       |-- checkpoints/
 |       |-- sandboxes/
 |       |-- eventlog/
@@ -161,6 +162,7 @@ profile state:
 |-- workers/
 |-- sessions/
 |-- artifacts/
+|   `-- workers/
 |-- checkpoints/
 |-- sandboxes/
 |-- eventlog/
@@ -255,6 +257,23 @@ execution.
 missing, invalid TOML, and oversized agent files. Dedicated `profile doctor` and
 `agent doctor` commands remain future work.
 
+## 3.2 Worker Artifact Paths
+
+Worker output artifacts are profile-scoped, not project-scoped:
+
+```text
+~/.cadis/profiles/<profile>/artifacts/workers/<worker-id>/
+|-- patch.diff
+|-- test-report.json
+|-- summary.md
+|-- changed-files.json
+`-- memory-candidates.jsonl
+```
+
+The store crate exposes path helpers for this layout. The current runtime can
+include these planned locations in worker events; producing the files is still
+part of the future worker runtime.
+
 ## 4. Workspace Registry
 
 Profile workspace metadata lives at:
@@ -330,6 +349,23 @@ media_root = ".cadis/media"
 missing, errors when `workspace_id` does not match the profile registry entry,
 and warns when project-local roots are absolute instead of project-relative.
 The file is metadata only; it does not create a workspace grant.
+
+## 4.2 Project Worker Worktree Metadata
+
+Worker worktree metadata is stored below the project worktree root:
+
+```text
+<project>/.cadis/worktrees/
+|-- <worker-id>/
+`-- .metadata/
+    `-- <worker-id>.toml
+```
+
+Each worker metadata file records the worker ID, workspace ID, planned or actual
+worktree path, branch name, optional base ref, lifecycle state, and profile
+artifact root. `workspace doctor` reports invalid TOML, stale/missing worktree
+paths, and stale/missing artifact roots. These checks are diagnostics only and
+do not run `git worktree` commands.
 
 ## 5. Native Avatar Config Contract
 

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -303,11 +303,13 @@ that model where the provider supports model overrides. Message events include
 the effective provider and model used for the response.
 
 The `models.list` protocol response exposes conservative readiness metadata for
-clients. `readiness = "fallback"` and `fallback = true` identify entries such as
-`echo` or fallback-capable `auto` behavior so clients can distinguish a real
-provider from the local fallback. Providers that need a daemon, login, API key,
-or local service are reported as `requires_configuration` until CADIS has active
-provider probing.
+clients and uses the configured `ollama_model` and `openai_model` as
+provider/model IDs. `readiness = "fallback"` and `fallback = true` identify
+entries such as `echo` or fallback-capable `auto` behavior so clients can
+distinguish a real provider from the local fallback. `openai` is reported as
+`ready` only when an OpenAI API key is present in the daemon environment.
+Providers that need a daemon, login, API key, or local service are otherwise
+reported as `requires_configuration` until CADIS has active provider probing.
 
 Provider failures are surfaced through the normal `ErrorPayload` fields on
 `session.failed` events. Clients should key off the stable `code` and

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -309,6 +309,15 @@ provider from the local fallback. Providers that need a daemon, login, API key,
 or local service are reported as `requires_configuration` until CADIS has active
 provider probing.
 
+Provider failures are surfaced through the normal `ErrorPayload` fields on
+`session.failed` events. Clients should key off the stable `code` and
+`retryable` fields instead of parsing the display message. Current provider
+codes include `model_auth_missing`, `model_auth_failed`,
+`provider_client_error`, `provider_unavailable`, `provider_rate_limited`,
+`provider_http_error`, `model_not_found`, `model_request_rejected`,
+`provider_response_invalid`, `provider_response_empty`, and `codex_cli_*`.
+Messages are redacted for client display and must not include provider keys.
+
 The OpenAI API key is not a config key. Do not put API keys, bearer tokens, or
 auth headers in `~/.cadis/config.toml`, examples, or logs.
 

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -117,6 +117,11 @@ max_depth = 2
 max_children_per_parent = 4
 max_total_agents = 32
 
+[agent_runtime]
+# Applies to daemon-owned per-route AgentSession records.
+default_timeout_sec = 900
+max_steps_per_session = 1
+
 [orchestrator]
 # Enables explicit /worker, /spawn, /route, and /delegate message actions.
 worker_delegation_enabled = true

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -223,6 +223,7 @@ read by the desktop MVP config loader:
 ```toml
 [avatar]
 renderer = "wgpu_native" # "headless", "wgpu_native", "bevy_scene"
+renderer_fallback = "orb" # "orb", "static_wulan_texture"
 reduced_motion = false
 max_delta_ms = 250
 
@@ -244,6 +245,8 @@ allow_face_identity = false
 Rules:
 
 - Face tracking is off by default.
+- Native Wulan renderer failure falls back to the CADIS orb by default and must
+  not block HUD launch.
 - Enabling face tracking requires explicit permission, a visible camera-active
   indicator, and a one-click disable action.
 - Face tracking data must stay local and must not be persisted by default.

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -214,6 +214,31 @@ These store helpers only persist metadata. Enforcement remains daemon/runtime
 owned: file, shell, git, and worker tools must resolve an active grant before
 using a project root.
 
+## 4.1 Project `.cadis/workspace.toml`
+
+Project-local metadata is optional but recommended for registered project
+workspaces:
+
+```text
+<project>/.cadis/workspace.toml
+```
+
+The store crate loads and writes this TOML shape:
+
+```toml
+workspace_id = "example-project"
+kind = "project"
+vcs = "git"
+worktree_root = ".cadis/worktrees"
+artifact_root = ".cadis/artifacts"
+media_root = ".cadis/media"
+```
+
+`workspace doctor` reads this file when present. It warns when the file is
+missing, errors when `workspace_id` does not match the profile registry entry,
+and warns when project-local roots are absolute instead of project-relative.
+The file is metadata only; it does not create a workspace grant.
+
 ## 5. Native Avatar Config Contract
 
 `crates/cadis-avatar` defines the Rust config contract for the future native

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -105,6 +105,9 @@ always_on_top = false
 
 [voice]
 enabled = false
+# Supported visible providers: "edge", "openai", "system".
+# "stub" is reserved for deterministic tests. Current provider implementations
+# are daemon-local stubs and do not call external APIs.
 provider = "edge"
 voice_id = "id-ID-GadisNeural"
 stt_language = "auto"
@@ -127,6 +130,12 @@ default_worker_role = "Worker"
 ```
 
 An example file is available at `config/cadis.example.toml`.
+
+Voice preferences are interpreted by `cadisd`. The speech policy respects
+`enabled`, `auto_speak`, and `max_spoken_chars` before dispatching text to a
+provider. The daemon blocks code, diffs, terminal logs, and long raw tool or
+test output from speech. HUD/Tauri remains the local microphone and playback
+bridge where platform APIs require it.
 
 ## 3. Profile Home Layout
 

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -245,6 +245,9 @@ allow_face_identity = false
 Rules:
 
 - Face tracking is off by default.
+- The current `wgpu-renderer` crate feature is a native adapter spike that builds
+  render plans from `AvatarFrame`; the desktop MVP config loader does not yet
+  instantiate a GPU surface from these keys.
 - Native Wulan renderer failure falls back to the CADIS orb by default and must
   not block HUD launch.
 - Enabling face tracking requires explicit permission, a visible camera-active

--- a/docs/17_DEVELOPER_SETUP.md
+++ b/docs/17_DEVELOPER_SETUP.md
@@ -230,6 +230,7 @@ The store crate owns the durable metadata path contract:
 ```text
 ~/.cadis/state/sessions/<session-id>.json
 ~/.cadis/state/agents/<agent-id>.json
+~/.cadis/state/agent-sessions/<agent-session-id>.json
 ~/.cadis/state/workers/<worker-id>.json
 ~/.cadis/state/approvals/<approval-id>.json
 ```
@@ -237,6 +238,10 @@ The store crate owns the durable metadata path contract:
 Use `StateStore` for new metadata writes. It sanitizes IDs for paths, writes
 redacted JSON through temp-file-plus-rename, ignores partial temp files during
 recovery, and reports corrupt final JSON as diagnostics.
+`cadis-core` currently reloads session, agent, and AgentSession metadata on
+runtime startup. Recovered AgentSession records are replayed in
+`events.snapshot`; corrupt final AgentSession JSON is reported as a redacted
+`daemon.error` diagnostic.
 
 ## 14. Development Rules
 

--- a/docs/17_DEVELOPER_SETUP.md
+++ b/docs/17_DEVELOPER_SETUP.md
@@ -13,6 +13,8 @@ CADIS now has a desktop MVP runtime:
 - Ollama optional model adapter with local fallback.
 - OpenAI optional model adapter using env-only API keys.
 - Official Codex CLI optional adapter using `codex exec`.
+- In-memory worker registry and `worker.tail` replay for route-time worker
+  delegation logs.
 - Tauri `cadis-hud` desktop prototype under `apps/cadis-hud`.
 - HUD-local voice doctor preflight for mic, `whisper-cli`, Whisper model, Node
   helper, and audio player checks.
@@ -217,9 +219,9 @@ message completed, and agent status events as follow-up frames for a request.
 It also supports request-driven `agent.spawn` with configured depth, child, and
 total-agent limits.
 
-The `session.subscribe` and worker-tail protocol surfaces exist, but live
-multi-client event fan-out, persistent subscriptions, and daemon worker
-execution are not implemented yet.
+The `session.subscribe` protocol surface exists, and `worker.tail` can replay
+recent in-memory daemon worker logs. Persistent worker recovery and daemon
+worker execution are not implemented yet.
 
 ## 13. Durable State Notes
 

--- a/docs/17_DEVELOPER_SETUP.md
+++ b/docs/17_DEVELOPER_SETUP.md
@@ -217,9 +217,9 @@ message completed, and agent status events as follow-up frames for a request.
 It also supports request-driven `agent.spawn` with configured depth, child, and
 total-agent limits.
 
-The `session.subscribe` and worker-tail protocol surfaces exist, but live
-multi-client event fan-out, persistent subscriptions, and daemon worker
-execution are not implemented yet.
+`events.subscribe` streams daemon-wide events. `session.subscribe` streams the
+current session snapshot, bounded replay, and live events filtered to one
+session ID. Worker-tail and daemon worker execution are not implemented yet.
 
 ## 13. Durable State Notes
 

--- a/docs/18_INSTALLATION.md
+++ b/docs/18_INSTALLATION.md
@@ -164,8 +164,8 @@ target/release/cadis chat "hello"
 - No native file/shell tool runtime yet.
 - Approval commands exist in the CLI protocol surface but approval storage and tool gating are not implemented yet.
 - Protocol types exist for orchestrator route, `session.subscribe`, and worker
-  events, but live multi-client event fan-out and worker execution are not
-  implemented yet.
+  events. Live event fan-out exists for daemon-wide and session-filtered
+  streams, but worker execution is not implemented yet.
 - Telegram, production daemon-owned voice output, full HUD parity, and code work window are not implemented yet.
 - The Tauri HUD is source-built for now; packaged desktop artifacts are not published yet.
 

--- a/docs/21_UI_FEATURE_PARITY_CHECKLIST.md
+++ b/docs/21_UI_FEATURE_PARITY_CHECKLIST.md
@@ -75,8 +75,8 @@ This checklist tracks RamaClaw-to-CADIS UI parity. A checked item means the CADI
 - [ ] Show current task target.
 - [ ] Show current task detail.
 - [ ] Show model detail when idle.
-- [ ] Show worker count when workers exist.
-- [ ] Show nested workers.
+- [x] Show worker count when workers exist.
+- [x] Show nested workers.
 - [ ] Support transient worker cards if desired.
 
 ## 8. Agent Rename
@@ -207,7 +207,7 @@ This checklist tracks RamaClaw-to-CADIS UI parity. A checked item means the CADI
 - [ ] Handle agent task.
 - [ ] Handle streaming messages.
 - [ ] Handle approvals.
-- [ ] Handle worker lifecycle.
+- [x] Handle worker lifecycle.
 - [ ] Handle route log.
 - [ ] Send message through `message.send`.
 - [ ] Send model update.
@@ -216,12 +216,12 @@ This checklist tracks RamaClaw-to-CADIS UI parity. A checked item means the CADI
 
 ## 17. Prototype Validation
 
-- [ ] HUD prototype can run against mock CADIS events without a full agent runtime.
+- [x] HUD prototype can run against mock CADIS events without a full agent runtime for worker progress.
 - [ ] Prototype view model contains only ephemeral UI state plus event-derived snapshots.
 - [ ] Prototype does not use localStorage, browser storage, or UI files as authoritative durable state.
 - [ ] Prototype shows daemon connected, disconnected, and reconnecting states.
 - [ ] Prototype renders active, idle, waiting, failed, and cancelled agent states.
-- [ ] Prototype renders worker lifecycle updates through `worker.event`.
+- [x] Prototype renders worker lifecycle updates through `worker.event` / `worker.*` daemon events.
 - [ ] Prototype renders approval lifecycle from `approval.requested` to `approval.resolved`.
 - [ ] Prototype keeps approval card visible after click until daemon resolution event.
 - [ ] Prototype confirms rename and model changes only after daemon events/responses.

--- a/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
+++ b/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
@@ -441,9 +441,16 @@ Updates worker tree and optional transient worker card.
 
 `worker.log.delta` carries `worker_id`, `delta`, and optional `agent_id` /
 `parent_agent_id`. `worker.completed` carries the same metadata plus optional
-`summary`. `worker.tail` returns recent daemon-owned log lines as
-`worker.log.delta` events for an existing worker; clients should apply those
-events through the same worker reducer used for live updates.
+`summary`. `worker.failed` and `worker.cancelled`, when emitted by later daemon
+phases, must flow through the same reducer. `worker.tail` returns recent
+daemon-owned log lines as `worker.log.delta` events for an existing worker;
+clients should apply those events through the same worker reducer used for live
+updates.
+
+HUD worker progress is derived from daemon events only. The worker tree may
+combine `agent.session.*` progress (`steps_used` / `budget_steps`) with
+`worker.*` status, log tail, worktree metadata, and artifact paths, but it must
+not create, execute, cancel, or approve workers locally.
 
 ### `orchestrator.route`
 
@@ -554,6 +561,8 @@ The HUD must speak only speakable content:
 Protocol adaptation is valid when:
 
 - HUD can render from a mock CADIS event stream.
+- HUD worker progress renders from the mock daemon worker stream fixture without
+  a running agent runtime.
 - All RamaClaw UI features have CADIS request/event equivalents.
 - UI preferences persist through daemon config, not localStorage.
 - Approval card lifecycle is server-confirmed.

--- a/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
+++ b/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
@@ -323,6 +323,32 @@ The optional `task` field on `agent.status.changed` drives the current task
 summary. A separate `agent.task.changed` event is reserved for a later protocol
 version.
 
+### `agent.session.started` / `agent.session.updated` / terminal events
+
+Tracks daemon-owned per-route agent runtime state. HUD may display these as
+task details under the agent card, but it must treat `cadisd` as authoritative
+for timeout, budget, cancellation, result, and parent-child metadata.
+
+```json
+{
+  "type": "agent.session.started",
+  "agent_session_id": "ags_000001",
+  "session_id": "ses_123",
+  "route_id": "route_000001",
+  "agent_id": "coder",
+  "parent_agent_id": "main",
+  "task": "run focused tests",
+  "status": "running",
+  "timeout_at": "2026-04-26T00:15:00Z",
+  "budget_steps": 1,
+  "steps_used": 0
+}
+```
+
+Terminal events are `agent.session.completed`, `agent.session.failed`, and
+`agent.session.cancelled`. Status values are `started`, `running`, `completed`,
+`failed`, `cancelled`, `timed_out`, and `budget_exceeded`.
+
 ### `agent.renamed`
 
 Confirms rename and updates all surfaces.

--- a/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
+++ b/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
@@ -514,6 +514,10 @@ Drive the voice status and doctor rows in the HUD config dialog.
 daemon `ok`, `warn`, and `error` statuses to its existing pass/warn/fail doctor
 presentation.
 
+Daemon-visible TTS provider IDs are `edge`, `openai`, and `system`; `stub` is
+reserved for deterministic tests. Current daemon providers are local stubs that
+validate speech policy and emit lifecycle events without external API calls.
+
 ## 7. RamaClaw Topic Mapping
 
 | RamaClaw topic/message | CADIS request/event |
@@ -573,6 +577,11 @@ The HUD must speak only speakable content:
 | diff | no |
 | terminal_log | no |
 | test_result | short summary only |
+
+`cadisd` applies this policy before provider dispatch. Auto-speak waits for the
+final `message.completed` event and may then emit `voice.started` and
+`voice.completed` for short speakable content. Code, diffs, terminal logs, and
+long raw tool or test output must not emit voice playback events.
 
 ## 10. Validation
 

--- a/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
+++ b/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
@@ -111,6 +111,25 @@ Sent when the HUD needs a one-shot daemon-owned state snapshot.
 The current desktop MVP snapshot is encoded as event frames, including
 `agent.list.response`, `ui.preferences.updated`, and `session.updated`.
 
+### `session.subscribe`
+
+Sent when a client wants only one session's events rather than the daemon-wide
+event stream.
+
+```json
+{
+  "type": "session.subscribe",
+  "session_id": "ses_...",
+  "replay_limit": 128,
+  "include_snapshot": true
+}
+```
+
+The daemon responds with `request.accepted`, then sends the current
+`session.updated` event, bounded replay, and live events whose envelope
+`session_id` matches the request. The HUD may use this for focused session panes
+while keeping daemon-wide `events.subscribe` as the main state feed.
+
 ### `message.send`
 
 Sent when the user submits text in the chat panel.

--- a/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
+++ b/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
@@ -415,7 +415,9 @@ Updates worker tree and optional transient worker card.
 
 `worker.log.delta` carries `worker_id`, `delta`, and optional `agent_id` /
 `parent_agent_id`. `worker.completed` carries the same metadata plus optional
-`summary`.
+`summary`. `worker.tail` returns recent daemon-owned log lines as
+`worker.log.delta` events for an existing worker; clients should apply those
+events through the same worker reducer used for live updates.
 
 ### `orchestrator.route`
 

--- a/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
+++ b/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
@@ -228,6 +228,37 @@ Sent when user clicks stop during preview or speech.
 }
 ```
 
+### `voice.status`, `voice.doctor`, and `voice.preflight`
+
+Sent by the HUD to read daemon-visible voice state and to publish local bridge
+preflight results. The HUD still owns platform capture/playback mechanics; it
+does not become authoritative for durable voice preferences, speech policy, or
+agent routing.
+
+```json
+{
+  "type": "voice.preflight",
+  "surface": "cadis-hud",
+  "summary": "ready",
+  "checks": [
+    {
+      "name": "microphone",
+      "status": "ok",
+      "message": "1 input visible"
+    },
+    {
+      "name": "MediaRecorder",
+      "status": "warn",
+      "message": "recorder available; WebAudio PCM fallback remains armed"
+    }
+  ]
+}
+```
+
+The local bridge preflight must include microphone permission/API state,
+`MediaRecorder`, analyser, WebAudio PCM fallback, whisper binary/model,
+Node helper, and audio player checks when available.
+
 ## 6. Events
 
 ### `daemon.status`
@@ -460,6 +491,28 @@ Drive voice test UI.
   "voice_id": "id-ID-GadisNeural"
 }
 ```
+
+### `voice.status.updated`, `voice.doctor.response`, `voice.preflight.response`
+
+Drive the voice status and doctor rows in the HUD config dialog.
+
+```json
+{
+  "type": "voice.status.updated",
+  "enabled": false,
+  "state": "disabled",
+  "provider": "edge",
+  "voice_id": "id-ID-GadisNeural",
+  "stt_language": "auto",
+  "max_spoken_chars": 800,
+  "bridge": "hud-local"
+}
+```
+
+`voice.doctor.response` and `voice.preflight.response` wrap the same status with
+`checks[]`, each containing `name`, `status`, and `message`. The HUD maps
+daemon `ok`, `warn`, and `error` statuses to its existing pass/warn/fail doctor
+presentation.
 
 ## 7. RamaClaw Topic Mapping
 

--- a/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
+++ b/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
@@ -262,6 +262,18 @@ Drives connection and status bar.
 }
 ```
 
+### `session.started`
+
+Creates a visible session progress row before model output arrives.
+
+```json
+{
+  "type": "session.started",
+  "session_id": "ses_123",
+  "title": "Fix auth test"
+}
+```
+
 ### `agent.list.response`
 
 Replaces the seeded roster with daemon-owned agent state.
@@ -545,6 +557,9 @@ The HUD must speak only speakable content:
 Protocol adaptation is valid when:
 
 - HUD can render from a mock CADIS event stream.
+- HUD shows `session.started`, `orchestrator.route`,
+  `agent.status.changed`, and `message.delta` progress before
+  `message.completed`.
 - All RamaClaw UI features have CADIS request/event equivalents.
 - UI preferences persist through daemon config, not localStorage.
 - Approval card lifecycle is server-confirmed.

--- a/docs/23_UI_DESIGN_SYSTEM.md
+++ b/docs/23_UI_DESIGN_SYSTEM.md
@@ -181,6 +181,8 @@ Responsibilities:
 - show worker status
 - show worker ID
 - show last text
+- show agent-session step progress when available
+- show compact worker progress without expanding card height unpredictably
 - collapse/expand
 
 ### `CadisChatPanel`
@@ -315,4 +317,3 @@ Canvas/pixel checks:
 - chat panel does not cover agent cards
 - approval cards do not cover config dialog
 - text fits in status bar at 1200px width
-

--- a/docs/26_WULAN_AVATAR_ENGINE.md
+++ b/docs/26_WULAN_AVATAR_ENGINE.md
@@ -146,6 +146,9 @@ The Rust state engine currently exposes:
   interruption, and reduced-motion metadata.
 - `BodyPose`, `FacePose`, and `AvatarMaterial` as renderer-neutral pose and
   shader hints.
+- `AvatarFallbackContract` and `AvatarFallbackState` so renderer failures can
+  degrade to the CADIS orb or a static Wulan texture without blocking HUD
+  launch.
 - `HeadlessAvatarRenderer` for tests and non-graphical planning.
 
 ## 6. Body Gesture Set

--- a/docs/26_WULAN_AVATAR_ENGINE.md
+++ b/docs/26_WULAN_AVATAR_ENGINE.md
@@ -88,8 +88,14 @@ Contract:
 - `WgpuRendererContract` declares target, texture format, alpha mode, uniform
   version, and first primitive families: portrait plane, hologram material,
   reticle rings, particles, face overlay, and body gesture rig.
-- The contract is data-only until a renderer crate is added; this avoids
-  pulling heavy GPU dependencies into the state engine.
+- With the `wgpu-renderer` feature, `crates/cadis-avatar` also exposes an
+  adapter-ready `wgpu_renderer` spike. It turns `AvatarFrame` data into a
+  deterministic `WgpuAvatarRenderPlan` for portrait, reticle, particle, face,
+  and body-rig primitives without linking the `wgpu` crate. A concrete GPU
+  adapter can translate that plan into pipelines and draw calls later.
+- The public boundary stays data-only and renderer-neutral until HUD integration
+  chooses a concrete GPU surface; this avoids pulling heavy GPU dependencies
+  into the state engine or daemon.
 
 ### Bevy Renderer
 
@@ -150,6 +156,8 @@ The Rust state engine currently exposes:
   degrade to the CADIS orb or a static Wulan texture without blocking HUD
   launch.
 - `HeadlessAvatarRenderer` for tests and non-graphical planning.
+- Feature-gated `wgpu_renderer::WgpuAvatarSpikeRenderer` and
+  `WgpuAvatarRenderPlan` for the next native renderer adapter slice.
 
 ## 6. Body Gesture Set
 
@@ -251,15 +259,24 @@ Exit criteria:
 
 ### Phase B - Native Renderer Spike
 
-- Create a small Rust/wgpu renderer outside `cadisd`.
-- Load the Wulan portrait texture.
-- Render alpha-cutout portrait, reticle rings, particles, and state color.
+- Create a small Rust/wgpu renderer outside `cadisd`. The first feature-gated
+  spike now lives in `crates/cadis-avatar::wgpu_renderer` as an adapter-ready
+  render-plan builder.
+- Load the Wulan portrait texture. The spike requires a
+  `portrait_texture_ready` readiness bit and fails into fallback state when the
+  adapter reports it unavailable; real texture upload remains a HUD/native
+  adapter task.
+- Render alpha-cutout portrait, reticle rings, particles, and state color. The
+  spike emits deterministic draw-state for those primitives but does not yet
+  issue GPU draw calls.
 - Support a mock render-state feed.
 
 Exit criteria:
 
-- Native renderer can show idle, thinking, speaking, approval, and error states.
-- It runs without camera or microphone permission.
+- Adapter-ready render plans cover idle, thinking, speaking, approval, and error
+  states, including reduced-motion particle and reticle limits.
+- It runs without camera or microphone permission and rejects renderer contracts
+  that require camera access.
 
 ### Phase C - HUD Integration
 

--- a/docs/27_WORKSPACE_ARCHITECTURE.md
+++ b/docs/27_WORKSPACE_ARCHITECTURE.md
@@ -6,7 +6,8 @@ workspace registry and active grants under the default profile, exposes
 `workspace list/register/grant/revoke/doctor` through the protocol and CLI, and
 keeps tool execution behind daemon-resolved workspace grants. Real worker
 worktree creation/cleanup, checkpoint rollback, workspace-local skill
-enforcement, and denied-path enforcement for mutating tools remain future work.
+enforcement, artifact production, and denied-path enforcement for mutating tools
+remain future work.
 
 ## 1. Purpose
 
@@ -51,10 +52,15 @@ Implemented baseline:
 - `workspace doctor` includes profile/agent-home diagnostics for missing,
   corrupt, and oversized agent files.
 - Worker events include planned worktree/artifact metadata.
+- Store helpers now resolve project worker worktree paths and metadata files
+  under `<project>/.cadis/worktrees/`, resolve worker artifact paths under
+  `profiles/<profile>/artifacts/workers/`, and let `workspace doctor` report
+  stale worker worktree metadata or missing artifact roots.
 
 Still future:
 
 - Worker worktree creation/cleanup.
+- Worker artifact production and durable worker runtime records.
 - Checkpoint and rollback manager.
 - Dedicated profile and agent doctor commands.
 - Workspace-local skills and project `.cadis/` metadata enforcement.
@@ -261,6 +267,19 @@ Worker state and artifacts live under the profile:
 ~/.cadis/profiles/default/workers/<worker-id>.jsonl
 ~/.cadis/profiles/default/artifacts/workers/<worker-id>/
 ```
+
+Project-local worker worktree metadata lives beside the project worktree root:
+
+```text
+<project>/.cadis/worktrees/
+|-- <worker-id>/                  # planned/actual git worktree checkout
+`-- .metadata/
+    `-- <worker-id>.toml          # worker ID, workspace ID, path, branch, base ref, state, artifact root
+```
+
+`workspace doctor` treats these metadata files as diagnostics only. It warns
+when a recorded worktree path or profile artifact root is stale/missing; it does
+not create, remove, or mutate git worktrees.
 
 Workers receive write/exec grants only for their worktree unless the user
 explicitly approves broader access. The parent project checkout remains

--- a/docs/27_WORKSPACE_ARCHITECTURE.md
+++ b/docs/27_WORKSPACE_ARCHITECTURE.md
@@ -133,6 +133,11 @@ under `.cadis/` and must not contain secrets:
 worktree root, artifact root, and media root. It does not grant access by
 itself; the daemon must still resolve a workspace grant.
 
+Current baseline: `cadis-store` can load and write this project-local metadata,
+and `workspace doctor` reports missing files, registry ID mismatch, absolute
+project-local roots, and duplicate registered roots. Creation/initialization UX
+remains future work.
+
 ## 5. Media Assets Convention
 
 Project-scoped media assets generated or curated by CADIS should use:

--- a/docs/27_WORKSPACE_ARCHITECTURE.md
+++ b/docs/27_WORKSPACE_ARCHITECTURE.md
@@ -1,11 +1,12 @@
 # Workspace Architecture
 
 Status: Baseline accepted and partially implemented. CADIS now initializes
-profile homes, persists the workspace registry and active grants under the
-default profile, exposes `workspace list/register/grant/revoke/doctor` through
-the protocol and CLI, and keeps tool execution behind daemon-resolved workspace
-grants. Agent homes, real worker worktree creation/cleanup, checkpoint rollback,
-and workspace-local skill enforcement remain future work.
+profile homes, creates daemon-known agent homes from templates, persists the
+workspace registry and active grants under the default profile, exposes
+`workspace list/register/grant/revoke/doctor` through the protocol and CLI, and
+keeps tool execution behind daemon-resolved workspace grants. Real worker
+worktree creation/cleanup, checkpoint rollback, workspace-local skill
+enforcement, and denied-path enforcement for mutating tools remain future work.
 
 ## 1. Purpose
 
@@ -39,19 +40,23 @@ The current desktop MVP implements only part of this architecture:
 Implemented baseline:
 
 - `~/.cadis/profiles/<profile>/` profile homes.
+- Persistent daemon-known agent homes under each profile with `AGENT.toml`,
+  persona/instruction/user/memory/tool guidance files, typed `POLICY.toml`
+  metadata, `SKILL_POLICY.toml`, and agent-local memory/skill/prompt folders.
 - Profile-local workspace registry and grant files.
 - Protocol/CLI workspace commands: `list`, `register`, `grant`, `revoke`, and
   `doctor`.
 - Tool calls require a registered workspace and matching active grant before
   safe-read execution or approval flow.
+- `workspace doctor` includes profile/agent-home diagnostics for missing,
+  corrupt, and oversized agent files.
 - Worker events include planned worktree/artifact metadata.
 
 Still future:
 
-- Persistent agent homes under each profile.
 - Worker worktree creation/cleanup.
 - Checkpoint and rollback manager.
-- Profile and agent doctor commands.
+- Dedicated profile and agent doctor commands.
 - Workspace-local skills and project `.cadis/` metadata enforcement.
 
 ## 3. Target Home Layout
@@ -282,11 +287,11 @@ The workspace architecture should be implemented in this order:
 | --- | --- |
 | W0 | Finalize terminology and protocol types |
 | W1 | CADIS home resolver and directory skeleton |
-| W2 | Profile manager |
-| W3 | Agent home manager |
+| W2 | Profile manager baseline implemented |
+| W3 | Agent home manager/templates baseline implemented |
 | W4 | Workspace registry and grants |
 | W5 | Worker worktree manager |
 | W6 | Checkpoint and rollback manager |
 | W7 | Event log and session store integration |
 | W8 | Channel bindings and deterministic routing |
-| W9 | Doctor, migration, and templates |
+| W9 | Doctor, migration, and templates; profile/agent file diagnostics baseline implemented |

--- a/docs/standards/13_MODEL_PROVIDER_STANDARD.md
+++ b/docs/standards/13_MODEL_PROVIDER_STANDARD.md
@@ -89,9 +89,15 @@ The daemon maps provider events into CADIS session events such as `message.delta
 Streaming rules:
 
 - Preserve token order.
-- Providers that do not support native upstream streaming must use the shared
+- Providers must emit normalized events through the shared callback interface.
+  Providers that do not support native upstream streaming must use the same
   callback interface to emit structured simulated deltas from chunked output.
-- Support cancellation where the upstream API permits it.
+- The callback returns `ModelStreamControl::Continue` to accept more events or
+  `ModelStreamControl::Cancel` to request provider-boundary cancellation.
+- On callback cancellation, providers must stop emitting deltas, return a
+  non-retryable `model_cancelled` error, and emit `model.cancelled` when they
+  can resolve invocation metadata.
+- Support upstream cancellation where the provider transport permits it.
 - Convert provider-specific stop reasons to CADIS stop metadata.
 - Bound memory usage for long streams.
 - Surface partial output carefully when errors occur.

--- a/docs/standards/15_UI_HUD_STANDARD.md
+++ b/docs/standards/15_UI_HUD_STANDARD.md
@@ -71,7 +71,8 @@ Required elements:
 - dashed spokes from orb to agents
 - 12 non-overlapping perimeter slots
 - agent satellite cards
-- nested worker tree under each agent
+- nested worker tree under each agent, derived from daemon `agent.session.*` and
+  `worker.*` events
 - model, context, mode, and voice readouts around the orb
 - state-driven orb animation
 

--- a/docs/standards/15_UI_HUD_STANDARD.md
+++ b/docs/standards/15_UI_HUD_STANDARD.md
@@ -97,8 +97,8 @@ Rules:
 - The current Three.js Wulan Arc implementation is a HUD prototype and migration
   reference, not the long-term native engine boundary.
 - `crates/cadis-avatar` owns the renderer-independent state engine and exposes
-  `AvatarFrame`, `BodyGestureState`, `AvatarPrivacy`, and direct-wgpu uniform
-  contract data without depending on `wgpu` or Bevy.
+  `AvatarFrame`, `BodyGestureState`, `AvatarPrivacy`, fallback state, and
+  direct-wgpu uniform contract data without depending on `wgpu` or Bevy.
 - The preferred native renderer is a focused Rust/wgpu engine. The renderer
   adapter should consume `WgpuAvatarUniforms` and `WgpuRendererContract`
   directly once the heavy renderer dependency is introduced.

--- a/docs/standards/16_VOICE_STANDARD.md
+++ b/docs/standards/16_VOICE_STANDARD.md
@@ -26,8 +26,8 @@ Provider responsibilities:
 Initial provider options:
 
 - `edge`
-- `os`
-- `piper`
+- `openai`
+- `system`
 - `stub`
 
 The `stub` provider is required for deterministic tests.
@@ -175,6 +175,9 @@ an encoder fallback path, not a failed microphone.
 Voice requests:
 
 ```text
+voice.status
+voice.doctor
+voice.preflight
 voice.preview
 voice.stop
 ui.preferences.set
@@ -183,6 +186,9 @@ ui.preferences.set
 Voice events:
 
 ```text
+voice.status.updated
+voice.doctor.response
+voice.preflight.response
 voice.preview.started
 voice.preview.completed
 voice.preview.failed
@@ -190,6 +196,9 @@ ui.preferences.updated
 ```
 
 Voice preview failure must be visible in the HUD and structured in logs.
+The HUD must report its local bridge doctor/preflight results to `cadisd`
+through `voice.preflight`, while still keeping microphone capture, WebAudio PCM
+fallback, whisper invocation, and native playback local to the HUD/Tauri bridge.
 
 ## 12. Privacy and Logging
 

--- a/docs/standards/16_VOICE_STANDARD.md
+++ b/docs/standards/16_VOICE_STANDARD.md
@@ -31,6 +31,10 @@ Initial provider options:
 - `stub`
 
 The `stub` provider is required for deterministic tests.
+The first daemon-owned provider slice may implement `edge`, `openai`, and
+`system` as local stubs. Stubs must report provider identity, curated voices,
+and lifecycle success or structured failure without making external API calls,
+spawning compatibility helpers, or reading provider credentials.
 
 ## 4. Voice Preferences
 
@@ -99,6 +103,10 @@ CADIS must speak only content that is useful and safe to hear.
 
 Long answers must be summarized before speaking. Long code, diffs, logs, and raw command output must not be spoken.
 
+The daemon speech policy must run before provider dispatch. Policy rejection
+must prevent `voice.started`, `voice.completed`, provider calls, and logging of
+the blocked text body.
+
 ## 7. Auto-Speak Rules
 
 Auto-speak must:
@@ -111,6 +119,9 @@ Auto-speak must:
 - stop current speech before starting a new preview or explicit speech action
 
 Streaming deltas must not be spoken one by one.
+
+In the current daemon-owned slice, long content that requires summarization is
+blocked from direct speech until a summarization path exists.
 
 ## 8. Approval Speech
 


### PR DESCRIPTION
## Summary
- Merge completed Track A/B/C/E/F/G/H and HUD worker progress branches into one clean integration branch.
- Resolve cross-track conflicts across runtime recovery, agent sessions, voice diagnostics, worker worktrees, avatar renderer spike, and HUD worker progress.
- Add strict-validation fixes for daemon streaming callbacks and RuntimeOptions test initializers.

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- pnpm test (apps/cadis-hud)
- pnpm typecheck (apps/cadis-hud)
- pnpm lint (apps/cadis-hud)
- pnpm build (apps/cadis-hud)
