### PR TITLE
Advance runtime tools and platform baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           test -f docs/01_PRD.md
           test -f docs/06_IMPLEMENTATION_PLAN.md
           test -f docs/07_MASTER_CHECKLIST.md
+          test -f docs/28_PLATFORM_BASELINE.md
           test -f docs/standards/00_STANDARD_INDEX.md
 
   rust:

--- a/.github/workflows/platform-baseline.yml
+++ b/.github/workflows/platform-baseline.yml
@@ -23,8 +23,8 @@ jobs:
         run: cargo fmt --all --check
       - name: Rust clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-      - name: Rust tests
-        run: cargo test --workspace --all-targets --all-features
+      - name: Rust portable and core tests
+        run: cargo test -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar -p cadis-core --all-targets --all-features
 
   windows-portable-crates:
     name: Windows portable crate baseline
@@ -40,5 +40,5 @@ jobs:
         run: cargo check -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
       - name: Portable crate clippy
         run: cargo clippy -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features -- -D warnings
-      - name: Portable crate tests
-        run: cargo test -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
+      - name: Portable pure crate tests
+        run: cargo test -p cadis-protocol -p cadis-policy -p cadis-models -p cadis-avatar --all-targets --all-features

--- a/.github/workflows/platform-baseline.yml
+++ b/.github/workflows/platform-baseline.yml
@@ -1,0 +1,44 @@
+name: Platform Baseline
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  macos-rust-source:
+    name: macOS Rust source baseline
+    runs-on: macos-latest
+    timeout-minutes: 45
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Rust format
+        run: cargo fmt --all --check
+      - name: Rust clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Rust tests
+        run: cargo test --workspace --all-targets --all-features
+
+  windows-portable-crates:
+    name: Windows portable crate baseline
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Portable crate check
+        run: cargo check -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
+      - name: Portable crate clippy
+        run: cargo clippy -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features -- -D warnings
+      - name: Portable crate tests
+        run: cargo test -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format follows Keep a Changelog style, and the project will use Semantic Ver
   paused message generation.
 - Runtime tool definitions now declare richer contract metadata (description, side effects, timeout, workspace scope, cancellation behavior, and secret/network posture), with approval summaries reflecting that contract.
 - Agent Runtime baseline with daemon-owned `AgentSession` lifecycle events, per-route timeout and step-budget metadata, cancellation metadata, and explicit `/worker` or `/spawn` orchestration through core spawn limits.
+- Native safe-read `git.diff` execution, pending approval restart recovery, and
+  daemon/HUD voice lifecycle event handling.
+- Platform baseline documentation and GitHub Actions coverage for macOS Rust
+  source validation and Windows portable-crate validation.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ The repository already includes a meaningful desktop MVP foundation:
 - optional Ollama, OpenAI API, and Codex CLI model adapters, with native
   streaming for Ollama and OpenAI
 - official Codex CLI adapter for ChatGPT Plus/Pro login flows
-- HUD-local Edge TTS playback, `whisper-cli` voice input, and voice doctor preflight
+- daemon-visible voice status/doctor/preflight with HUD-local Edge TTS
+  playback and `whisper-cli` voice input bridges
 
 Planned work still includes production-grade mutating tool execution, full
 policy coverage, richer worker isolation, Telegram/mobile clients,
@@ -95,6 +96,16 @@ architecture is partially implemented; real worker worktree creation,
 profile-scoped worker artifacts, and review-pending worker metadata are now in
 place. Checkpoint rollback, dedicated profile/agent doctor commands, and
 project media manifests remain next.
+
+## Platform support
+
+Linux desktop is the primary runtime and HUD target for the current MVP.
+macOS is covered as a Rust source-validation baseline. Windows is limited to
+portable-crate validation until daemon/CLI transport, shell, path, sandbox, HUD,
+and audio adapters exist.
+
+See the [Platform Baseline](docs/28_PLATFORM_BASELINE.md) for the support
+matrix and the exact macOS/Windows CI commands.
 
 ## Core capabilities
 
@@ -217,6 +228,8 @@ for C.A.D.I.S. in system settings and retry from the HUD.
 The HUD Settings -> Voice tab includes a local voice doctor that checks renderer
 mic status, WebAudio analyser/PCM fallback telemetry, `whisper-cli`, the
 configured Whisper model, Node helper execution, and available audio players.
+The daemon protocol also exposes voice status, doctor, and preflight results;
+HUD/Tauri remains the local capture and playback bridge for now.
 
 ## Repository layout
 
@@ -252,6 +265,7 @@ cadis/
 - [Memory Concept](docs/25_MEMORY_CONCEPT.md)
 - [Wulan Avatar Engine](docs/26_WULAN_AVATAR_ENGINE.md)
 - [Workspace Architecture](docs/27_WORKSPACE_ARCHITECTURE.md)
+- [Platform Baseline](docs/28_PLATFORM_BASELINE.md)
 
 ## Contributing
 

--- a/apps/cadis-hud/src/ui/cadisActions.test.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.test.ts
@@ -326,6 +326,48 @@ describe("cadisActions", () => {
     });
   });
 
+  it("tracks daemon voice preview lifecycle events", () => {
+    handleCadisFrameForTest({
+      frame: "event",
+      payload: {
+        type: "voice.preview.started",
+        payload: {},
+      },
+    });
+
+    expect(useHud.getState().voiceState).toBe("speaking");
+
+    handleCadisFrameForTest({
+      frame: "event",
+      payload: {
+        type: "voice.preview.completed",
+        payload: {},
+      },
+    });
+
+    expect(useHud.getState().voiceState).toBe("idle");
+
+    handleCadisFrameForTest({
+      frame: "event",
+      payload: {
+        type: "voice.started",
+        payload: {},
+      },
+    });
+
+    expect(useHud.getState().voiceState).toBe("speaking");
+
+    handleCadisFrameForTest({
+      frame: "event",
+      payload: {
+        type: "voice.failed",
+        payload: { code: "provider_failed", message: "failed", retryable: false },
+      },
+    });
+
+    expect(useHud.getState().voiceState).toBe("idle");
+  });
+
   it("publishes HUD bridge preflight checks to the daemon", async () => {
     connect();
     await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(4));

--- a/apps/cadis-hud/src/ui/cadisActions.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.ts
@@ -399,6 +399,19 @@ function handleMessage(type: string, payload: unknown, sessionId?: string): void
     handleVoiceDoctor(payload);
     return;
   }
