### PR TITLE
Track I: worker execution worktree baseline

### DIFF
--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
@@ -34,7 +35,8 @@ use cadis_protocol::{
 use cadis_store::{
     redact, AgentHomeDiagnostic, AgentHomeDoctorOptions, AgentHomeTemplate, ApprovalRecord,
     ApprovalState, ApprovalStore, CadisConfig, CadisHome, CheckpointPolicy,
-    GrantSource as StoreGrantSource, ProfileHome, ProjectWorkspaceStore, ProjectWorktreeDiagnostic,
+    GrantSource as StoreGrantSource, ProfileHome, ProjectWorkerWorktreeMetadata,
+    ProjectWorkerWorktreeState, ProjectWorkspaceStore, ProjectWorktreeDiagnostic,
     StateRecoveryDiagnostic, StateStore, WorkerArtifactPathSet,
     WorkspaceAccess as StoreWorkspaceAccess, WorkspaceAlias,
     WorkspaceGrantRecord as StoreWorkspaceGrantRecord, WorkspaceKind as StoreWorkspaceKind,
@@ -1015,12 +1017,16 @@ impl Runtime {
         ));
 
         let session_workspace = self.session_workspace(&session_id);
+        let session_workspace_id = session_workspace
+            .as_deref()
+            .and_then(|workspace| self.workspace_id_for_root(workspace));
         let worker = route.worker_summary.as_ref().map(|summary| {
             let worker_id = self.next_worker_id();
             WorkerDelegation {
                 worktree: planned_worker_worktree(
                     &worker_id,
                     session_workspace.as_deref(),
+                    session_workspace_id.as_deref(),
                     &route.content,
                 ),
                 artifacts: worker_artifact_locations(
@@ -2243,8 +2249,9 @@ impl Runtime {
         agent_id: AgentId,
         worker: &WorkerDelegation,
     ) -> Vec<EventEnvelope> {
-        let record = WorkerRecord::from_delegation(session_id, Some(agent_id), worker);
+        let mut record = WorkerRecord::from_delegation(session_id, Some(agent_id), worker);
         let worker_id = record.worker_id.clone();
+        let preparation_logs = prepare_worker_execution(&mut record);
         let mut events = vec![self.session_event(
             record.session_id.clone(),
             CadisEvent::WorkerStarted(record.event_payload()),
@@ -2255,6 +2262,11 @@ impl Runtime {
             self.append_worker_log(&worker_id, format!("started: {}\n", worker.summary))
         {
             events.push(event);
+        }
+        for line in preparation_logs {
+            if let Some(event) = self.append_worker_log(&worker_id, line) {
+                events.push(event);
+            }
         }
         events
     }
@@ -2269,10 +2281,27 @@ impl Runtime {
         if let Some(event) = self.append_worker_log(worker_id, format!("{status}: {summary}\n")) {
             events.push(event);
         }
+        for line in self.write_worker_artifacts(worker_id, status, &summary) {
+            if let Some(event) = self.append_worker_log(worker_id, line) {
+                events.push(event);
+            }
+        }
         if let Some(event) = self.update_worker_status(worker_id, status, Some(summary)) {
             events.push(event);
         }
         events
+    }
+
+    fn write_worker_artifacts(
+        &mut self,
+        worker_id: &str,
+        status: &str,
+        summary: &str,
+    ) -> Vec<String> {
+        let Some(worker) = self.workers.get_mut(worker_id) else {
+            return Vec::new();
+        };
+        write_worker_artifacts(worker, status, summary)
     }
 
     fn append_worker_log(
@@ -2536,6 +2565,14 @@ impl Runtime {
         self.sessions
             .get(session_id)
             .and_then(|session| session._cwd.clone())
+    }
+
+    fn workspace_id_for_root(&self, root: &str) -> Option<String> {
+        let root = canonical_workspace_root(root).ok()?;
+        self.workspaces
+            .iter()
+            .find(|(_, record)| record.root == root)
+            .map(|(workspace_id, _)| workspace_id.to_string())
     }
 
     fn execute_safe_tool(
@@ -5427,6 +5464,7 @@ fn summarize_task(content: &str) -> String {
 fn planned_worker_worktree(
     worker_id: &str,
     workspace: Option<&str>,
+    workspace_id: Option<&str>,
     task: &str,
 ) -> WorkerWorktreeIntent {
     let worktree_root = workspace
@@ -5446,7 +5484,7 @@ fn planned_worker_worktree(
         .to_string();
 
     WorkerWorktreeIntent {
-        workspace_id: None,
+        workspace_id: workspace_id.map(ToOwned::to_owned),
         project_root: workspace.map(ToOwned::to_owned),
         worktree_root,
         worktree_path,
@@ -5465,6 +5503,282 @@ fn worker_artifact_locations(paths: &WorkerArtifactPathSet) -> WorkerArtifactLoc
         summary: paths.summary.display().to_string(),
         changed_files: paths.changed_files.display().to_string(),
         memory_candidates: paths.memory_candidates.display().to_string(),
+    }
+}
+
+fn prepare_worker_execution(record: &mut WorkerRecord) -> Vec<String> {
+    let mut logs = Vec::new();
+    if let Some(artifacts) = &record.artifacts {
+        if let Err(error) = fs::create_dir_all(&artifacts.root) {
+            logs.push(format!("artifact layout failed: {error}\n"));
+        }
+    }
+
+    if let Some(worktree) = &mut record.worktree {
+        logs.extend(prepare_worker_worktree(
+            &record.worker_id,
+            worktree,
+            record.artifacts.as_ref(),
+        ));
+    }
+
+    logs.into_iter().map(|line| redact(&line)).collect()
+}
+
+fn prepare_worker_worktree(
+    worker_id: &str,
+    worktree: &mut WorkerWorktreeIntent,
+    artifacts: Option<&WorkerArtifactLocations>,
+) -> Vec<String> {
+    let mut logs = Vec::new();
+    let Some(project_root) = worktree.project_root.clone() else {
+        return logs;
+    };
+    let project_root = PathBuf::from(project_root);
+    let store = ProjectWorkspaceStore::new(&project_root);
+    let metadata = store.load().ok().flatten();
+    let paths = store.worker_worktree_paths(worker_id, metadata.as_ref());
+    let artifact_root = artifacts
+        .map(|artifacts| PathBuf::from(&artifacts.root))
+        .unwrap_or_else(|| PathBuf::from(format!("artifacts/workers/{worker_id}")));
+
+    if let Err(error) = store.ensure_layout() {
+        logs.push(format!("worktree layout failed: {error}\n"));
+        return logs;
+    }
+
+    if !is_git_work_tree(&project_root) {
+        let _ = store.save_worker_worktree_metadata(&project_worker_metadata(
+            worker_id,
+            worktree,
+            &paths.worktree_path,
+            &artifact_root,
+            ProjectWorkerWorktreeState::Planned,
+        ));
+        logs.push("worktree skipped: session workspace is not a git worktree\n".to_owned());
+        return logs;
+    }
+
+    if let Some(parent) = paths.worktree_path.parent() {
+        if let Err(error) = fs::create_dir_all(parent) {
+            logs.push(format!("worktree parent creation failed: {error}\n"));
+            return logs;
+        }
+    }
+
+    if paths.worktree_path.exists() {
+        worktree.state = WorkerWorktreeState::Active;
+        worktree.worktree_path = paths.worktree_path.display().to_string();
+        let _ = store.save_worker_worktree_metadata(&project_worker_metadata(
+            worker_id,
+            worktree,
+            &paths.worktree_path,
+            &artifact_root,
+            ProjectWorkerWorktreeState::Ready,
+        ));
+        logs.push(format!(
+            "worktree ready: {}\n",
+            paths.worktree_path.display()
+        ));
+        return logs;
+    }
+
+    let base_ref = worktree.base_ref.as_deref().unwrap_or("HEAD");
+    match create_git_worktree(
+        &project_root,
+        &paths.worktree_path,
+        &worktree.branch_name,
+        base_ref,
+    ) {
+        Ok(()) => {
+            worktree.state = WorkerWorktreeState::Active;
+            worktree.worktree_path = paths.worktree_path.display().to_string();
+            let _ = store.save_worker_worktree_metadata(&project_worker_metadata(
+                worker_id,
+                worktree,
+                &paths.worktree_path,
+                &artifact_root,
+                ProjectWorkerWorktreeState::Ready,
+            ));
+            logs.push(format!(
+                "worktree ready: {} ({})\n",
+                paths.worktree_path.display(),
+                worktree.branch_name
+            ));
+        }
+        Err(error) => {
+            let _ = store.save_worker_worktree_metadata(&project_worker_metadata(
+                worker_id,
+                worktree,
+                &paths.worktree_path,
+                &artifact_root,
+                ProjectWorkerWorktreeState::Planned,
+            ));
+            logs.push(format!("worktree creation failed: {error}\n"));
+        }
+    }
+
+    logs
+}
+
+fn project_worker_metadata(
+    worker_id: &str,
+    worktree: &WorkerWorktreeIntent,
+    worktree_path: &Path,
+    artifact_root: &Path,
+    state: ProjectWorkerWorktreeState,
+) -> ProjectWorkerWorktreeMetadata {
+    ProjectWorkerWorktreeMetadata {
+        worker_id: worker_id.to_owned(),
+        workspace_id: worktree
+            .workspace_id
+            .clone()
+            .unwrap_or_else(|| "session".to_owned()),
+        worktree_path: worktree_path.to_path_buf(),
+        branch_name: worktree.branch_name.clone(),
+        base_ref: worktree.base_ref.clone(),
+        state,
+        artifact_root: artifact_root.to_path_buf(),
+    }
+}
+
+fn is_git_work_tree(root: &Path) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn create_git_worktree(
+    project_root: &Path,
+    worktree_path: &Path,
+    branch_name: &str,
+    base_ref: &str,
+) -> Result<(), String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["worktree", "add", "-b"])
+        .arg(branch_name)
+        .arg(worktree_path)
+        .arg(base_ref)
+        .output()
+        .map_err(|error| error.to_string())?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = redact(&String::from_utf8_lossy(&output.stderr));
+        Err(if stderr.trim().is_empty() {
+            "git worktree add failed".to_owned()
+        } else {
+            stderr.trim().to_owned()
+        })
+    }
+}
+
+fn write_worker_artifacts(record: &mut WorkerRecord, status: &str, summary: &str) -> Vec<String> {
+    let mut logs = Vec::new();
+    let Some(artifacts) = record.artifacts.clone() else {
+        return logs;
+    };
+    if let Err(error) = fs::create_dir_all(&artifacts.root) {
+        logs.push(format!("artifact write failed: {error}\n"));
+        return logs;
+    }
+
+    let summary_content = format!(
+        "# Worker {}\n\nStatus: {}\n\n{}\n",
+        record.worker_id,
+        status,
+        redact(summary)
+    );
+    if let Err(error) = write_artifact(&artifacts.summary, &summary_content) {
+        logs.push(format!("summary artifact failed: {error}\n"));
+    }
+
+    let worktree_path = record
+        .worktree
+        .as_ref()
+        .filter(|worktree| worktree.state == WorkerWorktreeState::Active)
+        .map(|worktree| PathBuf::from(&worktree.worktree_path));
+
+    let patch = worktree_path
+        .as_deref()
+        .and_then(|path| git_stdout(path, ["diff", "--binary", "HEAD"]).ok())
+        .unwrap_or_default();
+    if let Err(error) = write_artifact(&artifacts.patch, &patch) {
+        logs.push(format!("patch artifact failed: {error}\n"));
+    }
+
+    let status_lines = worktree_path
+        .as_deref()
+        .and_then(|path| git_stdout(path, ["status", "--short"]).ok())
+        .unwrap_or_default()
+        .lines()
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    let changed_files = serde_json::json!({
+        "worker_id": record.worker_id.clone(),
+        "status": status,
+        "files": status_lines,
+    });
+    if let Err(error) = write_json_artifact(&artifacts.changed_files, &changed_files) {
+        logs.push(format!("changed-files artifact failed: {error}\n"));
+    }
+
+    let test_report = serde_json::json!({
+        "worker_id": record.worker_id.clone(),
+        "status": status,
+        "summary": redact(summary),
+        "generated_by": "cadisd",
+        "generated_at": now_timestamp(),
+    });
+    if let Err(error) = write_json_artifact(&artifacts.test_report, &test_report) {
+        logs.push(format!("test-report artifact failed: {error}\n"));
+    }
+
+    if let Err(error) = write_artifact(&artifacts.memory_candidates, "") {
+        logs.push(format!("memory-candidates artifact failed: {error}\n"));
+    }
+
+    if let Some(worktree) = &mut record.worktree {
+        if worker_status_is_terminal(status) && worktree.state == WorkerWorktreeState::Active {
+            worktree.state = WorkerWorktreeState::ReviewPending;
+        }
+    }
+
+    logs.into_iter().map(|line| redact(&line)).collect()
+}
+
+fn write_artifact(path: &str, content: &str) -> io::Result<()> {
+    let path = Path::new(path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, redact(content))
+}
+
+fn write_json_artifact(path: &str, value: &serde_json::Value) -> io::Result<()> {
+    let mut content = serde_json::to_string_pretty(value).unwrap_or_else(|_| "{}".to_owned());
+    content.push('\n');
+    write_artifact(path, &content)
+}
+
+fn git_stdout<const N: usize>(cwd: &Path, args: [&str; N]) -> Result<String, String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .output()
+        .map_err(|error| error.to_string())?;
+    if output.status.success() {
+        Ok(redact(&String::from_utf8_lossy(&output.stdout)))
+    } else {
+        Err(redact(&String::from_utf8_lossy(&output.stderr)))
     }
 }
 
@@ -5754,6 +6068,40 @@ mod tests {
         ));
         fs::create_dir_all(&path).expect("test workspace should be created");
         path
+    }
+
+    fn init_git_workspace(root: &Path) {
+        run_git(root, &["init"]);
+        fs::write(root.join("README.md"), "CADIS worker fixture\n")
+            .expect("fixture file should write");
+        run_git(root, &["add", "README.md"]);
+        run_git(
+            root,
+            &[
+                "-c",
+                "user.name=CADIS Test",
+                "-c",
+                "user.email=cadis@example.invalid",
+                "commit",
+                "-m",
+                "initial",
+            ],
+        );
+    }
+
+    fn run_git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .output()
+            .expect("git should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     fn register_workspace(runtime: &mut Runtime, workspace_id: &str, root: &Path) {
@@ -6710,6 +7058,96 @@ mod tests {
             .expect("worker metadata should recover");
         assert_eq!(recovered.records.len(), 1);
         assert_eq!(recovered.records[0].metadata.status, "failed");
+    }
+
+    #[test]
+    fn worker_execution_creates_git_worktree_and_artifacts() {
+        let cadis_home = test_workspace("worker-execution-home");
+        let workspace = test_workspace("worker-execution-workspace");
+        init_git_workspace(&workspace);
+
+        let mut runtime = runtime_with_home(cadis_home);
+        register_workspace(&mut runtime, "worker-git", &workspace);
+        let session_id = runtime
+            .handle_request(RequestEnvelope::new(
+                RequestId::from("req_worker_session"),
+                ClientId::from("cli_1"),
+                ClientRequest::SessionCreate(SessionCreateRequest {
+                    title: Some("Worker execution".to_owned()),
+                    cwd: Some(workspace.display().to_string()),
+                }),
+            ))
+            .events
+            .into_iter()
+            .find_map(|event| match event.event {
+                CadisEvent::SessionStarted(payload) => Some(payload.session_id),
+                _ => None,
+            })
+            .expect("session.started should be emitted");
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_worker_execution"),
+            ClientId::from("hud_1"),
+            ClientRequest::MessageSend(MessageSendRequest {
+                session_id: Some(session_id),
+                target_agent_id: None,
+                content: "/route @codex run focused tests".to_owned(),
+                content_kind: ContentKind::Chat,
+            }),
+        ));
+
+        let started = outcome
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::WorkerStarted(payload) => Some(payload),
+                _ => None,
+            })
+            .expect("worker.started should be emitted");
+        let worktree = started
+            .worktree
+            .as_ref()
+            .expect("worker.started should include worktree metadata");
+        assert_eq!(worktree.workspace_id.as_deref(), Some("worker-git"));
+        assert_eq!(worktree.state, WorkerWorktreeState::Active);
+        assert!(Path::new(&worktree.worktree_path).is_dir());
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::WorkerLogDelta(payload)
+                    if payload.delta.contains("worktree ready")
+            )
+        }));
+
+        let completed = outcome
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::WorkerCompleted(payload) => Some(payload),
+                _ => None,
+            })
+            .expect("worker.completed should be emitted");
+        let completed_worktree = completed
+            .worktree
+            .as_ref()
+            .expect("worker.completed should include worktree metadata");
+        assert_eq!(completed_worktree.state, WorkerWorktreeState::ReviewPending);
+
+        let artifacts = completed
+            .artifacts
+            .as_ref()
+            .expect("worker.completed should include artifact paths");
+        assert!(Path::new(&artifacts.summary).is_file());
+        assert!(Path::new(&artifacts.test_report).is_file());
+        assert!(Path::new(&artifacts.changed_files).is_file());
+        assert!(Path::new(&artifacts.patch).is_file());
+
+        let project_metadata = ProjectWorkspaceStore::new(&workspace)
+            .load_worker_worktree_metadata("worker_000001")
+            .expect("worker worktree metadata should load")
+            .expect("worker worktree metadata should exist");
+        assert_eq!(project_metadata.workspace_id, "worker-git");
+        assert_eq!(project_metadata.state, ProjectWorkerWorktreeState::Ready);
     }
 
     #[test]

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -85,8 +85,10 @@ Still pending:
 - Daemon startup wiring for pending approval recovery. Store-level atomic write
   and fail-safe recovery helpers exist, and the daemon now recovers durable
   session, agent, AgentSession, and worker metadata.
