### PR TITLE
feat: add native provider streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The repository already includes a meaningful desktop MVP foundation:
 - typed protocol events for messages, models, agents, approvals, workspaces, orchestrator routing, and workers
 - JSONL event persistence with redaction boundaries
 - profile-local agent homes, workspace registry, and grants for safe-read tools
-- optional Ollama, OpenAI API, and Codex CLI model adapters
+- optional Ollama, OpenAI API, and Codex CLI model adapters, with native
+  streaming for Ollama and OpenAI
 - official Codex CLI adapter for ChatGPT Plus/Pro login flows
 - HUD-local Edge TTS playback, `whisper-cli` voice input, and voice doctor preflight
 
@@ -83,8 +84,9 @@ Planned work still includes production-grade mutating tool execution, full
 policy coverage, richer worker isolation, Telegram/mobile clients,
 daemon-owned production voice, and code work windows. The workspace
 architecture is partially implemented; real worker worktree creation,
-checkpoint rollback, dedicated profile/agent doctor commands, and project media
-manifests remain next.
+profile-scoped worker artifacts, and review-pending worker metadata are now in
+place. Checkpoint rollback, dedicated profile/agent doctor commands, and
+project media manifests remain next.
 
 ## Core capabilities
 
@@ -160,7 +162,8 @@ The HUD resolves the daemon socket from `CADIS_HUD_SOCKET`, `CADIS_SOCKET`,
 
 Default mode is `auto`: C.A.D.I.S. tries Ollama at
 `http://127.0.0.1:11434`, then falls back to a local credential-free response
-if Ollama is unavailable.
+if Ollama is unavailable. Ollama and OpenAI responses stream through `cadisd`
+as live `message.delta` events before final completion.
 
 For OpenAI API billing, set `[model].provider = "openai"` and provide either
 `CADIS_OPENAI_API_KEY` or `OPENAI_API_KEY` in the daemon environment.

--- a/crates/cadis-models/README.md
+++ b/crates/cadis-models/README.md
@@ -7,8 +7,11 @@ local fallback provider that requires no credentials. The Codex CLI adapter uses
 `codex exec`; authenticate separately with the official CLI instead of storing
 ChatGPT tokens in CADIS.
 
-Providers stream normalized events through `ModelStreamCallback`. The callback
-returns `ModelStreamControl::Continue` to keep receiving events or
+Providers stream normalized events through `ModelStreamCallback`. Ollama uses
+native `/api/generate` NDJSON chunks and OpenAI uses Chat Completions
+server-sent events; providers without native upstream streaming still use the
+same callback contract around their completed output. The callback returns
+`ModelStreamControl::Continue` to keep receiving events or
 `ModelStreamControl::Cancel` to request provider-boundary cancellation. A
 cancelled provider request returns the non-retryable `model_cancelled` error and
 emits `model.cancelled` when invocation metadata is available.

--- a/crates/cadis-models/src/lib.rs
+++ b/crates/cadis-models/src/lib.rs
@@ -3,7 +3,7 @@
 use std::env;
 use std::error::Error;
 use std::fmt;
-use std::io::{ErrorKind, Read, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
 use std::process::{Command, ExitStatus, Stdio};
 use std::thread;
 use std::time::Duration;
@@ -51,50 +51,8 @@ pub trait ModelProvider: Send + Sync {
         callback: &mut ModelStreamCallback<'_>,
     ) -> Result<ModelResponse, ModelError> {
         match self.chat_with_request(request) {
-            Ok(response) => {
-                if emit_stream_event(
-                    callback,
-                    ModelStreamEvent::Started(response.invocation.clone()),
-                    &response.invocation,
-                )? == ModelStreamControl::Cancel
-                {
-                    return cancel_stream(callback, &response.invocation);
-                }
-                for delta in &response.deltas {
-                    if emit_stream_event(
-                        callback,
-                        ModelStreamEvent::Delta(delta.clone()),
-                        &response.invocation,
-                    )? == ModelStreamControl::Cancel
-                    {
-                        return cancel_stream(callback, &response.invocation);
-                    }
-                }
-                if emit_stream_event(
-                    callback,
-                    ModelStreamEvent::Completed(response.invocation.clone()),
-                    &response.invocation,
-                )? == ModelStreamControl::Cancel
-                {
-                    return cancel_stream(callback, &response.invocation);
-                }
-                Ok(response)
-            }
-            Err(error) => {
-                if error.is_cancelled() {
-                    if let Some(invocation) = error.invocation.as_deref() {
-                        let _ = callback(ModelStreamEvent::Cancelled(invocation.clone()))?;
-                    }
-                    return Err(error);
-                }
-                let _ = callback(ModelStreamEvent::Failed(ModelFailure {
-                    code: error.code.clone(),
-                    message: error.message.clone(),
-                    retryable: error.retryable,
-                    invocation: error.invocation.as_deref().cloned(),
-                }))?;
-                Err(error)
-            }
+            Ok(response) => stream_response(response, callback),
+            Err(error) => fail_stream(callback, error),
         }
     }
 }
@@ -303,6 +261,42 @@ fn emit_stream_event(
     callback(event).map_err(|error| error.with_invocation_if_missing(invocation))
 }
 