+  if (type === "voice.preview.started" || type === "voice.started") {
+    useHud.getState().setVoiceState("speaking");
+    return;
+  }
+  if (
+    type === "voice.preview.completed" ||
+    type === "voice.preview.failed" ||
+    type === "voice.completed" ||
+    type === "voice.failed"
+  ) {
+    useHud.getState().setVoiceState("idle");
+    return;
+  }
   if (type === "message.delta") {
     handleMessageDelta(payload, sessionId);
     return;

--- a/crates/cadis-cli/src/main.rs
+++ b/crates/cadis-cli/src/main.rs
@@ -1618,6 +1618,10 @@ fn tool_input_from_args(tool_name: &str, args: &[String]) -> serde_json::Value {
         "git.status" => serde_json::json!({
             "path": args.first().cloned().unwrap_or_else(|| ".".to_owned())
         }),
+        "git.diff" => serde_json::json!({
+            "path": args.first().cloned().unwrap_or_else(|| ".".to_owned()),
+            "pathspec": args.get(1).cloned()
+        }),
         "shell.run" => serde_json::json!({
             "command": args.join(" ")
         }),

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 use std::time::Instant;
@@ -48,6 +48,7 @@ use serde::{Deserialize, Serialize};
 const FILE_READ_LIMIT_BYTES: usize = 64 * 1024;
 const FILE_SEARCH_LIMIT_BYTES: u64 = 1024 * 1024;
 const FILE_SEARCH_DEFAULT_LIMIT: usize = 50;
+const GIT_DIFF_LIMIT_BYTES: usize = 128 * 1024;
 const APPROVAL_TIMEOUT_MINUTES: i64 = 5;
 const WORKER_TAIL_DEFAULT_LINES: usize = 64;
 const WORKER_TAIL_MAX_LINES: usize = 1_000;
@@ -314,6 +315,10 @@ impl Runtime {
         diagnostics.extend(worker_recovery.diagnostics);
         let mut workers = worker_recovery.records;
         diagnostics.extend(reconcile_recovered_workers(&state_store, &mut workers));
+        let approval_recovery = recover_approval_records(&state_store);
+        diagnostics.extend(approval_recovery.diagnostics);
+        let next_approval = next_approval_counter(&approval_recovery.records);
+        let pending_approvals = pending_approval_records(approval_recovery.records);
         let next_session = next_session_counter(&sessions);
         let next_agent = next_agent_counter(&agents);
         let next_worker = next_worker_counter(&workers);
@@ -343,13 +348,13 @@ impl Runtime {
             approval_store,
             state_store,
             profile_home,
-            pending_approvals: HashMap::new(),
+            pending_approvals,
             workspaces,
             workspace_grants,
             last_voice_preflight: None,
             recovery_diagnostics: diagnostics,
             next_tool: 1,
-            next_approval: 1,
+            next_approval,
             next_workspace_grant,
         }
     }
@@ -760,17 +765,7 @@ impl Runtime {
 
                 events.push(self.session_event(
                     session_id,
-                    CadisEvent::ApprovalRequested(ApprovalRequestPayload {
-                        approval_id,
-                        session_id: record.session_id,
-                        tool_call_id,
-                        risk_class,
-                        title: record.title,
-                        summary: record.summary,
-                        command,
-                        workspace,
-                        expires_at,
-                    }),
+                    CadisEvent::ApprovalRequested(approval_request_payload(&record)),
                 ));
                 self.accept(request_id, events)
             }
@@ -2003,6 +1998,17 @@ impl Runtime {
         records
     }
 
+    fn pending_approval_records_sorted(&self) -> Vec<ApprovalRecord> {
+        let mut records = self
+            .pending_approvals
+            .values()
+            .map(|pending| pending.record.clone())
+            .filter(|record| !approval_is_expired(record))
+            .collect::<Vec<_>>();
+        records.sort_by(|left, right| left.approval_id.cmp(&right.approval_id));
+        records
+    }
+
     fn snapshot_events(&mut self) -> Vec<EventEnvelope> {
         let agents = self
             .agent_records_sorted()
@@ -2076,6 +2082,13 @@ impl Runtime {
                 CadisEvent::WorkerStarted(payload)
             };
             events.push(self.session_event(session_id, event));
+        }
+
+        for record in self.pending_approval_records_sorted() {
+            events.push(self.session_event(
+                record.session_id.clone(),
+                CadisEvent::ApprovalRequested(approval_request_payload(&record)),
+            ));
         }
 
         events
@@ -2604,6 +2617,7 @@ impl Runtime {
                 "file.read" => self.execute_file_read(workspace, &request.input),
                 "file.search" => self.execute_file_search(workspace, &request.input),
                 "git.status" => self.execute_git_status(workspace, &request.input),
+                "git.diff" => self.execute_git_diff(workspace, &request.input),
                 _ => Err(tool_error(
                     "tool_not_implemented",
                     format!("{tool_name} has no native execution backend"),
@@ -2745,6 +2759,69 @@ impl Runtime {
             output: serde_json::json!({
                 "cwd": display_relative_path(workspace, &cwd),
                 "status": stdout
+            }),
+        })
+    }
+
+    fn execute_git_diff(
+        &self,
+        workspace: &Path,
+        input: &serde_json::Value,
+    ) -> Result<ToolExecutionResult, ErrorPayload> {
+        let cwd = input_string(input, "path")
+            .or_else(|| input_string(input, "cwd"))
+            .unwrap_or_else(|| ".".to_owned());
+        let cwd = resolve_inside_workspace(workspace, &cwd)?;
+        let pathspec = input_string(input, "pathspec")
+            .or_else(|| input_string(input, "target"))
+            .map(|value| validate_git_pathspec(&value))
+            .transpose()?;
+
+        let mut command = Command::new("git");
+        command
+            .arg("-C")
+            .arg(&cwd)
+            .args(["diff", "--no-ext-diff", "--no-color", "--"]);
+        if let Some(pathspec) = &pathspec {
+            command.arg(pathspec);
+        }
+
+        let output = command
+            .output()
+            .map_err(|error| tool_error("git_diff_failed", error.to_string(), false))?;
+        if !output.status.success() {
+            let stderr = redact(&String::from_utf8_lossy(&output.stderr));
+            return Err(tool_error(
+                "git_diff_failed",
+                if stderr.trim().is_empty() {
+                    "git diff failed".to_owned()
+                } else {
+                    stderr
+                },
+                false,
+            ));
+        }
+
+        let truncated = output.stdout.len() > GIT_DIFF_LIMIT_BYTES;
+        let visible = if truncated {
+            &output.stdout[..GIT_DIFF_LIMIT_BYTES]
+        } else {
+            &output.stdout
+        };
+        let diff = redact(&String::from_utf8_lossy(visible));
+        let summary = if diff.trim().is_empty() {
+            "no diff".to_owned()
+        } else {
+            diff.clone()
+        };
+
+        Ok(ToolExecutionResult {
+            summary,
+            output: serde_json::json!({
+                "cwd": display_relative_path(workspace, &cwd),
+                "pathspec": pathspec,
+                "diff": diff,
+                "truncated": truncated
             }),
         })
     }
@@ -4055,17 +4132,13 @@ impl ToolRegistry {
                 false,
                 false,
             ),
-            ToolDefinition::approval_placeholder(
+            ToolDefinition::safe_read(
                 "git.diff",
                 "Read git diff output for an approved workspace",
-                cadis_protocol::RiskClass::WorkspaceEdit,
-                ToolInputSchema::GitMutation,
+                ToolInputSchema::GitDiff,
                 &[ToolSideEffect::ReadGitDiff],
                 20,
-                ToolCancellationBehavior::NotSupported,
                 ToolWorkspaceBehavior::PathScoped,
-                false,
-                false,
             ),
             ToolDefinition::approval_placeholder(
                 "git.worktree.create",
@@ -4231,6 +4304,7 @@ enum ToolInputSchema {
     FileRead,
     FileSearch,
     GitStatus,
+    GitDiff,
     ShellRun,
     WorkspaceMutation,
     GitMutation,
@@ -4401,6 +4475,40 @@ fn recover_worker_records(state_store: &StateStore) -> RuntimeRecovery<String, W
             )],
         },
     }
+}
+
+fn recover_approval_records(
+    state_store: &StateStore,
+) -> RuntimeRecovery<ApprovalId, ApprovalRecord> {
+    match state_store.recover_approval_metadata::<ApprovalRecord>() {
+        Ok(recovery) => RuntimeRecovery {
+            records: recovery
+                .records
+                .into_iter()
+                .map(|record| (record.metadata.approval_id.clone(), record.metadata))
+                .collect(),
+            diagnostics: recovery_diagnostics("approval", recovery.diagnostics),
+        },
+        Err(error) => RuntimeRecovery {
+            records: HashMap::new(),
+            diagnostics: vec![recovery_error(
+                "approval_recovery_failed",
+                error.to_string(),
+                true,
+            )],
+        },
+    }
+}
+
+fn pending_approval_records(
+    records: HashMap<ApprovalId, ApprovalRecord>,
+) -> HashMap<ApprovalId, PendingApproval> {
+    records
+        .into_iter()
+        .filter(|(_, record)| record.state == ApprovalState::Pending)
+        .filter(|(_, record)| !approval_is_expired(record))
+        .map(|(approval_id, record)| (approval_id, PendingApproval { record }))
+        .collect()
 }
 
 fn reconcile_recovered_workers(
@@ -4580,6 +4688,16 @@ fn next_worker_counter(workers: &HashMap<String, WorkerRecord>) -> u64 {
     workers
         .keys()
         .filter_map(|worker_id| worker_id.strip_prefix("worker_"))
+        .filter_map(|suffix| suffix.parse::<u64>().ok())
+        .max()
+        .unwrap_or(0)
+        + 1
+}
+
+fn next_approval_counter(approvals: &HashMap<ApprovalId, ApprovalRecord>) -> u64 {
+    approvals
+        .keys()
+        .filter_map(|approval_id| approval_id.as_str().strip_prefix("apr_"))
         .filter_map(|suffix| suffix.parse::<u64>().ok())
         .max()
         .unwrap_or(0)
@@ -4770,6 +4888,20 @@ fn approval_is_expired(record: &ApprovalRecord) -> bool {
     DateTime::parse_from_rfc3339(record.expires_at.as_str())
         .map(|expires_at| expires_at.with_timezone(&Utc) <= Utc::now())
         .unwrap_or(true)
+}
+
+fn approval_request_payload(record: &ApprovalRecord) -> ApprovalRequestPayload {
+    ApprovalRequestPayload {
+        approval_id: record.approval_id.clone(),
+        session_id: record.session_id.clone(),
+        tool_call_id: record.tool_call_id.clone(),
+        risk_class: record.risk_class,
+        title: record.title.clone(),
+        summary: record.summary.clone(),
+        command: record.command.clone(),
+        workspace: record.workspace.clone(),
+        expires_at: record.expires_at.clone(),
+    }
 }
 
 fn input_string(input: &serde_json::Value, key: &str) -> Option<String> {
@@ -5198,6 +5330,42 @@ fn tool_command_summary(tool_name: &str, input: &serde_json::Value) -> Option<St
         _ => input_string(input, "path"),
     }
     .map(|value| redact(&value))
+}
+
+fn validate_git_pathspec(pathspec: &str) -> Result<String, ErrorPayload> {
+    let trimmed = pathspec.trim();
+    if trimmed.is_empty() {
+        return Err(tool_error(
+            "invalid_tool_input",
+            "git.diff pathspec cannot be empty",
+            false,
+        ));
+    }
+    if trimmed.starts_with(':') {
+        return Err(tool_error(
+            "invalid_tool_input",
+            "git.diff pathspec magic is not supported",
+            false,
+        ));
+    }
+
+    let path = Path::new(trimmed);
+    if path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(tool_error(
+            "outside_workspace",
+            "git.diff pathspec must be relative to the workspace",
+            false,
+        ));
+    }
+
+    Ok(trimmed.to_owned())
 }
 
 fn resolve_inside_workspace(workspace: &Path, user_path: &str) -> Result<PathBuf, ErrorPayload> {
@@ -6295,6 +6463,35 @@ mod tests {
     }
 
     #[test]
+    fn voice_status_reports_daemon_visible_preferences() {
+        let mut runtime = runtime_with_voice(true, true, 420);
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_voice_status"),
+            ClientId::from("hud_1"),
+            ClientRequest::VoiceStatus(EmptyPayload::default()),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        let status = outcome
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::VoiceStatusUpdated(payload) => Some(payload),
+                _ => None,
+            })
+            .expect("voice status should be emitted");
+        assert!(status.enabled);
+        assert_eq!(status.provider, "stub");
+        assert_eq!(status.voice_id, "id-ID-GadisNeural");
+        assert_eq!(status.stt_language, "auto");
+        assert_eq!(status.max_spoken_chars, 420);
+        assert_eq!(status.bridge, "hud-local");
+    }
+
+    #[test]
     fn voice_preview_uses_daemon_provider_stub() {
         let mut runtime = runtime_with_voice(false, false, 800);
         let outcome = runtime.handle_request(RequestEnvelope::new(
@@ -6319,6 +6516,55 @@ mod tests {
             .events
             .iter()
             .any(|event| matches!(event.event, CadisEvent::VoicePreviewStarted(_))));
+        assert!(outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::VoicePreviewCompleted(_))));
+    }
+
+    #[test]
+    fn voice_preview_blocks_unspeakable_text_by_policy() {
+        let mut runtime = runtime_with_voice(false, false, 800);
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_voice_preview_empty"),
+            ClientId::from("hud_1"),
+            ClientRequest::VoicePreview(VoicePreviewRequest {
+                text: "   ".to_owned(),
+                prefs: None,
+            }),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::VoicePreviewFailed(error)
+                    if error.code == "empty_text"
+                        && error.message.contains("not speakable")
+            )
+        }));
+        assert!(!outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::VoicePreviewStarted(_))));
+    }
+
+    #[test]
+    fn voice_stop_uses_daemon_provider_stop_contract() {
+        let mut runtime = runtime_with_voice(true, true, 800);
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_voice_stop"),
+            ClientId::from("hud_1"),
+            ClientRequest::VoiceStop(EmptyPayload::default()),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
         assert!(outcome
             .events
             .iter()
@@ -6413,6 +6659,7 @@ mod tests {
         assert!(registry.is_auto_executable_safe_read("file.read"));
         assert!(registry.is_auto_executable_safe_read("file.search"));
         assert!(registry.is_auto_executable_safe_read("git.status"));
+        assert!(registry.is_auto_executable_safe_read("git.diff"));
         assert!(!registry.is_auto_executable_safe_read("shell.run"));
 
         let shell = registry.get("shell.run").expect("shell tool exists");
@@ -6570,6 +6817,96 @@ mod tests {
             .events
             .iter()
             .any(|event| matches!(event.event, CadisEvent::ApprovalRequested(_))));
+    }
+
+    #[test]
+    fn safe_git_diff_tool_runs_without_approval() {
+        let workspace = test_workspace("git-diff");
+        init_git_workspace(&workspace);
+        fs::write(
+            workspace.join("README.md"),
+            "CADIS worker fixture\nupdated line\n",
+        )
+        .expect("tracked file should update");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "git-diff", &workspace);
+        grant_workspace(&mut runtime, "git-diff", vec![WorkspaceAccess::Read]);
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_git_diff"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "git.diff".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "git-diff",
+                    "path": ".",
+                    "pathspec": "README.md"
+                }),
+            }),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ToolStarted(_))));
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolCompleted(payload)
+                    if payload.tool_name == "git.diff"
+                        && payload.summary.as_deref().is_some_and(|summary| {
+                            summary.contains("+updated line")
+                                && summary.contains("diff --git")
+                        })
+            )
+        }));
+        assert!(!outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ApprovalRequested(_))));
+    }
+
+    #[test]
+    fn git_diff_rejects_parent_pathspec() {
+        let workspace = test_workspace("git-diff-pathspec");
+        init_git_workspace(&workspace);
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "git-diff-pathspec", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "git-diff-pathspec",
+            vec![WorkspaceAccess::Read],
+        );
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_git_diff_pathspec"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "git.diff".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "git-diff-pathspec",
+                    "path": ".",
+                    "pathspec": "../README.md"
+                }),
+            }),
+        ));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolFailed(payload)
+                    if payload.tool_name == "git.diff"
+                        && payload.error.code == "outside_workspace"
+            )
+        }));
     }
 
     #[test]