-- Worker execution lifecycle, isolated worktrees, Telegram/mobile adapters,
-  daemon-owned production voice output, and code work window.
+- Worker cancellation/cleanup, Telegram/mobile adapters, daemon-owned
+  production voice output, and code work window. The first worker execution
+  slice now creates git worktrees for session-bound project workspaces and
+  writes profile-scoped worker artifacts.
 - Denied-path enforcement for all mutating tools, checkpoint/rollback manager,
   dedicated profile/agent doctor commands, and media asset manifests.
 - Future daemon-owned memory architecture from `25_MEMORY_CONCEPT.md`, including
@@ -302,8 +304,9 @@ Tasks:
   path/metadata helpers under project `.cadis/worktrees/` now exist.
 - Route coding workers into git worktrees and persist worker artifacts under the
   profile home. Profile-scoped worker artifact path helpers now point at
-  `profiles/<profile>/artifacts/workers/`; actual artifact production remains
-  future work.
+  `profiles/<profile>/artifacts/workers/`; the first execution slice creates
+  project-local git worktrees and writes summary, patch, changed-file, test
+  report, and memory-candidate artifact files.
 - Add doctor checks for duplicated roots, broad grants, symlink escapes, secret
   paths, stale worktrees, corrupt JSONL, and oversized memory/persona files.
   Workspace doctor now includes a baseline for missing, corrupt, and oversized