+fn stream_response(
+    response: ModelResponse,
+    callback: &mut ModelStreamCallback<'_>,
+) -> Result<ModelResponse, ModelError> {
+    if emit_stream_event(
+        callback,
+        ModelStreamEvent::Started(response.invocation.clone()),
+        &response.invocation,
+    )? == ModelStreamControl::Cancel
+    {
+        return cancel_stream(callback, &response.invocation);
+    }
+
+    for delta in &response.deltas {
+        if emit_stream_event(
+            callback,
+            ModelStreamEvent::Delta(delta.clone()),
+            &response.invocation,
+        )? == ModelStreamControl::Cancel
+        {
+            return cancel_stream(callback, &response.invocation);
+        }
+    }
+
+    if emit_stream_event(
+        callback,
+        ModelStreamEvent::Completed(response.invocation.clone()),
+        &response.invocation,
+    )? == ModelStreamControl::Cancel
+    {
+        return cancel_stream(callback, &response.invocation);
+    }
+
+    Ok(response)
+}
+
 fn cancel_stream(
     callback: &mut ModelStreamCallback<'_>,
     invocation: &ModelInvocation,
@@ -313,6 +307,26 @@ fn cancel_stream(
         invocation,
     )?;
     Err(ModelError::cancelled("model request was cancelled").with_invocation(invocation.clone()))
+}
+
+fn fail_stream(
+    callback: &mut ModelStreamCallback<'_>,
+    error: ModelError,
+) -> Result<ModelResponse, ModelError> {
+    if error.is_cancelled() {
+        if let Some(invocation) = error.invocation.as_deref() {
+            let _ = callback(ModelStreamEvent::Cancelled(invocation.clone()))?;
+        }
+        return Err(error);
+    }
+
+    let _ = callback(ModelStreamEvent::Failed(ModelFailure {
+        code: error.code.clone(),
+        message: error.message.clone(),
+        retryable: error.retryable,
+        invocation: error.invocation.as_deref().cloned(),
+    }))?;
+    Err(error)
 }
 
 /// Conservative provider readiness exposed by the model catalog.
@@ -443,7 +457,7 @@ pub fn provider_catalog_for_config(config: &ModelCatalogConfig) -> Vec<ProviderC
             provider: "openai".to_owned(),
             model: config.openai_model.clone(),
             display_name: format!("OpenAI {}", config.openai_model),
-            capabilities: vec!["api_key".to_owned()],
+            capabilities: vec!["api_key".to_owned(), "streaming".to_owned()],
             readiness: openai_readiness,
             effective_provider: "openai".to_owned(),
             effective_model: config.openai_model.clone(),
@@ -577,6 +591,154 @@ impl ModelProvider for OllamaProvider {
             })
             .map_err(|error| error.with_invocation(invocation))
     }
+
+    fn stream_chat(
+        &self,
+        request: ModelRequest<'_>,
+        callback: &mut ModelStreamCallback<'_>,
+    ) -> Result<ModelResponse, ModelError> {
+        let invocation = ModelInvocation {
+            requested_model: request.selected_model.map(ToOwned::to_owned),
+            effective_provider: "ollama".to_owned(),
+            effective_model: self.model.clone(),
+            fallback: false,
+            fallback_reason: None,
+        };
+
+        let client = match reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+        {
+            Ok(client) => client,
+            Err(error) => {
+                return fail_stream(
+                    callback,
+                    ModelError::with_code(
+                        "provider_client_error",
+                        format!("failed to create Ollama client: {error}"),
+                        false,
+                    )
+                    .with_invocation(invocation),
+                );
+            }
+        };
+
+        let response = match client
+            .post(format!("{}/api/generate", self.endpoint))
+            .json(&OllamaGenerateRequest {
+                model: self.model.clone(),
+                prompt: request.prompt.to_owned(),
+                stream: true,
+            })
+            .send()
+        {
+            Ok(response) => response,
+            Err(_) => {
+                return fail_stream(
+                    callback,
+                    ModelError::with_code("provider_unavailable", "Ollama request failed", true)
+                        .with_invocation(invocation),
+                );
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            return fail_stream(
+                callback,
+                provider_http_error("Ollama", status).with_invocation(invocation),
+            );
+        }
+
+        if emit_stream_event(
+            callback,
+            ModelStreamEvent::Started(invocation.clone()),
+            &invocation,
+        )? == ModelStreamControl::Cancel
+        {
+            return cancel_stream(callback, &invocation);
+        }
+
+        let mut deltas = Vec::new();
+        for line in BufReader::new(response).lines() {
+            let line = match line {
+                Ok(line) => line,
+                Err(error) => {
+                    return fail_stream(
+                        callback,
+                        ModelError::with_code(
+                            "provider_response_invalid",
+                            format!("failed to read Ollama stream: {error}"),
+                            true,
+                        )
+                        .with_invocation(invocation),
+                    );
+                }
+            };
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            let chunk = match serde_json::from_str::<OllamaGenerateResponse>(line) {
+                Ok(chunk) => chunk,
+                Err(error) => {
+                    return fail_stream(
+                        callback,
+                        ModelError::with_code(
+                            "provider_response_invalid",
+                            format!("Ollama stream chunk was invalid: {error}"),
+                            false,
+                        )
+                        .with_invocation(invocation),
+                    );
+                }
+            };
+
+            if let Some(error) = chunk.error {
+                return fail_stream(
+                    callback,
+                    ModelError::with_code(
+                        "model_request_rejected",
+                        format!("Ollama error: {error}"),
+                        false,
+                    )
+                    .with_invocation(invocation),
+                );
+            }
+
+            if let Some(delta) = chunk.response.filter(|delta| !delta.is_empty()) {
+                deltas.push(delta.clone());
+                if emit_stream_event(callback, ModelStreamEvent::Delta(delta), &invocation)?
+                    == ModelStreamControl::Cancel
+                {
+                    return cancel_stream(callback, &invocation);
+                }
+            }
+
+            if chunk.done.unwrap_or(false) {
+                break;
+            }
+        }
+
+        if deltas.is_empty() {
+            deltas.push(String::new());
+        }
+
+        let response = ModelResponse {
+            deltas,
+            invocation: invocation.clone(),
+        };
+        if emit_stream_event(
+            callback,
+            ModelStreamEvent::Completed(invocation.clone()),
+            &invocation,
+        )? == ModelStreamControl::Cancel
+        {
+            return cancel_stream(callback, &invocation);
+        }
+        Ok(response)
+    }
 }
 
 /// OpenAI Chat Completions provider.