@@ -7445,6 +7782,125 @@ mod tests {
                     if payload.error.code == "approval_denied"
             )
         }));
+    }
+
+    #[test]
+    fn pending_approval_survives_runtime_restart_snapshot_and_denial() {
+        let cadis_home = test_workspace("approval-recovery-home");
+        let workspace = test_workspace("approval-recovery-workspace");
+        let approval_id = {
+            let mut runtime = runtime_with_home(cadis_home.clone());
+            register_workspace(&mut runtime, "approval-recovery", &workspace);
+            grant_workspace(
+                &mut runtime,
+                "approval-recovery",
+                vec![WorkspaceAccess::Exec],
+            );
+
+            let outcome = runtime.handle_request(RequestEnvelope::new(
+                RequestId::from("req_shell_approval"),
+                ClientId::from("cli_1"),
+                ClientRequest::ToolCall(ToolCallRequest {
+                    session_id: None,
+                    agent_id: None,
+                    tool_name: "shell.run".to_owned(),
+                    input: serde_json::json!({
+                        "workspace_id": "approval-recovery",
+                        "command": "echo hello"
+                    }),
+                }),
+            ));
+
+            outcome
+                .events
+                .iter()
+                .find_map(|event| match &event.event {
+                    CadisEvent::ApprovalRequested(payload) => Some(payload.approval_id.clone()),
+                    _ => None,
+                })
+                .expect("approval.requested should be emitted")
+        };
+
+        let mut runtime = runtime_with_home(cadis_home.clone());
+        let snapshot = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_approval_snapshot"),
+            ClientId::from("hud_1"),
+            ClientRequest::EventsSnapshot(EventsSnapshotRequest::default()),
+        ));
+
+        assert!(snapshot.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ApprovalRequested(payload)
+                    if payload.approval_id == approval_id
+                        && payload.tool_call_id.as_str() == "tool_000001"
+                        && payload.summary.contains("run_subprocess")
+            )
+        }));
+
+        let next = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_second_shell_approval"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "shell.run".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "approval-recovery",
+                    "command": "echo next"
+                }),
+            }),
+        ));
+        assert!(next.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ApprovalRequested(payload)
+                    if payload.approval_id.as_str() == "apr_000002"
+            )
+        }));
+
+        let deny = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_deny_recovered"),
+            ClientId::from("cli_1"),
+            ClientRequest::ApprovalRespond(ApprovalResponseRequest {
+                approval_id: approval_id.clone(),
+                decision: ApprovalDecision::Denied,
+                reason: Some("not needed".to_owned()),
+            }),
+        ));
+
+        assert!(deny.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ApprovalResolved(payload)
+                    if payload.approval_id == approval_id
+                        && payload.decision == ApprovalDecision::Denied
+            )
+        }));
+        assert!(deny.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolFailed(payload)
+                    if payload.error.code == "approval_denied"
+            )
+        }));
+
+        let mut restarted = runtime_with_home(cadis_home);
+        let repeated = restarted.handle_request(RequestEnvelope::new(
+            RequestId::from("req_deny_recovered_again"),
+            ClientId::from("cli_1"),
+            ClientRequest::ApprovalRespond(ApprovalResponseRequest {
+                approval_id,
+                decision: ApprovalDecision::Denied,
+                reason: Some("again".to_owned()),
+            }),
+        ));
+
+        assert!(matches!(
+            repeated.response.response,
+            DaemonResponse::RequestRejected(error)
+                if error.code == "approval_already_resolved"
+        ));
     }
 
     #[test]

--- a/docs/00_PROJECT_CHARTER.md
+++ b/docs/00_PROJECT_CHARTER.md
@@ -9,7 +9,8 @@
 - Version: 0.1.0-planning
 - Date: 2026-04-26
 - Primary target: Linux desktop
-- Later targets: Windows, macOS, Android remote client
+- Later targets: Windows, macOS, Android remote client. Current
+  macOS/Windows validation status is defined in `docs/28_PLATFORM_BASELINE.md`.
 
 ## Executive Summary
 