@@ -317,6 +320,31 @@ Exit criteria:
 - Coding workers edit only their worker worktree unless explicitly approved.
 - Project `.cadis/media/` manifests record generated media provenance without
   storing secrets or raw transcripts.
+
+### Track I - Worker Execution Runtime
+
+Owner: worker-runtime agents.
+
+Tasks:
+
+- Turn planned worker metadata into daemon-owned execution setup.
+- Create git worktrees under project `.cadis/worktrees/<worker-id>/` for
+  session-bound project workspaces.
+- Persist project-local worker worktree metadata with `ready` state once the
+  worktree exists.
+- Write profile-scoped worker artifacts: `summary.md`, `patch.diff`,
+  `changed-files.json`, `test-report.json`, and `memory-candidates.jsonl`.
+- Keep the parent checkout untouched; patch application remains gated by Track D
+  policy/approval work.
+- Continue surfacing worker lifecycle and log events to CLI/HUD.
+
+Exit criteria:
+
+- A routed coding worker with a git workspace receives an isolated worktree.
+- `worker.started` includes active worktree metadata, and `worker.completed`
+  moves it to review-pending state.
+- Worker artifacts are written under the profile artifact root and are redacted
+  before persistence.
 
 ## 3. P0 - Repository Foundation
 
@@ -592,10 +620,13 @@ Goal: isolate long-running and coding work.
 Tasks:
 
 - Define worker scheduler.
