### PR TITLE
feat: propagate session cancel to provider streams

### DIFF
--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -1141,6 +1141,11 @@ impl Runtime {
         )
     }
 
+    /// Returns whether a prepared model generation has been cancelled by the runtime.
+    pub fn message_generation_cancelled(&self, pending: &PendingMessageGeneration) -> bool {
+        self.agent_session_cancelled(&pending.context.agent_session_id)
+    }
+
     /// Finalizes a successful streamed model generation.
     pub fn complete_message_generation(
         &mut self,
@@ -1149,6 +1154,10 @@ impl Runtime {
         final_content: String,
         emitted_delta: bool,
     ) -> Vec<EventEnvelope> {
+        if self.message_generation_cancelled(&pending) {
+            return Vec::new();
+        }
+
         let mut events = Vec::new();
         let model = Some(model_invocation_payload(&response.invocation));
         let mut content = final_content;
@@ -1255,6 +1264,10 @@ impl Runtime {
         pending: PendingMessageGeneration,
         error: cadis_models::ModelError,
     ) -> Vec<EventEnvelope> {
+        if error.is_cancelled() && self.message_generation_cancelled(&pending) {
+            return Vec::new();
+        }
+
         let context = pending.context;
         let error_message = error.message().to_owned();
         let mut events = Vec::new();
@@ -2194,6 +2207,12 @@ impl Runtime {
         self.agent_sessions
             .get(agent_session_id)
             .is_some_and(|record| timestamp_is_past(&record.timeout_at))
+    }
+
+    fn agent_session_cancelled(&self, agent_session_id: &AgentSessionId) -> bool {
+        self.agent_sessions
+            .get(agent_session_id)
+            .is_some_and(|record| record.status == AgentSessionStatus::Cancelled)
     }
 
     fn cancel_agent_sessions_for_session(&mut self, session_id: &SessionId) -> Vec<EventEnvelope> {
@@ -7501,6 +7520,51 @@ mod tests {
             .initial_events
             .iter()
             .any(|event| matches!(event.event, CadisEvent::MessageCompleted(_))));
+    }
+
+    #[test]
+    fn pending_message_generation_observes_session_cancel() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = CountingProvider {
+            calls: Arc::clone(&calls),
+        };
+        let mut runtime = runtime_with_provider(Box::new(provider), "counting");
+
+        let pending = runtime
+            .begin_message_request(RequestEnvelope::new(
+                RequestId::from("req_1"),
+                ClientId::from("cli_1"),
+                ClientRequest::MessageSend(MessageSendRequest {
+                    session_id: None,
+                    target_agent_id: None,
+                    content: "cancel me".to_owned(),
+                    content_kind: ContentKind::Chat,
+                }),
+            ))
+            .expect("message request should be prepared");
+        let session_id = pending.context.session_id.clone();
+
+        assert!(!runtime.message_generation_cancelled(&pending));
+
+        let cancel = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_cancel"),
+            ClientId::from("cli_2"),
+            ClientRequest::SessionCancel(SessionTargetRequest {
+                session_id: session_id.clone(),
+            }),
+        ));
+
+        assert!(matches!(
+            cancel.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(runtime.message_generation_cancelled(&pending));
+
+        let final_events = runtime.fail_message_generation(
+            pending,
+            cadis_models::ModelError::cancelled("model request was cancelled"),
+        );
+        assert!(final_events.is_empty());
     }
 
     #[test]

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -263,6 +263,20 @@ fn serve_pending_message_generation<W: Write>(
     let stream_result = provider.stream_chat(
         ModelRequest::new(&pending.prompt).with_selected_model(pending.selected_model.as_deref()),
         &mut |event| {
+            if runtime
+                .lock()
+                .map_err(|_| {
+                    ModelError::with_code(
+                        "runtime_lock_failed",
+                        "runtime mutex was poisoned",
+                        false,
+                    )
+                })?
+                .message_generation_cancelled(&pending)
+            {
+                return Ok(ModelStreamControl::Cancel);
+            }
+
             match event {
                 ModelStreamEvent::Started(started) | ModelStreamEvent::Completed(started) => {
                     invocation = Some(started);
@@ -475,7 +489,8 @@ mod tests {
     use cadis_models::{ModelInvocation, ModelProvider, ModelResponse};
     use cadis_protocol::{
         CadisEvent, ClientId, ContentKind, DaemonResponse, EmptyPayload, MessageSendRequest,
-        RequestEnvelope, ServerFrame, SessionCreateRequest, SessionEventPayload, Timestamp,
+        RequestEnvelope, ServerFrame, SessionCreateRequest, SessionEventPayload,
+        SessionTargetRequest, Timestamp,
     };
     use std::sync::Condvar;
     use std::time::{Duration, Instant};
@@ -805,6 +820,107 @@ mod tests {
         assert_eq!(completed_one.event_id, completed_two.event_id);
     }
 
+    #[test]
+    fn session_cancel_propagates_to_active_provider_stream() {
+        let cadis_home = test_workspace("cadis-daemon-provider-cancel");
+        let socket_path = cadis_home.join("run").join("cadisd-test.sock");
+        let first_delta = Arc::new((Mutex::new(false), Condvar::new()));
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let cancel_seen = Arc::new((Mutex::new(false), Condvar::new()));
+        let config = CadisConfig {
+            cadis_home: cadis_home.clone(),
+            ..CadisConfig::default()
+        };
+        ensure_layout(&config).expect("test CADIS layout should be created");
+
+        let runtime = Arc::new(Mutex::new(Runtime::new(
+            RuntimeOptions {
+                cadis_home,
+                profile_id: "default".to_owned(),
+                socket_path: Some(socket_path.clone()),
+                model_provider: "cancellable".to_owned(),
+                ollama_model: "llama3.2".to_owned(),
+                openai_model: "gpt-5.2".to_owned(),
+                openai_api_key_configured: false,
+                ui_preferences: serde_json::json!({}),
+            },
+            Box::new(CancellableProvider {
+                first_delta: Arc::clone(&first_delta),
+                release: Arc::clone(&release),
+                cancel_seen: Arc::clone(&cancel_seen),
+            }),
+        )));
+        let event_log = EventLog::new(&config);
+        let event_bus = EventBus::new(32);
+        let listener = UnixListener::bind(&socket_path).expect("test socket should bind");
+        let accept_runtime = Arc::clone(&runtime);
+        let accept_event_log = event_log.clone();
+        let accept_event_bus = event_bus.clone();
+        let accept_thread = thread::spawn(move || {
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().expect("test client should connect");
+                let runtime = Arc::clone(&accept_runtime);
+                let event_log = accept_event_log.clone();
+                let event_bus = accept_event_bus.clone();
+                thread::spawn(move || {
+                    let _ = serve_unix_stream(stream, runtime, event_log, event_bus);
+                });
+            }
+        });
+
+        let mut messenger = TestClient::connect(&socket_path);
+        let mut control = TestClient::connect(&socket_path);
+        accept_thread
+            .join()
+            .expect("test accept thread should not panic");
+
+        messenger.send(RequestEnvelope::new(
+            RequestId::from("req_message"),
+            ClientId::from("cli_message"),
+            ClientRequest::MessageSend(MessageSendRequest {
+                session_id: None,
+                target_agent_id: None,
+                content: "cancel active provider".to_owned(),
+                content_kind: ContentKind::Chat,
+            }),
+        ));
+        assert_accepted_response(&mut messenger);
+
+        let session_id = match messenger
+            .read_event_matching(|event| matches!(event.event, CadisEvent::SessionStarted(_)))
+            .event
+        {
+            CadisEvent::SessionStarted(payload) => payload.session_id,
+            other => panic!("expected session.started event, got {other:?}"),
+        };
+        messenger.read_event_matching(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::MessageDelta(payload) if payload.delta == "first"
+            )
+        });
+        wait_for_flag(&first_delta);
+
+        control.send(RequestEnvelope::new(
+            RequestId::from("req_cancel"),
+            ClientId::from("cli_control"),
+            ClientRequest::SessionCancel(SessionTargetRequest {
+                session_id: session_id.clone(),
+            }),
+        ));
+        assert_accepted_response(&mut control);
+        control.read_event_matching(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentSessionCancelled(payload)
+                    if payload.session_id == session_id
+            )
+        });
+
+        set_flag(&release);
+        wait_for_flag_timeout(&cancel_seen, Duration::from_secs(2));
+    }
+
     #[derive(Clone, Debug)]
     struct WaitingProvider {
         entered: Arc<(Mutex<bool>, Condvar)>,
@@ -844,6 +960,52 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Debug)]
+    struct CancellableProvider {
+        first_delta: Arc<(Mutex<bool>, Condvar)>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+        cancel_seen: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl ModelProvider for CancellableProvider {
+        fn name(&self) -> &str {
+            "cancellable"
+        }
+
+        fn chat(&self, _prompt: &str) -> Result<Vec<String>, ModelError> {
+            Ok(vec!["done".to_owned()])
+        }
+
+        fn stream_chat(
+            &self,
+            request: ModelRequest<'_>,
+            callback: &mut cadis_models::ModelStreamCallback<'_>,
+        ) -> Result<ModelResponse, ModelError> {
+            let invocation = ModelInvocation {
+                requested_model: request.selected_model.map(ToOwned::to_owned),
+                effective_provider: "cancellable".to_owned(),
+                effective_model: "unit-test".to_owned(),
+                fallback: false,
+                fallback_reason: None,
+            };
+            callback(ModelStreamEvent::Started(invocation.clone()))?;
+            callback(ModelStreamEvent::Delta("first".to_owned()))?;
+            set_flag(&self.first_delta);
+            wait_for_flag(&self.release);
+            if callback(ModelStreamEvent::Delta("second".to_owned()))? == ModelStreamControl::Cancel
+            {
+                set_flag(&self.cancel_seen);
+                return Err(ModelError::cancelled("model request was cancelled")
+                    .with_invocation(invocation));
+            }
+            callback(ModelStreamEvent::Completed(invocation.clone()))?;
+            Ok(ModelResponse {
+                deltas: vec!["first".to_owned(), "second".to_owned()],
+                invocation,
+            })
+        }
+    }
+
     fn wait_for_flag(flag: &Arc<(Mutex<bool>, Condvar)>) {
         let (lock, condvar) = &**flag;
         let mut ready = lock.lock().expect("flag mutex should lock");
@@ -858,6 +1020,22 @@ mod tests {
         let (lock, condvar) = &**flag;
         *lock.lock().expect("flag mutex should lock") = true;
         condvar.notify_all();
+    }
+
+    fn wait_for_flag_timeout(flag: &Arc<(Mutex<bool>, Condvar)>, timeout: Duration) {
+        let (lock, condvar) = &**flag;
+        let deadline = Instant::now() + timeout;
+        let mut ready = lock.lock().expect("flag mutex should lock");
+        while !*ready {
+            let now = Instant::now();
+            assert!(now < deadline, "timed out waiting for flag");
+            let wait_for = deadline.saturating_duration_since(now);
+            let (guard, result) = condvar
+                .wait_timeout(ready, wait_for)
+                .expect("flag mutex should not be poisoned");
+            ready = guard;
+            assert!(!result.timed_out() || *ready, "timed out waiting for flag");
+        }
     }
 
     struct TestClient {

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -56,7 +56,9 @@ Implemented in the first runnable baseline:
 - Agent Runtime baseline: durable per-route `AgentSession` records with route,
   task, result, timeout deadline, step budget, cancellation, and parent-child
   metadata exposed through `agent.session.*` lifecycle events and replayed in
-  snapshot responses after daemon restart.
+  snapshot responses after daemon restart. `session.cancel` now propagates into
+  active model provider streams through callback cancellation, so an in-flight
+  provider response cannot later overwrite a cancelled AgentSession.
 - Track C worker baseline: in-memory daemon worker registry, route-time
   `worker.log.delta` lifecycle logs, `events.snapshot` worker lifecycle
   snapshots, and one-shot `worker.tail` replay.
@@ -83,9 +85,10 @@ Implemented in the first runnable baseline:
 Still pending:
 
 - Native mutating file/shell tools.
-- Agent runtime beyond the current route-and-answer path: async cancellation,
-  model-driven spawn, multi-step budgets, and a provider/tool-call loop remain
-  future work; existing `agent.spawn` is client-requested, not agent-driven.
+- Agent runtime beyond the current route-and-answer path: model-driven spawn,
+  multi-step budgets, full tool cancellation, and a provider/tool-call loop
+  remain future work; existing `agent.spawn` is client-requested, not
+  agent-driven.
 - Daemon startup wiring for pending approval recovery. Store-level atomic write
   and fail-safe recovery helpers exist, and the daemon now recovers durable
   session, agent, AgentSession, and worker metadata.
@@ -185,6 +188,10 @@ Tasks:
 - Add a worker registry with `worker.started`, `worker.log.delta`,
   `worker.completed`, `worker.failed`, and `worker.cancelled`.
 - Implement `worker.tail` from daemon-owned worker logs.
+- Propagate `session.cancel` into active provider streams. Baseline now checks
+  pending AgentSession cancellation inside daemon provider callbacks, returns
+  `ModelStreamControl::Cancel`, and prevents cancelled generations from
+  finalizing as failed or completed after the cancel event.
 
 Exit criteria:
 
@@ -192,6 +199,8 @@ Exit criteria:
   limits.
 - HUD worker tree is driven by daemon worker events.
 - Worker logs can be tailed from CLI and HUD.
+- Cancelling a session stops the active provider stream at the next callback
+  boundary and preserves the AgentSession as `cancelled`.
 
 ### Track D - Policy, Approval, and Tool Runtime
 

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -222,7 +222,8 @@
 - [x] Add per-route AgentSession step budget baseline.
 - [x] Add per-route AgentSession timeout deadline baseline.
 - [x] Add session-cancel AgentSession cancellation baseline.
-- [ ] Add async provider/tool cancellation.
+- [x] Add async provider cancellation at the daemon callback boundary.
+- [ ] Add async tool cancellation.
 - [ ] Add tool-call loop.
 - [ ] Add model fallback behavior.
 
@@ -325,9 +326,10 @@
 - [x] Track B: provider readiness, effective model metadata, selected-model routing, and provider streaming/cancellation contract.
 - [ ] Track C: `AgentSession`, agent-driven spawn, limits, and worker registry.
   Baselines landed: AgentSession state/events, explicit daemon-owned spawn,
-  spawn limits, worker registry, and worker tail. Remaining: implicit
-  model-driven spawn, worker failed/cancelled events, and real command/test
-  execution inside worker worktrees.
+  spawn limits, worker registry, worker tail, and provider-stream cancellation
+  on `session.cancel`. Remaining: implicit model-driven spawn, worker
+  failed/cancelled events, and real command/test execution inside worker
+  worktrees.
 - [ ] Track D: policy-backed tools and approval persistence.
 - [ ] Track E: daemon-owned voice provider path, STT language setting, and voice doctor.
 - [ ] Track F: durable metadata and restart recovery for sessions, agents, AgentSessions, workers, and approvals.

--- a/docs/12_TEST_STRATEGY.md
+++ b/docs/12_TEST_STRATEGY.md
@@ -45,6 +45,7 @@ Use for:
 Use for:
 
 - model provider contract
+- daemon provider-stream cancellation on `session.cancel`
 - tool registry contract
 - local protocol compatibility
 - event schema compatibility

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -387,8 +387,11 @@ an optional redacted `result`. Terminal failure/cancellation events add optional
 The current baseline enforces a per-route step budget before provider execution
 and records timeout deadlines. AgentSession metadata is written atomically under
 `state/agent-sessions/` and recovered on daemon restart so snapshots can replay
-the current AgentSession state. Model/tool-loop cancellation and async
-interrupt remain later runtime work.
+the current AgentSession state. `session.cancel` marks active AgentSessions as
+`cancelled` and daemon provider callbacks now return provider-boundary
+`Cancel` for that pending generation, preventing a later provider response from
+turning the AgentSession back into `failed` or `completed`. Tool-loop
+cancellation and broader async interrupts remain later runtime work.
 
 `workspace.list.response` payload:
 

--- a/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
+++ b/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
@@ -411,6 +411,12 @@ Terminal events are `agent.session.completed`, `agent.session.failed`, and
 `agent.session.cancelled`. Status values are `started`, `running`, `completed`,
 `failed`, `cancelled`, `timed_out`, and `budget_exceeded`.
 
+When a client sends `session.cancel`, `cadisd` marks active AgentSessions as
+`cancelled` and active model-provider callbacks return provider-boundary
+`Cancel` at the next stream callback. HUD should keep rendering the
+`agent.session.cancelled` state and must not convert a later closed stream into
+an error unless a distinct `session.failed` event is received.
+
 ### `agent.renamed`
 
 Confirms rename and updates all surfaces.


### PR DESCRIPTION
## Summary
- add runtime cancellation checks for pending model generations
- return provider-boundary Cancel from daemon stream callbacks when session.cancel marks the AgentSession cancelled
- prevent cancelled generations from finalizing as failed or completed, and document the Track C cancellation baseline

## Validation
- cargo test -p cadis-core pending_message_generation_observes_session_cancel
- cargo test -p cadis-daemon session_cancel_propagates_to_active_provider_stream
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features