--- a/docs/02_BRD.md
+++ b/docs/02_BRD.md
@@ -50,8 +50,9 @@ Possible future distribution paths:
 
 - GitHub releases with static binaries.
 - Linux packages.
-- Homebrew for macOS later.
-- Windows installer later.
+- Homebrew for macOS after runtime validation.
+- Windows installer after transport, shell, path, sandbox, HUD, and audio
+  adapters are implemented.
 - Optional hosted relay or team features later.
 
 The core daemon should remain useful without paid infrastructure.
@@ -115,6 +116,7 @@ No monetization is required for the first release. Future options must not compr
 
 - Rust is acceptable for the entire core.
 - Linux desktop is the right first platform.
+- macOS and Windows support claims must follow `docs/28_PLATFORM_BASELINE.md`.
 - Users value local control more than browser-first convenience.
 - A daemon-first architecture will outperform UI-first assistant shells.
 - Open-source credibility requires docs and governance before hype.
@@ -132,4 +134,3 @@ No monetization is required for the first release. Future options must not compr
 - Product, business, functional, technical, architecture, roadmap, checklist, risk, and decision docs exist.
 - Open-source files exist.
 - The first implementation sprint is explicit enough to start without redesign.
-

--- a/docs/04_TRD.md
+++ b/docs/04_TRD.md
@@ -15,9 +15,11 @@ client request -> local protocol -> daemon session -> event bus -> model/tool st
 | Platform | Phase | Notes |
 | --- | --- | --- |
 | Linux desktop | First | Primary development and MVP target |
-| Windows | Later | Requires shell, sandbox, path, and audio adapter work |
-| macOS | Later | Requires sandbox and audio adapter work |
+| macOS | Baseline validation | Rust source validation only until sandbox, audio, packaging, and runtime support are documented |
+| Windows | Portable baseline | Portable-crate validation only until transport, shell, sandbox, path, and audio adapter work lands |
 | Android | Later | Remote controller first, not local coding runtime |
+
+The current support matrix is maintained in `docs/28_PLATFORM_BASELINE.md`.
 
 ## 3. Proposed Workspace Structure
 

--- a/docs/05_ARCHITECTURE.md
+++ b/docs/05_ARCHITECTURE.md
@@ -354,11 +354,15 @@ Security-sensitive behavior is centralized:
 
 No adapter may bypass policy by executing tools directly.
 
-## 14. Future Cross-Platform Notes
+## 14. Platform Baseline And Future Cross-Platform Notes
 
-Linux starts with Unix sockets, POSIX shell behavior, and Linux-friendly desktop assumptions.
+Linux starts with Unix sockets, POSIX shell behavior, and Linux-friendly desktop
+assumptions. It remains the primary runtime and HUD target for the current MVP.
+The current validation matrix is documented in `docs/28_PLATFORM_BASELINE.md`.
 
-Windows and macOS need separate adapters for:
+macOS is a Rust source-validation baseline only. Windows is a portable-crate
+validation baseline only. Runtime support on either platform needs separate
+adapters for:
 
 - shell execution
 - path normalization

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -50,6 +50,10 @@ Implemented in the first runnable baseline:
 - Workspace architecture docs: accepted target design for profile homes, agent
   homes, project workspaces, worker worktrees, workspace grants, denied paths,
   and project `.cadis/media/` assets in `docs/27_WORKSPACE_ARCHITECTURE.md`.
+- Platform baseline docs and CI: Linux remains the primary runtime/HUD target,
+  macOS is Rust source validation, and Windows validates only portable crates
+  until transport, shell, path, sandbox, HUD, and audio adapters exist. See
+  `docs/28_PLATFORM_BASELINE.md`.
 - Orchestrator baseline: daemon-owned `@agent` routing, `orchestrator.route`
   events, route-time `agent.status.changed` events, request-driven
   `agent.spawn`, and spawn limits.
@@ -89,9 +93,9 @@ Still pending:
   multi-step budgets, full tool cancellation, and a provider/tool-call loop
   remain future work; existing `agent.spawn` is client-requested, not
   agent-driven.
-- Daemon startup wiring for pending approval recovery. Store-level atomic write
-  and fail-safe recovery helpers exist, and the daemon now recovers durable
-  session, agent, AgentSession, and worker metadata.
+- Risky tool execution after approval. Approval records now persist and pending
+  approvals are replayed after daemon restart, but approved mutating/shell tools
+  still fail closed until native execution backends are implemented.
 - Worker cancellation/cleanup, Telegram/mobile adapters, daemon-owned
   production voice output, and code work window. The first worker execution
   slice now creates git worktrees for session-bound project workspaces and
@@ -192,6 +196,10 @@ Tasks:
   pending AgentSession cancellation inside daemon provider callbacks, returns
   `ModelStreamControl::Cancel`, and prevents cancelled generations from
   finalizing as failed or completed after the cancel event.
+- Create worker worktrees and profile-scoped worker artifacts for explicit
+  daemon-planned workers. Baseline now creates session-bound project worktrees
+  and writes review artifacts; real command/test execution, cleanup, and patch
+  application remain future work.
 
 Exit criteria:
 
@@ -213,6 +221,11 @@ Tasks:
 - Add first native tools: `file.search`, `file.read`, `shell.run`, `git.status`,
   `git.diff`.
 - Add timeouts, cancellation, and redaction boundaries.
+- Baseline now includes tool contract metadata, safe-read `file.read` and
+  `file.search`, `git.status`, `git.diff`, workspace grants, approval
+  summaries, approval persistence/recovery, and redaction boundaries. Mutating
+  tools, shell execution, and full policy-gated tool execution remain future
+  work.
 
 Exit criteria:
 
@@ -243,6 +256,9 @@ Tasks:
   `edge`, `openai`, and `system`, and speech policy that blocks code, diffs,
   terminal logs, and long raw tool/test output before provider dispatch.
 - Handle daemon voice events in HUD.
+- Baseline now exposes daemon-visible voice status/doctor/preflight, keeps the
+  HUD/Tauri bridge for local capture and playback, separates STT language from
+  TTS voice selection, and applies speech policy before TTS provider dispatch.
 
 Exit criteria:
 
@@ -408,9 +424,9 @@ Tasks:
 Exit criteria:
 
 ```bash
-cargo fmt --check
+cargo fmt --all --check
 cargo clippy --all-targets --all-features -- -D warnings
-cargo test
+cargo test --all-targets --all-features
 ```
 
 ## 5. P2 - Protocol and Events
@@ -782,6 +798,9 @@ Tasks:
 - Add release checks.
 - Add install docs.
 - Add provider setup docs.
+- Add platform support matrix and macOS/Windows baseline CI. Baseline now lives
+  in `docs/28_PLATFORM_BASELINE.md` and
+  `.github/workflows/platform-baseline.yml`.
 - Add security review checklist.
 - Add dependency license audit.
 - Add crash recovery tests.

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -14,6 +14,7 @@
 - [x] Add discussion template.
 - [x] Add PR template.
 - [x] Add CI hygiene workflow.
+- [x] Add macOS/Windows platform baseline workflow.
 - [x] Add Rust workspace placeholder.
 - [x] Add environment example.
 - [x] Add AGENT.md.
@@ -50,6 +51,7 @@
 - [x] Contributor skills guide.
 - [x] Wulan avatar engine plan.
 - [x] Workspace architecture plan.
+- [x] Platform baseline/support matrix.
 - [x] Large open-source project standards index.
 - [x] Contribution standard.
 - [x] Code standard.
@@ -130,8 +132,8 @@
 - [x] Add `cadis status`.
 - [x] Add `cadis chat`.
 - [x] Add `cadis run`.
-- [ ] Add `cadis approve`.
-- [ ] Add `cadis deny`.
+- [x] Add `cadis approve`.
+- [x] Add `cadis deny`.
 - [x] Add `cadis doctor`.
 - [x] Add JSON output mode.
 - [ ] Add CLI integration tests.
@@ -164,7 +166,7 @@
 - [ ] Implement `file.patch`.
 - [ ] Implement `shell.run`.
 - [x] Implement `git.status`.
-- [ ] Implement `git.diff`.
+- [x] Implement `git.diff`.
 - [ ] Add timeouts.
 - [ ] Add cancellation.
 - [x] Add tests for success and failure.
@@ -173,16 +175,16 @@
 
 - [ ] Define policy config.
 - [x] Define default risk rules.
-- [ ] Add approval request type.
-- [ ] Add approval resolution type.
-- [ ] Implement first-response-wins.
-- [ ] Implement approval expiry.
-- [ ] Gate shell execution.
+- [x] Add approval request type.
+- [x] Add approval resolution type.
+- [x] Implement first-response-wins.
+- [x] Implement approval expiry.
+- [x] Gate shell execution.
 - [ ] Gate outside-workspace writes.
 - [ ] Gate secret access.
 - [ ] Gate dangerous delete.
 - [ ] Add race condition tests.
-- [ ] Add denial tests.
+- [x] Add denial tests.
 
 ## 10. Persistence and Logs
 