@@ -646,6 +808,7 @@ impl ModelProvider for OpenAiProvider {
                     role: "user",
                     content: prompt,
                 }],
+                stream: false,
             })
             .send()
             .map_err(|_| {
@@ -695,6 +858,166 @@ impl ModelProvider for OpenAiProvider {
                 invocation: invocation.clone(),
             })
             .map_err(|error| error.with_invocation(invocation))
+    }
+
+    fn stream_chat(
+        &self,
+        request: ModelRequest<'_>,
+        callback: &mut ModelStreamCallback<'_>,
+    ) -> Result<ModelResponse, ModelError> {
+        let invocation = ModelInvocation {
+            requested_model: request.selected_model.map(ToOwned::to_owned),
+            effective_provider: "openai".to_owned(),
+            effective_model: self.model.clone(),
+            fallback: false,
+            fallback_reason: None,
+        };
+
+        if self.api_key.trim().is_empty() {
+            return fail_stream(
+                callback,
+                ModelError::with_code(
+                    "model_auth_missing",
+                    "OpenAI provider requires OPENAI_API_KEY or CADIS_OPENAI_API_KEY",
+                    false,
+                )
+                .with_invocation(invocation),
+            );
+        }
+
+        let client = match reqwest::blocking::Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+        {
+            Ok(client) => client,
+            Err(_) => {
+                return fail_stream(
+                    callback,
+                    ModelError::with_code(
+                        "provider_client_error",
+                        "failed to create OpenAI client",
+                        false,
+                    )
+                    .with_invocation(invocation),
+                );
+            }
+        };
+
+        let response = match client
+            .post(format!("{}/chat/completions", self.base_url))
+            .bearer_auth(&self.api_key)
+            .json(&OpenAiChatRequest {
+                model: self.model.clone(),
+                messages: vec![OpenAiChatMessage {
+                    role: "user",
+                    content: request.prompt,
+                }],
+                stream: true,
+            })
+            .send()
+        {
+            Ok(response) => response,
+            Err(_) => {
+                return fail_stream(
+                    callback,
+                    ModelError::with_code("provider_unavailable", "OpenAI request failed", true)
+                        .with_invocation(invocation),
+                );
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            return fail_stream(
+                callback,
+                provider_http_error("OpenAI", status).with_invocation(invocation),
+            );
+        }
+
+        if emit_stream_event(
+            callback,
+            ModelStreamEvent::Started(invocation.clone()),
+            &invocation,
+        )? == ModelStreamControl::Cancel
+        {
+            return cancel_stream(callback, &invocation);
+        }
+
+        let mut deltas = Vec::new();
+        for line in BufReader::new(response).lines() {
+            let line = match line {
+                Ok(line) => line,
+                Err(error) => {
+                    return fail_stream(
+                        callback,
+                        ModelError::with_code(
+                            "provider_response_invalid",
+                            format!("failed to read OpenAI stream: {error}"),
+                            true,
+                        )
+                        .with_invocation(invocation),
+                    );
+                }
+            };
+            let line = line.trim();
+            if line.is_empty() || line.starts_with(':') || line.starts_with("event:") {
+                continue;
+            }
+            let Some(data) = line.strip_prefix("data:").map(str::trim) else {
+                continue;
+            };
+            if data == "[DONE]" {
+                break;
+            }
+
+            let chunk = match serde_json::from_str::<OpenAiChatStreamChunk>(data) {
+                Ok(chunk) => chunk,
+                Err(error) => {
+                    return fail_stream(
+                        callback,
+                        ModelError::with_code(
+                            "provider_response_invalid",
+                            format!("OpenAI stream chunk was invalid: {error}"),
+                            false,
+                        )
+                        .with_invocation(invocation),
+                    );
+                }
+            };
+
+            for choice in chunk.choices {
+                if let Some(delta) = choice.delta.content.filter(|delta| !delta.is_empty()) {
+                    deltas.push(delta.clone());
+                    if emit_stream_event(callback, ModelStreamEvent::Delta(delta), &invocation)?
+                        == ModelStreamControl::Cancel
+                    {
+                        return cancel_stream(callback, &invocation);
+                    }
+                }
+            }
+        }
+
+        if deltas.is_empty() {
+            return fail_stream(
+                callback,
+                ModelError::with_code("provider_response_empty", "OpenAI response was empty", true)
+                    .with_invocation(invocation),
+            );
+        }
+
+        let response = ModelResponse {
+            deltas,
+            invocation: invocation.clone(),
+        };
+        if emit_stream_event(
+            callback,
+            ModelStreamEvent::Completed(invocation.clone()),
+            &invocation,
+        )? == ModelStreamControl::Cancel
+        {
+            return cancel_stream(callback, &invocation);
+        }
+        Ok(response)
     }
 }
 