-- Add git worktree creation.
+- Add git worktree creation. Baseline now creates a project-local worktree for
+  session-bound git workspaces before worker execution starts.
 - Add worker log stream.
 - Add worker cleanup.
-- Add patch collection.
+- Add patch collection. Baseline now writes `patch.diff`, `changed-files.json`,
+  `test-report.json`, `summary.md`, and `memory-candidates.jsonl` artifact files
+  under the profile worker artifact root.
 - Add apply approval flow.
 
 Exit criteria:
@@ -627,6 +658,8 @@ Tasks:
   Baseline complete for registry/grants, broad-root rejection, and safe-read
   path guards.
 - W5: add worker worktree creation, artifact storage, and cleanup rules.
+  Baseline worktree creation and artifact storage now exist; cleanup remains
+  future work.
 - W6: add checkpoint/rollback before destructive or mutating operations.
 - W7: integrate workspace, grant, worker, checkpoint, and rollback events.
 - W8: add deterministic channel and cwd/project routing.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -231,15 +231,15 @@
 - [ ] Define worker state.
 - [x] Implement daemon worker registry.
 - [x] Implement `worker.tail`.
-- [ ] Create git worktree.
+- [x] Create git worktree for session-bound project workers.
 - [ ] Stream worker logs.
 - [ ] Add worker cancellation.