@@ -193,7 +195,7 @@
 - [x] Write worker metadata for daemon-planned worker delegations.
 - [x] Write AgentSession metadata.
 - [x] Write JSONL event logs.
-- [ ] Write approval state.
+- [x] Write approval state.
 - [x] Add store-level atomic JSON state helpers under `~/.cadis/state`.
 - [x] Implement atomic writes for store-level JSON metadata.
 - [x] Implement redaction.
@@ -204,6 +206,7 @@
 - [x] Add daemon persistence integration tests for session/agent restart recovery.
 - [x] Add daemon persistence integration tests for worker restart recovery.
 - [x] Add daemon persistence integration tests for AgentSession restart snapshot recovery.
+- [x] Add daemon persistence integration tests for pending approval restart recovery.
 - [x] Add corrupt/partial AgentSession state fail-safe tests.
 
 ## 11. Agent Runtime
@@ -267,7 +270,7 @@
 - [x] Add HUD-local voice doctor/preflight.
 - [x] Add WebAudio PCM fallback for WebKit MediaRecorder zero-chunk mic capture.
 - [x] Promote voice doctor/preflight into daemon-visible status.
-- [ ] Handle daemon voice events in HUD.
+- [x] Handle daemon voice events in HUD.
 - [x] Add provider stub.
 - [ ] Implement first provider.
 - [x] Speak short normal answers.
@@ -331,12 +334,21 @@
   failed/cancelled events, and real command/test execution inside worker
   worktrees.
 - [ ] Track D: policy-backed tools and approval persistence.
+- [x] Track D baseline: tool contract metadata, safe-read `file.read` and
+  `file.search`, `git.status`, `git.diff`, workspace grants, approval
+  summaries, approval persistence/recovery, and redaction boundaries.
 - [ ] Track E: daemon-owned voice provider path, STT language setting, and voice doctor.
+- [x] Track E baseline: daemon-visible voice status/doctor/preflight, separated
+  STT language and TTS voice settings, TTS provider stubs, and speech policy
+  blocking for code, diffs, logs, and long tool/test output.
 - [ ] Track F: durable metadata and restart recovery for sessions, agents, AgentSessions, workers, and approvals.
 - [x] Track F store baseline: atomic JSON helpers and fail-safe metadata recovery.
 - [x] Track F daemon baseline: session/agent metadata survives runtime restart and cancelled sessions are removed.
 - [x] Track F daemon worker baseline: worker metadata survives runtime restart and stale running workers recover as failed.
 - [x] Track F AgentSession baseline: per-route AgentSession metadata survives runtime restart, snapshots replay recovered records, and corrupt final JSON reports daemon diagnostics while partial temp files are ignored.
+- [x] Track F approval baseline: pending approval metadata survives runtime
+  restart, snapshots replay active pending approvals, and repeated responses
+  fail closed.
 - [ ] Track G: CADIS-native Wulan avatar engine.
 - [ ] Track H: profile homes, agent homes, workspace registry, grants, and worker worktrees.
 - [x] Track H baseline: default profile layout plus persistent workspace registry/grants.

--- a/docs/08_ROADMAP.md
+++ b/docs/08_ROADMAP.md
@@ -211,6 +211,8 @@ Exit criteria:
 - Windows desktop.
 - macOS desktop.
 - Android remote controller.
+- Promote macOS/Windows beyond the baselines in `docs/28_PLATFORM_BASELINE.md`
+  only after platform adapters and CI coverage exist.
 - Daemon-owned memory runtime based on Wulan's `25_MEMORY_CONCEPT.md`.
 - Offline TTS provider.
 - Additional model providers.

--- a/docs/09_OPEN_SOURCE_STANDARD.md
+++ b/docs/09_OPEN_SOURCE_STANDARD.md
@@ -88,10 +88,12 @@ Planning baseline:
 
 After Rust code starts:
 
-- `cargo fmt --check`
+- `cargo fmt --all --check`
 - `cargo clippy --all-targets --all-features -- -D warnings`
-- `cargo test`
+- `cargo test --all-targets --all-features`
 - docs link check if practical
+- macOS source-validation baseline and Windows portable-crate baseline, as
+  documented in `docs/28_PLATFORM_BASELINE.md`
 - dependency license audit before releases
 
 ## 7. Security Standard
@@ -193,4 +195,3 @@ Do not claim production readiness before:
 - secret redaction is tested
 - install and recovery docs exist
 - known limitations are published
-

--- a/docs/10_RISK_REGISTER.md
+++ b/docs/10_RISK_REGISTER.md
@@ -25,7 +25,7 @@ CADIS has high potential but also high risk because it will execute local tools,
 | R-015 | Dependency bloat slows runtime | Medium | Medium | Dependency review; optional features | Maintainer |
 | R-016 | Desktop framework choice delays core | Medium | Medium | Delay HUD until runtime is stable | UI |
 | R-017 | Users expect production readiness too early | Medium | High | Clear status labels and known limitations | Maintainer |
-| R-018 | Windows/macOS differences are underestimated | Medium | Medium | Linux-first scope; platform adapters later | Platform |
+| R-018 | Windows/macOS differences are underestimated | Medium | Medium | Linux-first scope; platform baseline matrix; adapters later | Platform |
 | R-019 | Model tool-call formats differ too much | Medium | Medium | Capability metadata; fallback protocol | Models |
 | R-020 | Tests lag behind security behavior | High | Medium | Require tests for policy, tools, store | Maintainer |
 

--- a/docs/12_TEST_STRATEGY.md
+++ b/docs/12_TEST_STRATEGY.md
@@ -149,6 +149,9 @@ frontend dependency failure is visible:
 - native avatar checks are covered by workspace Rust checks; `cargo test -p cadis-avatar` is the focused local check for avatar-only changes, and `cargo test -p cadis-avatar --all-features` also covers the feature-gated wgpu render-plan spike
 - HUD checks run from `apps/cadis-hud` with pnpm: `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build`
 - HUD native shell check runs `cargo check --manifest-path apps/cadis-hud/src-tauri/Cargo.toml --locked`
+- platform baseline checks run separately: macOS validates Rust workspace source
+  with format, clippy, and tests; Windows validates only portable crates until
+  runtime adapters exist
 - browser preview and Playwright E2E are local or later-stage checks until stable enough for required CI
 - current orchestrator coverage should include route events, agent status events,
   request-driven spawn limits, and live `session.subscribe` fan-out to multiple

--- a/docs/12_TEST_STRATEGY.md
+++ b/docs/12_TEST_STRATEGY.md
@@ -150,8 +150,9 @@ frontend dependency failure is visible:
 - HUD checks run from `apps/cadis-hud` with pnpm: `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build`
 - HUD native shell check runs `cargo check --manifest-path apps/cadis-hud/src-tauri/Cargo.toml --locked`
 - platform baseline checks run separately: macOS validates Rust workspace source
-  with format, clippy, and tests; Windows validates only portable crates until
-  runtime adapters exist
+  with format, clippy, and selected portable/core tests; Windows validates only
+  portable crate check/clippy and pure portable crate tests until runtime and
+  storage adapters exist
 - browser preview and Playwright E2E are local or later-stage checks until stable enough for required CI
 - current orchestrator coverage should include route events, agent status events,
   request-driven spawn limits, and live `session.subscribe` fan-out to multiple

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -606,13 +606,15 @@ Initial:
 The desktop daemon keeps an in-memory bounded replay buffer for recent runtime
 events. The baseline buffer is process-local and is not a durable event store.
 
-- Unix socket for Linux.
+- Unix socket for the Linux runtime/HUD target.
 - Stdio for tests.
 - Newline-delimited JSON frames.
 
 Later:
 
 - WebSocket for HUD and remote relay.
+- Windows and macOS runtime transport adapters are not supported yet; see
+  `docs/28_PLATFORM_BASELINE.md`.
 
 ## 10. HUD Request Drafts
 

--- a/docs/17_DEVELOPER_SETUP.md
+++ b/docs/17_DEVELOPER_SETUP.md
@@ -20,13 +20,16 @@ CADIS now has a desktop MVP runtime:
   helper, and audio player checks.
 - `cadis-avatar` renderer-neutral Wulan avatar state crate.
 
-Tools, approval-gated execution, live event fan-out, worker execution,
-Telegram, production daemon-owned voice output, and full HUD parity are still
-planned work.
+Native mutating tools, risky tool execution after approval, real worker
+command/test execution, worker cleanup, Telegram, production daemon-owned voice
+provider execution, and full HUD parity are still planned work. The current
+baseline already includes live event fan-out, safe-read tools including
+`git.diff`, worker registry/tail replay, worker worktree setup, and
+daemon-visible voice status/preflight.
 
-The durable state helper baseline exists in `cadis-store`; full daemon startup
-recovery and runtime writes for sessions, agents, workers, and approvals remain
-pending core/runtime integration.
+The durable state helper baseline exists in `cadis-store`; daemon startup
+recovery now covers sessions, agents, AgentSessions, workers, and pending
+approval state.
 
 ## 2. Requirements
 