@@ -1096,6 +1419,57 @@ impl ModelProvider for AutoProvider {
             }
         }
     }
+
+    fn stream_chat(
+        &self,
+        request: ModelRequest<'_>,
+        callback: &mut ModelStreamCallback<'_>,
+    ) -> Result<ModelResponse, ModelError> {
+        let requested_model = request.selected_model.map(ToOwned::to_owned);
+        let primary_request =
+            ModelRequest::new(request.prompt).with_selected_model(request.selected_model);
+        let mut native_stream_started = false;
+        let stream_result = self.ollama.stream_chat(primary_request, &mut |event| {
+            match &event {
+                ModelStreamEvent::Started(_)
+                | ModelStreamEvent::Delta(_)
+                | ModelStreamEvent::Completed(_)
+                | ModelStreamEvent::Cancelled(_) => native_stream_started = true,
+                ModelStreamEvent::Failed(_) => {}
+            }
+
+            if matches!(event, ModelStreamEvent::Failed(_)) && !native_stream_started {
+                return Ok(ModelStreamControl::Continue);
+            }
+
+            callback(event)
+        });
+
+        match stream_result {
+            Ok(response) => Ok(response),
+            Err(error) if error.is_cancelled() => Err(error),
+            Err(error) if !native_stream_started => {
+                let response = format!(
+                    "CADIS runtime is online, but Ollama is not ready ({error}).\n\nI received: {}\n\nStart Ollama or set [model].provider = \"echo\" in ~/.cadis/config.toml for an explicit local fallback.",
+                    request.prompt
+                );
+                stream_response(
+                    ModelResponse {
+                        deltas: chunk_text(&response),
+                        invocation: ModelInvocation {
+                            requested_model,
+                            effective_provider: "echo".to_owned(),
+                            effective_model: ECHO_MODEL.to_owned(),
+                            fallback: true,
+                            fallback_reason: Some(format!("ollama unavailable: {error}")),
+                        },
+                    },
+                    callback,
+                )
+            }
+            Err(error) => Err(error),
+        }
+    }
 }
 
 /// Builds a provider from a provider label.
@@ -1216,6 +1590,69 @@ impl ModelProvider for RoutingModelProvider {
             _ => Err(self.unsupported_provider_error(&selection)),
         }
     }
+
+    fn stream_chat(
+        &self,
+        request: ModelRequest<'_>,
+        callback: &mut ModelStreamCallback<'_>,
+    ) -> Result<ModelResponse, ModelError> {
+        let selection = self.selection(request.selected_model);
+        let model_request = ModelRequest::new(request.prompt)
+            .with_selected_model(selection.requested_model.as_deref());
+
+        match selection.provider.as_str() {
+            "auto" => {
+                let model = selection
+                    .model
+                    .as_deref()
+                    .unwrap_or(&self.config.ollama_model);
+                AutoProvider::new(&self.config.ollama_endpoint, model).stream_chat(
+                    model_request.with_selected_model(selection.requested_model.as_deref()),
+                    callback,
+                )
+            }
+            "ollama" => {
+                let model = selection
+                    .model
+                    .as_deref()
+                    .unwrap_or(&self.config.ollama_model);
+                OllamaProvider::new(&self.config.ollama_endpoint, model)
+                    .stream_chat(model_request, callback)
+            }
+            "openai" => {
+                let model = selection
+                    .model
+                    .as_deref()
+                    .unwrap_or(&self.config.openai_model);
+                match self.config.openai_api_key.as_deref() {
+                    Some(api_key) => {
+                        OpenAiProvider::new(&self.config.openai_base_url, model, api_key)
+                            .stream_chat(model_request, callback)
+                    }
+                    None => fail_stream(callback, missing_openai_key_error(model_request, model)),
+                }
+            }
+            "codex-cli" => {
+                match CodexCliProvider::from_env_with_model(selection.model.as_deref()) {
+                    Ok(provider) => provider.stream_chat(model_request, callback),
+                    Err(error) => fail_stream(
+                        callback,
+                        error.with_invocation(ModelInvocation {
+                            requested_model: selection.requested_model,
+                            effective_provider: "codex-cli".to_owned(),
+                            effective_model: selection
+                                .model
+                                .unwrap_or_else(|| CODEX_CLI_PLAN_MODEL.to_owned()),
+                            fallback: false,
+                            fallback_reason: None,
+                        }),
+                    ),
+                }
+            }
+            "echo" => EchoProvider.stream_chat(model_request, callback),
+            _ => fail_stream(callback, self.unsupported_provider_error(&selection)),
+        }
+    }
 }
 
 /// Configuration used by the provider router.