-- [ ] Generate worker diff.
+- [x] Generate worker diff artifact.
 - [ ] Run tests in worker.
 - [ ] Request patch approval.
 - [ ] Apply approved patch.
 - [ ] Cleanup worktree.
-- [ ] Add worker isolation tests.
+- [x] Add worker isolation tests for worktree creation and artifact output.
 
 ## 13. Telegram Adapter
 
@@ -325,7 +325,8 @@
 - [ ] Track C: `AgentSession`, agent-driven spawn, limits, and worker registry.
   Baselines landed: AgentSession state/events, explicit daemon-owned spawn,
   spawn limits, worker registry, and worker tail. Remaining: implicit
-  model-driven spawn, worker failed/cancelled events, and executable workers.
+  model-driven spawn, worker failed/cancelled events, and real command/test
+  execution inside worker worktrees.
 - [ ] Track D: policy-backed tools and approval persistence.
 - [ ] Track E: daemon-owned voice provider path, STT language setting, and voice doctor.
 - [ ] Track F: durable metadata and restart recovery for sessions, agents, AgentSessions, workers, and approvals.
@@ -336,6 +337,9 @@
 - [ ] Track G: CADIS-native Wulan avatar engine.
 - [ ] Track H: profile homes, agent homes, workspace registry, grants, and worker worktrees.
 - [x] Track H baseline: default profile layout plus persistent workspace registry/grants.