@@ -34,7 +37,9 @@ pending core/runtime integration.
 - Git.
 - Node.js 20 or newer with Corepack for the Tauri HUD frontend.
 - pnpm 10.x; the HUD package pins the exact version through `packageManager`.
-- Linux desktop for the first target.
+- Linux desktop for the primary runtime/HUD target.
+- macOS for source-validation baseline work only.
+- Windows for portable-crate validation only until runtime adapters exist.
 - Tauri Linux development packages for HUD native checks: WebKitGTK 4.1,
   Ayatana AppIndicator, librsvg, and patchelf.
 - Optional Ollama for real local model responses.
@@ -43,6 +48,8 @@ pending core/runtime integration.
 
 Cloud provider credentials are not required unless `[model].provider = "openai"`.
 ChatGPT-plan auth is handled by the official Codex CLI, not by CADIS.
+
+See `docs/28_PLATFORM_BASELINE.md` for the platform support matrix.
 
 ## 3. Clone
 
@@ -76,6 +83,24 @@ pnpm typecheck
 pnpm test
 pnpm build
 cargo check --manifest-path src-tauri/Cargo.toml --locked
+```
+
+## 4.1 Platform Baseline Checks
+
+The project-standard macOS source baseline runs:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-targets --all-features
+```
+
+The project-standard Windows baseline is limited to portable crates:
+
+```bash
+cargo check -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
+cargo clippy -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features -- -D warnings
+cargo test -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
 ```
 
 ## 5. Daemon Commands
@@ -151,8 +176,9 @@ export CADIS_WHISPER_MODEL="$HOME/.local/share/cadis/whisper-models/ggml-base.bi
 export CADIS_WHISPER_LANGUAGE="id"
 ```
 
-This is a HUD-local preflight today. Daemon-owned voice provider execution and
-daemon-visible voice status are still planned.
+This is still a HUD-local capture/playback preflight. The HUD publishes the
+preflight into daemon-visible voice status, while production daemon-owned TTS
+provider execution remains planned.
 
 ## 9. Optional Ollama Setup
 

--- a/docs/17_DEVELOPER_SETUP.md
+++ b/docs/17_DEVELOPER_SETUP.md
@@ -92,7 +92,7 @@ The project-standard macOS source baseline runs:
 ```bash
 cargo fmt --all --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo test --workspace --all-targets --all-features
+cargo test -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar -p cadis-core --all-targets --all-features
 ```
 
 The project-standard Windows baseline is limited to portable crates:
@@ -100,7 +100,7 @@ The project-standard Windows baseline is limited to portable crates:
 ```bash
 cargo check -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
 cargo clippy -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features -- -D warnings
-cargo test -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
+cargo test -p cadis-protocol -p cadis-policy -p cadis-models -p cadis-avatar --all-targets --all-features
 ```
 
 ## 5. Daemon Commands

--- a/docs/18_INSTALLATION.md
+++ b/docs/18_INSTALLATION.md
@@ -3,7 +3,10 @@
 ## Status
 
 CADIS has no packaged release yet. The desktop MVP can be built and run from
-source on Linux.
+source on Linux. macOS is currently a Rust source-validation baseline only, and
+Windows is limited to portable-crate validation until runtime transport, shell,
+path, sandbox, HUD, and audio adapters exist. See
+`docs/28_PLATFORM_BASELINE.md`.
 
 ## From Source
 
@@ -77,6 +80,8 @@ directly.
 Voice dependencies are optional unless you use HUD speech or mic input. The HUD
 Voice settings include a local doctor that checks mic status, `whisper-cli`, the
 Whisper model path, the Node helper used for Edge TTS, and local audio players.
+The daemon exposes voice status, doctor, and preflight state, but the HUD/Tauri
+bridge still owns local capture and playback mechanics.
 
 The default provider mode is `auto`: CADIS tries Ollama at
 `http://127.0.0.1:11434` and falls back to a local credential-free response if
@@ -163,11 +168,20 @@ target/release/cadis chat "hello"
 ## Known Limitations
 
 - No packaged installer yet.
-- No native file/shell tool runtime yet.
-- Approval commands exist in the CLI protocol surface but approval storage and tool gating are not implemented yet.
+- Linux is the only current source-built runtime/HUD target.
+- macOS has CI source validation but no packaged runtime or HUD support claim.
+- Windows CI checks portable crates only; daemon, CLI transport, HUD, shell,
+  and audio runtime paths are not supported yet.
+- Native file/git safe-read tools exist, including `file.read`, `file.search`,
+  `git.status`, and `git.diff`; mutating file tools and shell execution are not
+  implemented yet.
+- Approval commands, persistence, expiry, and restart recovery exist; approved
+  risky tool execution still fails closed until the native execution backends
+  are implemented.
 - Protocol types exist for orchestrator route, `session.subscribe`, and worker
   events. Live event fan-out exists for daemon-wide and session-filtered
-  streams, but worker execution is not implemented yet.
+  streams. Worker worktree setup and artifact output exist; worker command/test
+  execution and cleanup are not implemented yet.
 - Telegram, production daemon-owned voice output, full HUD parity, and code work window are not implemented yet.
 - The Tauri HUD is source-built for now; packaged desktop artifacts are not published yet.
 
@@ -176,5 +190,6 @@ target/release/cadis chat "hello"
 - Linux tarball.
 - Debian package.
 - AppImage or similar desktop package.
-- Homebrew formula for macOS later.
-- Windows installer later.
+- Homebrew formula for macOS after runtime adapters are validated.
+- Windows installer after transport, shell, path, sandbox, HUD, and audio
+  adapters are implemented and tested.

--- a/docs/21_UI_FEATURE_PARITY_CHECKLIST.md
+++ b/docs/21_UI_FEATURE_PARITY_CHECKLIST.md
@@ -22,7 +22,9 @@ This checklist tracks RamaClaw-to-CADIS UI parity. A checked item means the CADI
 - [ ] Decide HUD toolkit: Tauri + React for fastest parity or Dioxus for Rust-first UI.
 - [ ] Record toolkit decision in `docs/11_DECISIONS.md`.
 - [ ] Define `cadis-hud.v1` protocol subset or reuse CADIS protocol directly.
-- [ ] Decide whether voice preview is daemon-owned or HUD-owned.
+- [x] Decide voice ownership: daemon owns status, doctor, preview protocol,
+  stop protocol, and speech policy; HUD remains the local capture/playback
+  bridge where desktop APIs require it.
 - [ ] Decide how first-run wizard writes config.
 
 ## 4. Shell and Desktop Window

--- a/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
+++ b/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
@@ -558,11 +558,13 @@ Drive voice test UI.
 
 ```json
 {
-  "type": "voice.preview.completed",
-  "provider": "edge",
-  "voice_id": "id-ID-GadisNeural"
+  "type": "voice.preview.completed"
 }
 ```
+
+`voice.preview.started` and `voice.preview.completed` currently carry empty
+payloads. Provider and voice selection remain visible through
+`voice.status.updated`.
 
 ### `voice.status.updated`, `voice.doctor.response`, `voice.preflight.response`
 