@@ -1291,6 +1728,10 @@ fn missing_openai_key_response(
     request: ModelRequest<'_>,
     effective_model: &str,
 ) -> Result<ModelResponse, ModelError> {
+    Err(missing_openai_key_error(request, effective_model))
+}
+
+fn missing_openai_key_error(request: ModelRequest<'_>, effective_model: &str) -> ModelError {
     let invocation = ModelInvocation {
         requested_model: request.selected_model.map(ToOwned::to_owned),
         effective_provider: "openai".to_owned(),
@@ -1298,12 +1739,12 @@ fn missing_openai_key_response(
         fallback: false,
         fallback_reason: None,
     };
-    Err(ModelError::with_code(
+    ModelError::with_code(
         "model_auth_missing",
         "OpenAI provider requires OPENAI_API_KEY or CADIS_OPENAI_API_KEY",
         false,
     )
-    .with_invocation(invocation))
+    .with_invocation(invocation)
 }
 
 fn normalize_provider_id(provider: &str) -> &str {
@@ -1377,12 +1818,14 @@ struct OllamaGenerateRequest {
 struct OllamaGenerateResponse {
     response: Option<String>,
     error: Option<String>,
+    done: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
 struct OpenAiChatRequest<'a> {
     model: String,
     messages: Vec<OpenAiChatMessage<'a>>,
+    stream: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -1406,9 +1849,26 @@ struct OpenAiResponseMessage {
     content: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct OpenAiChatStreamChunk {
+    choices: Vec<OpenAiChatStreamChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChatStreamChoice {
+    delta: OpenAiChatStreamDelta,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChatStreamDelta {
+    content: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::TcpListener;
+    use std::sync::mpsc;
 
     #[derive(Clone, Debug, Eq, PartialEq)]
     struct DeterministicStreamingProvider {
@@ -1431,6 +1891,68 @@ mod tests {
                 fallback_reason: None,
             }
         }
+    }
+
+    fn start_http_response_server(
+        status: &str,
+        content_type: &str,
+        body: &str,
+    ) -> (String, mpsc::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test HTTP listener should bind");
+        let addr = listener
+            .local_addr()
+            .expect("test HTTP listener should have an address");
+        let status = status.to_owned();
+        let content_type = content_type.to_owned();
+        let body = body.to_owned();
+        let (request_tx, request_rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("test HTTP client should connect");
+            let mut request = String::new();
+            let mut content_length = 0usize;
+            {
+                let mut reader = BufReader::new(
+                    stream
+                        .try_clone()
+                        .expect("test HTTP stream should clone for reading"),
+                );
+                loop {
+                    let mut line = String::new();
+                    let bytes = reader
+                        .read_line(&mut line)
+                        .expect("test HTTP header should read");
+                    if bytes == 0 || line == "\r\n" {
+                        break;
+                    }
+                    if let Some((name, value)) = line.split_once(':') {
+                        if name.eq_ignore_ascii_case("content-length") {
+                            content_length = value.trim().parse().unwrap_or(0);
+                        }
+                    }
+                    request.push_str(&line);
+                }
+                if content_length > 0 {
+                    let mut body_bytes = vec![0u8; content_length];
+                    reader
+                        .read_exact(&mut body_bytes)
+                        .expect("test HTTP request body should read");
+                    request.push_str(&String::from_utf8_lossy(&body_bytes));
+                }
+            }
+            request_tx
+                .send(request)
+                .expect("test HTTP request should send");
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("test HTTP response should write");
+        });
+
+        (format!("http://{addr}"), request_rx)
     }
 
     impl ModelProvider for DeterministicStreamingProvider {
@@ -1601,6 +2123,65 @@ mod tests {
     }
 
     #[test]
+    fn native_stream_failures_emit_failed_event() {
+        let provider = OllamaProvider::new("http://127.0.0.1:1", "llama3.2");
+        let mut events = Vec::new();
+
+        let error = provider
+            .stream_chat(ModelRequest::new("hello"), &mut |event| {
+                events.push(event);
+                Ok(ModelStreamControl::Continue)
+            })
+            .expect_err("closed localhost port should fail");
+
+        assert_eq!(error.code(), "provider_unavailable");
+        assert!(matches!(
+            events.last(),
+            Some(ModelStreamEvent::Failed(failure)) if failure.code == "provider_unavailable"
+        ));
+    }
+
+    #[test]
+    fn auto_stream_falls_back_only_before_native_stream_starts() {
+        let provider = AutoProvider::new("http://127.0.0.1:1", "llama3.2");
+        let mut events = Vec::new();
+
+        let response = provider
+            .stream_chat(ModelRequest::new("hello"), &mut |event| {
+                events.push(event);
+                Ok(ModelStreamControl::Continue)
+            })
+            .expect("auto should fall back when Ollama cannot connect");
+
+        assert!(response.invocation.fallback);
+        assert_eq!(response.invocation.effective_provider, "echo");
+        assert!(!events
+            .iter()
+            .any(|event| matches!(event, ModelStreamEvent::Failed(_))));
+
+        let invalid_body = "not-json\n";
+        let (endpoint, _request_rx) =
+            start_http_response_server("200 OK", "application/x-ndjson", invalid_body);
+        let provider = AutoProvider::new(endpoint, "llama3.2");
+        let mut events = Vec::new();
+
+        let error = provider
+            .stream_chat(ModelRequest::new("hello"), &mut |event| {
+                events.push(event);
+                Ok(ModelStreamControl::Continue)
+            })
+            .expect_err("auto should not mix fallback after native stream starts");
+
+        assert_eq!(error.code(), "provider_response_invalid");
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, ModelStreamEvent::Started(_))));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, ModelStreamEvent::Failed(_))));
+    }
+
+    #[test]
     fn http_status_errors_are_structured() {
         let auth_error = provider_http_error("OpenAI", StatusCode::UNAUTHORIZED);
         assert_eq!(auth_error.code(), "model_auth_failed");
@@ -1673,6 +2254,174 @@ mod tests {
             })
             .collect::<String>();
         assert_eq!(streamed, response.deltas.join(""));
+    }
+
+    #[test]
+    fn ollama_native_stream_emits_http_deltas_in_order() {
+        let stream_body = concat!(
+            r#"{"response":"hel","done":false}"#,
+            "\n",
+            r#"{"response":"lo","done":true}"#,
+            "\n"
+        );
+        let (endpoint, request_rx) =
+            start_http_response_server("200 OK", "application/x-ndjson", stream_body);
+        let provider = OllamaProvider::new(endpoint, "llama3.2");
+        let mut events = Vec::new();
+
+        let response = provider
+            .stream_chat(
+                ModelRequest::new("hello").with_selected_model(Some("ollama/llama3.2")),
+                &mut |event| {
+                    events.push(event);
+                    Ok(ModelStreamControl::Continue)
+                },
+            )
+            .expect("Ollama native stream should succeed");
+
+        let request = request_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("test server should capture request");
+        assert!(request.contains("POST /api/generate"));
+        assert!(request.contains(r#""stream":true"#));
+        assert_eq!(response.deltas, vec!["hel", "lo"]);
+        assert_eq!(
+            response.invocation.requested_model.as_deref(),
+            Some("ollama/llama3.2")
+        );
+        assert!(matches!(events.first(), Some(ModelStreamEvent::Started(_))));
+        assert!(matches!(
+            events.last(),
+            Some(ModelStreamEvent::Completed(_))
+        ));
+        let streamed = events
+            .into_iter()
+            .filter_map(|event| match event {
+                ModelStreamEvent::Delta(delta) => Some(delta),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(streamed, vec!["hel", "lo"]);
+    }
+
+    #[test]
+    fn openai_native_stream_parses_sse_delta_content() {
+        let stream_body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"hel\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"lo\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (base_url, request_rx) =
+            start_http_response_server("200 OK", "text/event-stream", stream_body);
+        let provider = OpenAiProvider::new(base_url, "gpt-test", "sk-test");
+        let mut events = Vec::new();
+
+        let response = provider
+            .stream_chat(
+                ModelRequest::new("hello").with_selected_model(Some("openai/gpt-test")),
+                &mut |event| {
+                    events.push(event);
+                    Ok(ModelStreamControl::Continue)
+                },
+            )
+            .expect("OpenAI native stream should succeed");
+
+        let request = request_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("test server should capture request");
+        assert!(request.contains("POST /chat/completions"));
+        assert!(request
+            .to_ascii_lowercase()
+            .contains("authorization: bearer sk-test"));
+        assert!(request.contains(r#""stream":true"#));
+        assert_eq!(response.deltas, vec!["hel", "lo"]);
+        assert_eq!(response.invocation.effective_provider, "openai");
+        let streamed = events
+            .into_iter()
+            .filter_map(|event| match event {
+                ModelStreamEvent::Delta(delta) => Some(delta),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(streamed, vec!["hel", "lo"]);
+    }
+
+    #[test]
+    fn routing_provider_uses_native_openai_stream_path() {
+        let stream_body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"route\"}}]}\n\n",
+            "data: [DONE]\n\n",
+        );
+        let (base_url, _request_rx) =
+            start_http_response_server("200 OK", "text/event-stream", stream_body);
+        let provider = provider_from_config(
+            "echo",
+            "http://127.0.0.1:11434",
+            "llama3.2",
+            &base_url,
+            "gpt-test",
+            Some("sk-test"),
+        );
+        let mut events = Vec::new();
+
+        let response = provider
+            .stream_chat(
+                ModelRequest::new("hello").with_selected_model(Some("openai/gpt-test")),
+                &mut |event| {
+                    events.push(event);
+                    Ok(ModelStreamControl::Continue)
+                },
+            )
+            .expect("router should use selected OpenAI native stream");
+
+        assert_eq!(response.deltas, vec!["route"]);
+        assert_eq!(
+            response.invocation.requested_model.as_deref(),
+            Some("openai/gpt-test")
+        );
+        assert_eq!(response.invocation.effective_provider, "openai");
+        assert!(events
+            .iter()
+            .any(|event| matches!(event, ModelStreamEvent::Delta(delta) if delta == "route")));
+    }
+
+    #[test]
+    fn native_stream_callback_cancellation_stops_ollama() {
+        let stream_body = concat!(
+            r#"{"response":"first","done":false}"#,
+            "\n",
+            r#"{"response":"second","done":true}"#,
+            "\n"
+        );
+        let (endpoint, _request_rx) =
+            start_http_response_server("200 OK", "application/x-ndjson", stream_body);
+        let provider = OllamaProvider::new(endpoint, "llama3.2");
+        let mut events = Vec::new();
+
+        let error = provider
+            .stream_chat(ModelRequest::new("hello"), &mut |event| {
+                let should_cancel = matches!(event, ModelStreamEvent::Delta(_));
+                events.push(event);
+                if should_cancel {
+                    Ok(ModelStreamControl::Cancel)
+                } else {
+                    Ok(ModelStreamControl::Continue)
+                }
+            })
+            .expect_err("callback cancellation should stop native Ollama stream");
+
+        assert_eq!(error.code(), "model_cancelled");
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ModelStreamEvent::Delta(_)))
+                .count(),
+            1
+        );
+        assert!(matches!(
+            events.last(),
+            Some(ModelStreamEvent::Cancelled(_))
+        ));
     }
 
     #[test]

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -39,7 +39,11 @@ Implemented in the first runnable baseline:
 - P1 workspace skeleton crates: `cadis-core`, `cadis-daemon`, `cadis-cli`, `cadis-store`, `cadis-policy`, and `cadis-models`.
 - P3 daemon subset: `cadisd --version`, `cadisd --check`, Unix socket transport, stdio test mode, config load, health status, session registry, and event emission.
 - P4 CLI subset: `cadis status`, `cadis doctor`, `cadis models`, `cadis chat`, JSON frame output, and `cadis daemon` launcher.
-- P5 model subset: local fallback provider plus optional Ollama, OpenAI API, and Codex CLI adapters.
+- P5 model subset: local fallback provider plus optional Ollama, OpenAI API,
+  and Codex CLI adapters. Ollama now streams native NDJSON deltas and OpenAI
+  now streams Chat Completions SSE deltas through the shared provider callback;
+  Codex CLI remains wrapped through `codex exec` output until the CLI exposes a
+  stable token stream.
 - P8 persistence subset: `~/.cadis` layout, JSONL event logs, redaction before
   persistence, and store-level atomic JSON metadata helpers under
   `~/.cadis/state`.
@@ -94,9 +98,9 @@ Still pending:
 - Future daemon-owned memory architecture from `25_MEMORY_CONCEPT.md`, including
   memory records, scoped retrieval, provenance ledger, candidate promotion, and
   memory capsules.
-- Native provider streaming for providers that support token streams directly;
-  the current provider trait can stream normalized events, but OpenAI/Ollama
-  still use non-streaming request paths.
+- Codex CLI native token streaming; the current adapter streams normalized
+  callback events from `codex exec` output, but its granularity is limited by
+  the official CLI's stdout behavior.
 
 ## 2.2 Next Execution Plan
 
@@ -146,10 +150,13 @@ Tasks:
 - Make effective provider/model visible to clients.
 - Route agent-selected model IDs into provider selection instead of treating
   `agent.model.set` as UI-only state.
-- Add streaming callback support for providers that can stream.
+- Add streaming callback support for providers that can stream. Baseline now
+  includes native Ollama NDJSON streaming, native OpenAI Chat Completions SSE
+  streaming, and router dispatch that preserves provider-native stream paths.
 - Provider-boundary cancellation is defined as callback `Cancel` control,
-  `model.cancelled`, and a non-retryable `model_cancelled` error; native
-  upstream cancellation still needs per-provider integration.
+  `model.cancelled`, and a non-retryable `model_cancelled` error. Ollama and
+  OpenAI stop reading the upstream stream when callbacks request cancellation;
+  Codex CLI still uses the default callback wrapper around process output.
 - Keep echo provider available only as an explicit fallback state.
 
 Exit criteria:
@@ -157,6 +164,8 @@ Exit criteria:
 - HUD can show whether the active model is real, fallback, or unavailable.
 - Per-agent model selection changes which provider/model answers.
 - OpenAI/Ollama/Codex CLI errors surface as structured daemon errors.
+- Ollama and OpenAI emit live `message.delta` events from native provider
+  streams before final completion.
 
 ### Track C - Orchestrator, Agents, and Workers
 

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -141,16 +141,17 @@
 - [x] Define `ModelProvider` trait.
 - [x] Define provider capabilities.
 - [x] Define streaming event type.
-- [ ] Add real provider streaming callback support.
+- [x] Add real provider streaming callback support for Ollama and OpenAI.
 - [x] Add provider readiness and effective model metadata.
 - [x] Apply per-agent model selection to provider routing.
 - [x] Define provider-boundary cancellation behavior.
 - [x] Define provider error mapping.
 - [x] Implement first provider.
 - [x] Add provider callback/cancellation conformance tests.
+- [x] Add deterministic mock native streaming tests for Ollama and OpenAI.
 - [ ] Add full live-provider conformance tests.
 - [x] Add provider config docs.
-- [ ] Add second provider.
+- [x] Add second provider.
 
 ## 8. Tool Runtime
 

--- a/docs/12_TEST_STRATEGY.md
+++ b/docs/12_TEST_STRATEGY.md
@@ -37,7 +37,8 @@ Use for:
 - approval flow
 - tool execution through policy
 - log persistence
-- provider streaming with mock server
+- provider streaming with mock servers, including native Ollama NDJSON and
+  OpenAI SSE fixtures
 
 ### Conformance Tests
 

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -502,6 +502,15 @@ Providers with stream callbacks cause `message.delta` events to be fanned out
 as callbacks arrive; providers without native streaming still produce the same
 typed events after their blocking response returns.
 
+Ollama and OpenAI use provider-native streams in the current baseline: Ollama
+reads `/api/generate` NDJSON chunks and OpenAI reads Chat Completions
+server-sent events. The provider router preserves these native paths for
+per-agent selections such as `ollama/llama3.2` or `openai/gpt-5.2`. Callback
+cancellation stops reading the provider stream and returns a non-retryable
+`model_cancelled` error. Codex CLI still uses the callback-compatible wrapper
+around `codex exec` output because token-level CLI streaming is not part of the
+adapter contract yet.
+
 Model provider failures use the normal `ErrorPayload` shape on `session.failed`
 events:
 

--- a/docs/16_CONFIG_REFERENCE.md
+++ b/docs/16_CONFIG_REFERENCE.md
@@ -460,8 +460,10 @@ total-agent limits.
   Authenticate the CLI separately with `codex login` for ChatGPT Plus/Pro access.
   CADIS does not read, copy, or persist `~/.codex/auth.json`.
 - `openai`: sends chat requests to the OpenAI Chat Completions API. It requires
-  `CADIS_OPENAI_API_KEY` or `OPENAI_API_KEY` in the daemon environment.
+  `CADIS_OPENAI_API_KEY` or `OPENAI_API_KEY` in the daemon environment. OpenAI
+  responses stream through server-sent events when the provider supports them.
 - `ollama`: requires a running Ollama server and returns an error event if unavailable.
+  Ollama responses stream through native `/api/generate` NDJSON chunks.
 - `echo`: uses the credential-free local fallback.
 
 Per-agent model selections set through `agent.model.set` are routed by `cadisd`
@@ -488,6 +490,9 @@ distinguish a real provider from the local fallback. `openai` is reported as
 `ready` only when an OpenAI API key is present in the daemon environment.
 Providers that need a daemon, login, API key, or local service are otherwise
 reported as `requires_configuration` until CADIS has active provider probing.
+Ollama and OpenAI entries advertise the `streaming` capability; Codex CLI
+stream events currently follow the shared callback contract but are limited by
+the official CLI process output granularity.
 
 Provider failures are surfaced through the normal `ErrorPayload` fields on
 `session.failed` events. Clients should key off the stable `code` and

--- a/docs/18_INSTALLATION.md
+++ b/docs/18_INSTALLATION.md
@@ -80,7 +80,8 @@ Whisper model path, the Node helper used for Edge TTS, and local audio players.
 
 The default provider mode is `auto`: CADIS tries Ollama at
 `http://127.0.0.1:11434` and falls back to a local credential-free response if
-Ollama is not ready.
+Ollama is not ready. When Ollama is running, CADIS streams native NDJSON deltas
+from `/api/generate` into daemon `message.delta` events.
 
 To use OpenAI, keep the API key in the daemon environment and set the provider
 in `~/.cadis/config.toml`:
@@ -96,7 +97,8 @@ openai_model = "gpt-5.2"
 openai_base_url = "https://api.openai.com/v1"
 ```
 
-Do not store the API key in `config.toml`.
+Do not store the API key in `config.toml`. OpenAI responses stream through
+Chat Completions server-sent events before the final `message.completed` event.
 
 To use a ChatGPT Plus/Pro subscription through Codex, authenticate the official
 Codex CLI first and then select the adapter provider:

--- a/docs/standards/13_MODEL_PROVIDER_STANDARD.md
+++ b/docs/standards/13_MODEL_PROVIDER_STANDARD.md
@@ -162,6 +162,15 @@ Required conformance tests:
 
 Live provider tests must be opt-in and skipped by default in CI.
 
+Current baseline support:
+
+- Ollama streams native `/api/generate` NDJSON chunks through the shared
+  callback interface.
+- OpenAI streams Chat Completions server-sent events through the shared
+  callback interface.
+- Codex CLI remains callback-compatible through `codex exec` output, with
+  stream granularity limited by the official CLI process output.
+
 ## 10. Custom HTTP Provider
 
 The custom HTTP provider is for advanced users and integration testing.


### PR DESCRIPTION
## Summary
- add native Ollama NDJSON and OpenAI Chat Completions SSE streaming through the shared provider callback
- preserve provider-native streaming in the routing provider and keep auto fallback from mixing streams after Ollama starts
- update provider docs, checklist, protocol/config/install notes, and README status

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features