### PR TITLE
Tighten secret scan hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ private/
 .tokens/
 .codex/
 **/.codex/
+.claude/
+**/.claude/
 .openai/
 *.pem
 *.key

--- a/docs/17_DEVELOPER_SETUP.md
+++ b/docs/17_DEVELOPER_SETUP.md
@@ -103,6 +103,21 @@ cargo clippy -p cadis-protocol -p cadis-policy -p cadis-store -p cadis-models -p
 cargo test -p cadis-protocol -p cadis-policy -p cadis-models -p cadis-avatar --all-targets --all-features
 ```
 
+## 4.2 Secret Scan
+
+Before pushing public branches, run a redacted secret scan against both Git
+history and the current working tree:
+
+```bash
+gitleaks detect --source . --redact=100
+gitleaks detect --no-git --source . --redact=100
+```
+
+The first command scans committed history. The second command scans local files
+that are present in the checkout, including ignored build output, so findings in
+`target/`, `node_modules/`, or other ignored artifact directories must be
+triaged separately from tracked repository leaks.
+
 ## 5. Daemon Commands
 
 ```bash

--- a/docs/standards/20_CI_CD_STANDARD.md
+++ b/docs/standards/20_CI_CD_STANDARD.md
@@ -43,6 +43,7 @@ Baseline checks:
 - repository hygiene check
 - Markdown and documentation path check where tooling exists
 - no committed secrets
+- redacted `gitleaks detect --source .` scan before public release branches
 - no generated artifacts unless expected
 - no forbidden runtime defaults such as OpenClaw paths
 


### PR DESCRIPTION
## Summary
- ignore local Claude project settings directories
- document redacted gitleaks scans for git history and working tree
- add secret scanning to the CI/CD standard baseline

## Validation
- git diff --check
- gitleaks detect --source . --redact=100
- gitleaks detect --no-git --source . --redact=100