--- a/docs/28_PLATFORM_BASELINE.md
+++ b/docs/28_PLATFORM_BASELINE.md
@@ -1,0 +1,91 @@
+# Platform Baseline
+
+## 1. Purpose
+
+This document defines CADIS platform support during the pre-alpha runtime
+slice. It separates primary runtime targets from source validation so docs and
+CI do not overstate current support.
+
+## 2. Support Matrix
+
+| Platform | Current status | CI baseline | Runtime claim |
+| --- | --- | --- | --- |
+| Linux desktop | Primary runtime and HUD target | Full Ubuntu CI, Rust workspace checks, HUD frontend checks, and Tauri native shell check | Supported source-built MVP target |
+| macOS | Source validation and baseline only | Rust workspace format, clippy, and tests on `macos-latest` | No packaged runtime or HUD support claim yet |
+| Windows | Portable crate validation only | Selected portable crates check, clippy, and tests on `windows-latest` | No daemon, CLI transport, HUD, shell, or audio runtime claim yet |
+| Android | Future remote controller target | None | Not a local runtime target |
+
+Linux remains the first platform for `cadisd`, the CLI, local Unix socket
+transport, the Tauri HUD, HUD voice capture/playback bridges, and desktop
+runtime behavior.
+
+macOS validation proves that the Rust workspace remains source-portable enough
+to compile and test under Unix-like desktop conditions. It does not mean the
+daemon, CLI, HUD packaging, voice bridge, sandboxing, or shell behavior is
+supported for users on macOS.
+
+Windows validation is deliberately narrower. Until CADIS has Windows transport,
+shell, path, sandbox, and audio adapters, Windows CI must not build or test the
+daemon, CLI, core runtime, HUD crates, or Tauri app as a supported runtime path.
+
+## 3. Portable Windows Crate Set
+
+The Windows baseline checks only crates that should remain independent of local
+daemon transport and desktop shell assumptions:
+
+- `cadis-protocol`
+- `cadis-policy`
+- `cadis-store`
+- `cadis-models`
+- `cadis-avatar`
+
+The Windows baseline intentionally excludes:
+
+- `cadis-core`, while runtime shell/git/workspace behavior is still
+  Linux-first.
+- `cadis-daemon`, until non-Unix local transport exists.
+- `cadis-cli`, until the client can use a Windows transport adapter.
+- `crates/cadis-hud`, because the legacy native HUD uses Unix socket client
+  code.
+- `apps/cadis-hud`, until the Tauri shell has Windows transport, audio, and
+  packaging adapters.
+
+## 4. Workflow Commands
+
+The platform workflow lives at
+`.github/workflows/platform-baseline.yml`. It does not require secrets, model
+provider credentials, microphone access, camera access, signing keys, or release
+tokens.
+
+macOS source baseline:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-targets --all-features
+```
+
+Windows portable crate baseline:
+
+```bash
+cargo check -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
+cargo clippy -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features -- -D warnings
+cargo test -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
+```
+
+## 5. Promotion Requirements
+
+Before CADIS can claim runtime support beyond Linux, the relevant platform must
+have:
+
+- local daemon transport that does not depend on Unix sockets where unsupported
+- shell execution adapters with explicit policy and approval behavior
+- path normalization and denied-path enforcement tests
+- sandbox and permission behavior documented for that platform
+- audio capture/playback or a documented unsupported voice state
+- CI coverage that builds and tests the claimed runtime crates
+- installation and known-limitation docs for that platform
+
+Live provider tests and real device checks remain opt-in local validation and
+must not become default pull request requirements while they need credentials or
+hardware.

--- a/docs/28_PLATFORM_BASELINE.md
+++ b/docs/28_PLATFORM_BASELINE.md
@@ -11,8 +11,8 @@ CI do not overstate current support.
 | Platform | Current status | CI baseline | Runtime claim |
 | --- | --- | --- | --- |
 | Linux desktop | Primary runtime and HUD target | Full Ubuntu CI, Rust workspace checks, HUD frontend checks, and Tauri native shell check | Supported source-built MVP target |
-| macOS | Source validation and baseline only | Rust workspace format, clippy, and tests on `macos-latest` | No packaged runtime or HUD support claim yet |
-| Windows | Portable crate validation only | Selected portable crates check, clippy, and tests on `windows-latest` | No daemon, CLI transport, HUD, shell, or audio runtime claim yet |
+| macOS | Source validation and baseline only | Rust workspace format and clippy, plus selected portable/core crate tests on `macos-latest` | No packaged runtime or HUD support claim yet |
+| Windows | Portable crate validation only | Selected portable crates check and clippy, plus pure portable crate tests on `windows-latest` | No daemon, CLI transport, HUD, shell, storage permission, or audio runtime claim yet |
 | Android | Future remote controller target | None | Not a local runtime target |
 
 Linux remains the first platform for `cadisd`, the CLI, local Unix socket
@@ -20,13 +20,16 @@ transport, the Tauri HUD, HUD voice capture/playback bridges, and desktop
 runtime behavior.
 
 macOS validation proves that the Rust workspace remains source-portable enough
-to compile and test under Unix-like desktop conditions. It does not mean the
-daemon, CLI, HUD packaging, voice bridge, sandboxing, or shell behavior is
-supported for users on macOS.
+to format, compile, lint, and run selected portable/core tests under Unix-like
+desktop conditions. It intentionally avoids the Linux-first daemon socket
+integration tests until local transport paths are platform-adapted. It does not
+mean the daemon, CLI, HUD packaging, voice bridge, sandboxing, or shell behavior
+is supported for users on macOS.
 
 Windows validation is deliberately narrower. Until CADIS has Windows transport,
-shell, path, sandbox, and audio adapters, Windows CI must not build or test the
-daemon, CLI, core runtime, HUD crates, or Tauri app as a supported runtime path.
+shell, path, sandbox, storage permission, and audio adapters, Windows CI must
+not build or test the daemon, CLI, core runtime, HUD crates, Tauri app, or
+state-store permission behavior as a supported runtime path.
 
 ## 3. Portable Windows Crate Set
 
@@ -62,7 +65,7 @@ macOS source baseline:
 ```bash
 cargo fmt --all --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo test --workspace --all-targets --all-features
+cargo test -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar -p cadis-core --all-targets --all-features
 ```
 
 Windows portable crate baseline:
@@ -70,7 +73,7 @@ Windows portable crate baseline:
 ```bash
 cargo check -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
 cargo clippy -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features -- -D warnings
-cargo test -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
+cargo test -p cadis-protocol -p cadis-policy -p cadis-models -p cadis-avatar --all-targets --all-features
 ```
 
 ## 5. Promotion Requirements

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,4 +35,7 @@ Supporting documents:
 - `23_UI_DESIGN_SYSTEM.md`
 - `24_CONTRIBUTOR_SKILLS.md`
 - `25_MEMORY_CONCEPT.md`
+- `26_WULAN_AVATAR_ENGINE.md`
+- `27_WORKSPACE_ARCHITECTURE.md`
+- `28_PLATFORM_BASELINE.md`
 - `standards/`

--- a/docs/standards/00_STANDARD_INDEX.md
+++ b/docs/standards/00_STANDARD_INDEX.md
@@ -87,6 +87,8 @@ The external baseline is adapted to CADIS constraints:
 - Model providers are replaceable.
 - RamaClaw is the canonical HUD reference.
 - Code-heavy work is visual, not spoken.
+- Linux is the primary runtime/HUD target; macOS and Windows validation status
+  is defined in `docs/28_PLATFORM_BASELINE.md`.
 
 ## How To Use This Folder
 
@@ -97,4 +99,3 @@ When a task touches a standard area:
 3. Make the change.
 4. Update checklist and docs if behavior changes.
 5. Run the relevant validation.
-

--- a/docs/standards/01_CONTRIBUTION_STANDARD.md
+++ b/docs/standards/01_CONTRIBUTION_STANDARD.md
@@ -89,9 +89,12 @@ A contribution is done when:
 
 Required checks for Rust changes:
 
-- `cargo fmt --check`
+- `cargo fmt --all --check`
 - `cargo clippy --all-targets --all-features -- -D warnings`
-- `cargo test`
+- `cargo test --all-targets --all-features`
+
+Platform baseline status and commands are documented in
+`docs/28_PLATFORM_BASELINE.md`.
 
 Required checks for docs-only changes:
 

--- a/docs/standards/03_ARCHITECTURE_STANDARD.md
+++ b/docs/standards/03_ARCHITECTURE_STANDARD.md
@@ -150,6 +150,9 @@ Initial transport is local-only:
 - Unix domain socket for Linux MVP.
 - Stdio for tests and scripted clients.
 - WebSocket later for HUD and remote relay only after protocol behavior is stable.
+- Windows and macOS runtime transport support requires explicit adapters and
+  validation; current platform status is documented in
+  `docs/28_PLATFORM_BASELINE.md`.
 
 Rules:
 

--- a/docs/standards/05_TESTING_STANDARD.md
+++ b/docs/standards/05_TESTING_STANDARD.md
@@ -106,22 +106,27 @@ The following areas require tests before the related feature is considered compl
 The default CI gate for Rust code is:
 
 ```bash
-cargo fmt --check
+cargo fmt --all --check
 cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all-features
+cargo test --all-targets --all-features
 ```
 
 When the HUD exists, UI CI must include:
 
 ```bash
