### PR TITLE
Document repository rulesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format follows Keep a Changelog style, and the project will use Semantic Ver
   daemon/HUD voice lifecycle event handling.
 - Platform baseline documentation and GitHub Actions coverage for macOS Rust
   source validation and Windows portable-crate validation.
+- GitHub repository rulesets for protected `main` pull-request flow, required
+  checks, and protected `v*` release tags.
 
 ### Changed
 

--- a/docs/09_OPEN_SOURCE_STANDARD.md
+++ b/docs/09_OPEN_SOURCE_STANDARD.md
@@ -85,6 +85,7 @@ Recommended release stages:
 Planning baseline:
 
 - repository hygiene checks
+- GitHub repository rulesets for protected `main` and `v*` release tags
 
 After Rust code starts:
 
@@ -95,6 +96,10 @@ After Rust code starts:
 - macOS source-validation baseline and Windows portable-crate baseline, as
   documented in `docs/28_PLATFORM_BASELINE.md`
 - dependency license audit before releases
+
+`main` must stay protected by a GitHub ruleset that requires pull requests and
+the documented CI checks. Release tags matching `v*` must stay protected against
+deletion and non-fast-forward updates.
 
 ## 7. Security Standard
 

--- a/docs/standards/20_CI_CD_STANDARD.md
+++ b/docs/standards/20_CI_CD_STANDARD.md
@@ -18,6 +18,26 @@ CI should catch correctness, formatting, security, documentation, dependency, an
 
 ## Required Pull Request Checks
 
+GitHub repository rulesets enforce the current required checks on protected
+refs. Rulesets should be changed through a reviewed branch and then updated in
+GitHub repository settings or the GitHub Rulesets API.
+
+Active repository rulesets:
+
+- `CADIS main branch protection` targets `refs/heads/main`, blocks deletion
+  and non-fast-forward updates, requires pull requests, requires resolved
+  review threads, and requires the CI status checks listed below.
+- `CADIS release tag protection` targets `refs/tags/v*` and blocks deletion
+  and non-fast-forward updates for release tags.
+
+Required `main` status checks:
+
+- `Repository hygiene`
+- `Rust workspace`
+- `HUD frontend`
+- `macOS Rust source baseline`
+- `Windows portable crate baseline`
+
 Baseline checks:
 
 - repository hygiene check


### PR DESCRIPTION
## Summary
- document active GitHub repository rulesets in the CI/CD standard
- note protected main and v* release tag behavior in the open-source standard
- add changelog entry for the repository governance change

## Validation
- git diff --check