+- [x] Track I baseline: daemon worker execution setup creates git worktrees,
+  persists project-local worktree metadata, and writes profile-scoped worker
+  artifacts for review.
 
 ## 15.2 Workspace Architecture
 
@@ -355,8 +359,8 @@
 - [x] Implement project `.cadis/workspace.toml` store support.
 - [x] Add project `.cadis/worktrees/` worker path and metadata helpers.
 - [x] Add profile `artifacts/workers/` worker artifact path helpers.
-- [ ] Implement worker worktree creation under project `.cadis/worktrees/`.
-- [ ] Persist worker artifacts under profile `artifacts/workers/`.
+- [x] Implement worker worktree creation under project `.cadis/worktrees/`.
+- [x] Persist worker artifacts under profile `artifacts/workers/`.
 - [ ] Add project `.cadis/media/` manifests for generated media.
 - [x] Add workspace doctor checks for project metadata mismatch and duplicate roots.
 - [x] Add workspace doctor checks for stale worker worktree metadata and missing artifact roots.

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -146,6 +146,13 @@ The desktop MVP replays log lines from the in-memory worker registry as
 up to 64 recent lines, capped at 1000. Unknown workers are rejected with
 `worker_not_found`.
 
+`worker.started` and `worker.completed` may include worktree and artifact
+metadata. For session-bound project workspaces, the daemon worker runtime creates
+`<project>/.cadis/worktrees/<worker-id>/`, emits the active worktree path in
+`worker.started`, and writes profile-scoped artifacts before `worker.completed`.
+Terminal worker events move active worktrees to `review_pending`; patch apply and
+cleanup remain separate approval-gated flows.
+
 Example:
 
 ```json

--- a/docs/27_WORKSPACE_ARCHITECTURE.md
+++ b/docs/27_WORKSPACE_ARCHITECTURE.md
@@ -56,11 +56,14 @@ Implemented baseline:
   under `<project>/.cadis/worktrees/`, resolve worker artifact paths under
   `profiles/<profile>/artifacts/workers/`, and let `workspace doctor` report
   stale worker worktree metadata or missing artifact roots.
+- Worker execution setup now creates a git worktree for session-bound project
+  workspaces, marks project-local worker worktree metadata `ready`, and writes
+  profile-scoped worker artifacts for review.
 
 Still future:
 
-- Worker worktree creation/cleanup.
-- Worker artifact production and durable worker runtime records.
+- Worker worktree cleanup.
+- Real worker command/test execution and durable worker runtime logs.
 - Checkpoint and rollback manager.
 - Dedicated profile and agent doctor commands.
 - Workspace-local skills and project `.cadis/` metadata enforcement.
@@ -279,7 +282,8 @@ Project-local worker worktree metadata lives beside the project worktree root:
 
 `workspace doctor` treats these metadata files as diagnostics only. It warns
 when a recorded worktree path or profile artifact root is stale/missing; it does
-not create, remove, or mutate git worktrees.
+not create, remove, or mutate git worktrees. Worktree creation is owned by the
+daemon worker runtime when a session-bound worker starts.
 
 Workers receive write/exec grants only for their worktree unless the user
 explicitly approves broader access. The parent project checkout remains


### PR DESCRIPTION
## Summary
- Create daemon-owned worker execution setup for session-bound project workspaces.
- Create git worktrees under project .cadis/worktrees, persist project-local worker metadata, and move completed workers to review-pending worktree state.
- Write profile-scoped worker artifacts: summary, patch, changed-files, test-report, and memory-candidates files.
- Update implementation plan, protocol draft, workspace architecture, and checklist for Track I baseline.

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -p cadis-core
- cargo test --all-targets --all-features