-npm test
-npm run lint
-npm run build
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
 ```
 
 Equivalent commands are acceptable if the final HUD toolkit is not Node-based.
 
 CI must publish clear logs for failing tests and must not upload secrets, local config, or raw event logs containing unredacted data.
+
+Platform CI must follow `docs/28_PLATFORM_BASELINE.md`: macOS is a Rust
+source-validation baseline, and Windows checks only portable crates until
+runtime transport, shell, path, sandbox, HUD, and audio adapters exist.
 
 ## 7. Performance Tests
 

--- a/docs/standards/06_DOCUMENTATION_STANDARD.md
+++ b/docs/standards/06_DOCUMENTATION_STANDARD.md
@@ -33,6 +33,7 @@ The repository should maintain:
 - `docs/15_PROTOCOL_DRAFT.md` for daemon protocol concepts
 - `docs/16_CONFIG_REFERENCE.md` for user-facing configuration
 - `docs/17_DEVELOPER_SETUP.md` and `docs/18_INSTALLATION.md` for local setup
+- `docs/28_PLATFORM_BASELINE.md` for supported platform and validation claims
 - `docs/standards/` for operational standards
 - `skills/` docs for repeatable CADIS-specific workflows
 
@@ -48,6 +49,7 @@ Update documentation in the same change when code or policy changes affect:
 - configuration keys or defaults
 - persisted state, logs, or recovery behavior
 - install, build, or release steps
+- supported platform, runtime, or CI baseline claims
 - public contribution, governance, or support processes
 - security assumptions, boundaries, or mitigations
 
@@ -118,3 +120,4 @@ Recommended future automated checks:
 - `docs/11_DECISIONS.md`
 - `docs/13_GLOSSARY.md`
 - `docs/24_CONTRIBUTOR_SKILLS.md`
+- `docs/28_PLATFORM_BASELINE.md`

--- a/docs/standards/07_RELEASE_STANDARD.md
+++ b/docs/standards/07_RELEASE_STANDARD.md
@@ -53,6 +53,7 @@ Before a public release, confirm these files are present and current:
 - `CHANGELOG.md`
 - `docs/17_DEVELOPER_SETUP.md`
 - `docs/18_INSTALLATION.md`
+- `docs/28_PLATFORM_BASELINE.md`
 - `docs/11_DECISIONS.md`
 - `docs/12_TEST_STRATEGY.md`
 - release workflow under `.github/workflows/`
@@ -70,12 +71,13 @@ Before binary releases, also confirm:
 
 Minimum checks before any release:
 
-- `cargo fmt --check`
+- `cargo fmt --all --check`
 - `cargo clippy --all-targets --all-features -- -D warnings`
-- `cargo test`
+- `cargo test --all-targets --all-features`
 - `cd apps/cadis-hud && pnpm lint && pnpm typecheck && pnpm test && pnpm build`
 - `cargo check --manifest-path apps/cadis-hud/src-tauri/Cargo.toml --locked`
 - docs link/path spot check
+- platform support matrix review
 - license audit
 - changelog review
 - release notes review for accurate maturity claims
@@ -105,12 +107,13 @@ Additional checks before releases that include clients:
 3. Run required checks locally and in CI.
 4. Update `CHANGELOG.md`.
 5. Update installation, configuration, and known limitation docs.
-6. Confirm `NOTICE` and dependency license status.
-7. Confirm generated artifacts are reproducible and local credential files are excluded.
-8. Create the release tag.
-9. Publish artifacts through the release workflow.
-10. Publish release notes with limitations and upgrade guidance.
-11. Monitor issue reports after release.
+6. Confirm `docs/28_PLATFORM_BASELINE.md` matches the release artifacts and CI.
+7. Confirm `NOTICE` and dependency license status.
+8. Confirm generated artifacts are reproducible and local credential files are excluded.
+9. Create the release tag.
+10. Publish artifacts through the release workflow.
+11. Publish release notes with limitations and upgrade guidance.
+12. Monitor issue reports after release.
 
 ## Release Notes Requirements
 
@@ -168,6 +171,7 @@ Before beta, CADIS should have:
 - `CHANGELOG.md`
 - `docs/08_ROADMAP.md`
 - `docs/09_OPEN_SOURCE_STANDARD.md`
+- `docs/28_PLATFORM_BASELINE.md`
 - `docs/11_DECISIONS.md`
 - `docs/12_TEST_STRATEGY.md`
 - `docs/17_DEVELOPER_SETUP.md`

--- a/docs/standards/11_TOOL_RUNTIME_STANDARD.md
+++ b/docs/standards/11_TOOL_RUNTIME_STANDARD.md
@@ -33,10 +33,10 @@ Initial tools:
 
 Current implementation baseline:
 
-- `file.read`, `file.search`, and `git.status` are native safe-read tools.
-- `shell.run`, `file.write`, `file.patch`, `git.diff`,
-  `git.worktree.create`, and `git.worktree.remove` are classified and
-  approval-gated placeholders.
+- `file.read`, `file.search`, `git.status`, and `git.diff` are native
+  safe-read tools.
+- `shell.run`, `file.write`, `file.patch`, `git.worktree.create`, and
+  `git.worktree.remove` are classified and approval-gated placeholders.
 - Unknown tool names are denied before execution.
 - Approval-gated placeholders fail closed after approval resolution until their
   execution backends are implemented.
@@ -171,9 +171,10 @@ Git tools must prefer explicit commands or library calls with clear output.
 Rules:
 
 - `git.status` and `git.diff` are safe-read by default.
-- The current native baseline implements only `git.status` and runs
-  `git status --short --branch` under the daemon after workspace path
-  normalization.
+- The current native baseline runs `git.status` and `git.diff` under the daemon
+  after workspace path normalization. `git.diff` uses `git diff --no-ext-diff
+  --no-color --` with a workspace-relative pathspec guard and bounded,
+  redacted output.
 - Worktree creation must validate repository state.
 - Worktree cleanup must avoid deleting paths not created by CADIS.
 - `git.worktree.create` must consume daemon worktree intent, not ad hoc client

--- a/docs/standards/15_UI_HUD_STANDARD.md
+++ b/docs/standards/15_UI_HUD_STANDARD.md
@@ -58,7 +58,11 @@ Desktop behavior:
 - close
 - background opacity preference
 
-Linux is the initial target. Toolkit selection may be Tauri + React for fastest parity or a Rust-first toolkit if it preserves the interaction contract.
+Linux is the initial HUD target. macOS has source-validation coverage only, and
+Windows HUD runtime support is blocked on transport, shell, path, sandbox, and
+audio adapters. See `docs/28_PLATFORM_BASELINE.md`. Toolkit selection may be
+Tauri + React for fastest parity or a Rust-first toolkit if it preserves the
+interaction contract.
 
 ## 5. Orbital HUD
 

--- a/docs/standards/20_CI_CD_STANDARD.md
+++ b/docs/standards/20_CI_CD_STANDARD.md
@@ -58,16 +58,16 @@ Platform baseline checks:
 
 - macOS may run Rust workspace source validation with `cargo fmt --all --check`,
   `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and
-  `cargo test --workspace --all-targets --all-features`.
+  selected portable/core crate tests.
 - Windows must check only portable crates until daemon/CLI transport, shell,
-  path, sandbox, HUD, and audio adapters exist.
+  path, sandbox, state-store permission, HUD, and audio adapters exist.
 
 Current Windows portable crate commands:
 
 ```text
 cargo check -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
 cargo clippy -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features -- -D warnings
-cargo test -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
+cargo test -p cadis-protocol -p cadis-policy -p cadis-models -p cadis-avatar --all-targets --all-features
 ```
 
 Security and dependency checks once tooling is configured:

--- a/docs/standards/20_CI_CD_STANDARD.md
+++ b/docs/standards/20_CI_CD_STANDARD.md
@@ -54,6 +54,22 @@ provider credentials, microphone access, camera access, or audio devices.
 Voice doctor behavior should be covered by deterministic unit tests where
 possible; live mic and player checks remain local smoke tests.
 
+Platform baseline checks:
+
+- macOS may run Rust workspace source validation with `cargo fmt --all --check`,
+  `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and
+  `cargo test --workspace --all-targets --all-features`.
+- Windows must check only portable crates until daemon/CLI transport, shell,
+  path, sandbox, HUD, and audio adapters exist.
+
+Current Windows portable crate commands:
+
+```text
+cargo check -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
+cargo clippy -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features -- -D warnings
+cargo test -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p cadis-avatar --all-targets --all-features
+```
+
 Security and dependency checks once tooling is configured:
 
 ```text
@@ -98,6 +114,7 @@ v0.x.y-rc.N
 Recommended workflows:
 
 - `.github/workflows/ci.yml`
+- `.github/workflows/platform-baseline.yml`
 - `.github/workflows/security.yml`
 - `.github/workflows/docs.yml`
 - `.github/workflows/release.yml`
@@ -125,6 +142,9 @@ CI should protect daemon-first boundaries with targeted checks as the codebase g
   execution is explicitly implemented
 - native avatar crates must remain renderer/state boundaries and must not call
   tools, approvals, models, memory, or policy APIs
+- platform checks must not imply unsupported runtime coverage; Windows remains
+  portable-crate-only until transport, shell, path, sandbox, HUD, and audio
+  adapters are implemented
 
 Some of these checks may start as review checklist items and become automated as package boundaries stabilize.
 
@@ -161,6 +181,7 @@ pnpm build
 cargo check --manifest-path src-tauri/Cargo.toml --locked
 ```
 
+Platform baseline CI is documented in `docs/28_PLATFORM_BASELINE.md`.
 Additional documented commands should be added as CI expands, including docs checks, dependency checks, and package smoke tests.
 
 ## Failure Handling
@@ -179,4 +200,5 @@ When CI fails:
 - `docs/09_OPEN_SOURCE_STANDARD.md`
 - `docs/12_TEST_STRATEGY.md`
 - `docs/14_SECURITY_THREAT_MODEL.md`
+- `docs/28_PLATFORM_BASELINE.md`
 - `docs/standards/07_RELEASE_STANDARD.md`


### PR DESCRIPTION
## Summary
- add native safe-read git.diff execution with bounded redacted output and CLI input support
- recover pending approvals on daemon restart and replay active approval requests in snapshots
- handle daemon voice lifecycle events in the HUD and add voice status/preview/stop coverage
- add macOS/Windows platform baseline docs and CI without claiming unsupported Windows runtime support

## Validation
- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- cargo check --manifest-path apps/cadis-hud/src-tauri/Cargo.toml --locked