### PR TITLE
Add structured policy classification primitives

### DIFF
--- a/crates/cadis-policy/src/lib.rs
+++ b/crates/cadis-policy/src/lib.rs
@@ -36,6 +36,28 @@ impl PolicyEngine {
         }
     }
 
+    /// Decides the default behavior for a structured risk classification.
+    pub fn decide_classification(
+        &self,
+        classification: PolicyClassification,
+    ) -> ClassifiedPolicyDecision {
+        let decision = match classification.risk_class {
+            Some(risk_class) => self.decide(risk_class),
+            None => PolicyDecision::Deny,
+        };
+
+        ClassifiedPolicyDecision {
+            risk_class: classification.risk_class,
+            decision,
+            reason: classification.reason,
+        }
+    }
+
+    /// Classifies and decides a structured policy action.
+    pub fn decide_action(&self, action: PolicyAction) -> ClassifiedPolicyDecision {
+        self.decide_classification(classify_action(action))
+    }
+
     /// Classifies and decides a tool call by stable tool name.
     pub fn decide_tool(&self, tool_name: &str) -> ToolPolicyDecision {
         let Some(risk_class) = classify_tool(tool_name) else {
@@ -54,6 +76,42 @@ impl PolicyEngine {
     }
 }
 
+/// Policy classification for an action before execution.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct PolicyClassification {
+    /// Classified risk class, absent when classification failed closed.
+    pub risk_class: Option<RiskClass>,
+    /// Redacted reason suitable for events and logs.
+    pub reason: String,
+}
+
+impl PolicyClassification {
+    fn classified(risk_class: RiskClass, reason: impl Into<String>) -> Self {
+        Self {
+            risk_class: Some(risk_class),
+            reason: reason.into(),
+        }
+    }
+
+    fn unclassified(reason: impl Into<String>) -> Self {
+        Self {
+            risk_class: None,
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Policy decision with structured risk metadata.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct ClassifiedPolicyDecision {
+    /// Classified risk class, absent when the action could not be classified.
+    pub risk_class: Option<RiskClass>,
+    /// Final policy decision.
+    pub decision: PolicyDecision,
+    /// Redacted reason suitable for events and logs.
+    pub reason: String,
+}
+
 /// Policy decision with tool-specific risk metadata.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ToolPolicyDecision {
@@ -63,6 +121,168 @@ pub struct ToolPolicyDecision {
     pub decision: PolicyDecision,
     /// Redacted reason suitable for events and logs.
     pub reason: String,
+}
+
+/// Path scope resolved before workspace mutation classification.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkspacePathScope {
+    /// Target was resolved inside an approved workspace.
+    InsideWorkspace,
+    /// Target was resolved outside the approved workspace boundary.
+    OutsideWorkspace,
+    /// Target scope is unavailable or could not be resolved.
+    Unknown,
+}
+
+/// Source category for secret access classification.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecretAccessSource {
+    /// Environment variable or process environment secret.
+    Environment,
+    /// Config file or profile setting that may contain a secret.
+    Config,
+    /// File path known or suspected to contain credentials.
+    File,
+    /// OS keychain, credential helper, or future secret store.
+    CredentialStore,
+    /// Secret source is known to exist but its category is not available.
+    Unknown,
+}
+
+/// Risk hints supplied by shell command validation.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+pub struct ShellExecutionRisk {
+    /// Command uses sudo or equivalent privilege escalation.
+    pub uses_sudo: bool,
+    /// Command may read environment, config, or credential secrets.
+    pub reads_secrets: bool,
+    /// Command performs recursive or otherwise destructive deletion.
+    pub dangerous_delete: bool,
+    /// Command mutates system packages, services, devices, or global state.
+    pub mutates_system: bool,
+}
+
+/// Structured action shape for policy classification.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyAction {
+    /// File or workspace mutation after path scope validation.
+    WorkspaceMutation {
+        /// Resolved target scope.
+        target_scope: WorkspacePathScope,
+    },
+    /// Shell command execution after command validation.
+    ShellExecution {
+        /// Shell risk hints.
+        risk: ShellExecutionRisk,
+    },
+    /// Secret read or credential lookup.
+    SecretAccess {
+        /// Secret source category.
+        source: SecretAccessSource,
+    },
+    /// Recursive or destructive deletion.
+    DangerousDelete {
+        /// Resolved target scope.
+        target_scope: WorkspacePathScope,
+    },
+}
+
+/// Classifies a structured policy action.
+pub fn classify_action(action: PolicyAction) -> PolicyClassification {
+    match action {
+        PolicyAction::WorkspaceMutation { target_scope } => {
+            classify_workspace_mutation(target_scope)
+        }
+        PolicyAction::ShellExecution { risk } => classify_shell_execution(risk),
+        PolicyAction::SecretAccess { source } => classify_secret_access(source),
+        PolicyAction::DangerousDelete { target_scope } => classify_dangerous_delete(target_scope),
+    }
+}
+
+/// Classifies a workspace mutation after path scope validation.
+pub fn classify_workspace_mutation(target_scope: WorkspacePathScope) -> PolicyClassification {
+    match target_scope {
+        WorkspacePathScope::InsideWorkspace => PolicyClassification::classified(
+            RiskClass::WorkspaceEdit,
+            "workspace mutation inside approved workspace requires approval",
+        ),
+        WorkspacePathScope::OutsideWorkspace => PolicyClassification::classified(
+            RiskClass::OutsideWorkspace,
+            "workspace mutation targets a path outside the approved workspace",
+        ),
+        WorkspacePathScope::Unknown => PolicyClassification::unclassified(
+            "workspace mutation target scope is unknown and is denied by default",
+        ),
+    }
+}
+
+/// Classifies shell execution from structured command risk hints.
+pub fn classify_shell_execution(risk: ShellExecutionRisk) -> PolicyClassification {
+    if risk.uses_sudo {
+        return PolicyClassification::classified(
+            RiskClass::SudoSystem,
+            "shell execution uses privilege escalation",
+        );
+    }
+
+    if risk.dangerous_delete {
+        return PolicyClassification::classified(
+            RiskClass::DangerousDelete,
+            "shell execution performs dangerous deletion",
+        );
+    }
+
+    if risk.reads_secrets {
+        return PolicyClassification::classified(
+            RiskClass::SecretAccess,
+            "shell execution may access secrets",
+        );
+    }
+
+    if risk.mutates_system {
+        return PolicyClassification::classified(
+            RiskClass::SystemChange,
+            "shell execution mutates system state",
+        );
+    }
+
+    PolicyClassification::classified(
+        RiskClass::SystemChange,
+        "shell execution requires policy approval",
+    )
+}
+
+/// Classifies explicit secret access.
+pub fn classify_secret_access(source: SecretAccessSource) -> PolicyClassification {
+    let reason = match source {
+        SecretAccessSource::Environment => "environment secret access requires approval",
+        SecretAccessSource::Config => "config secret access requires approval",
+        SecretAccessSource::File => "secret file access requires approval",
+        SecretAccessSource::CredentialStore => "credential store access requires approval",
+        SecretAccessSource::Unknown => "secret access requires approval",
+    };
+
+    PolicyClassification::classified(RiskClass::SecretAccess, reason)
+}
+
+/// Classifies recursive or otherwise destructive deletion.
+pub fn classify_dangerous_delete(target_scope: WorkspacePathScope) -> PolicyClassification {
+    let reason = match target_scope {
+        WorkspacePathScope::InsideWorkspace => {
+            "dangerous delete inside approved workspace requires approval"
+        }
+        WorkspacePathScope::OutsideWorkspace => {
+            "dangerous delete outside approved workspace requires approval"
+        }
+        WorkspacePathScope::Unknown => {
+            "dangerous delete target scope is unknown and requires approval"
+        }
+    };
+
+    PolicyClassification::classified(RiskClass::DangerousDelete, reason)
 }
 
 fn classify_tool(tool_name: &str) -> Option<RiskClass> {
@@ -124,6 +344,45 @@ mod tests {
     #[test]
     fn unknown_tool_is_denied() {
         let decision = PolicyEngine.decide_tool("browser.open");
+
+        assert_eq!(decision.risk_class, None);
+        assert_eq!(decision.decision, PolicyDecision::Deny);
+    }
+
+    #[test]
+    fn secret_access_classification_requires_approval() {
+        let decision =
+            PolicyEngine.decide_classification(classify_secret_access(SecretAccessSource::Config));
+
+        assert_eq!(decision.risk_class, Some(RiskClass::SecretAccess));
+        assert_eq!(decision.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn dangerous_delete_classification_requires_approval() {
+        let decision = PolicyEngine.decide_classification(classify_dangerous_delete(
+            WorkspacePathScope::InsideWorkspace,
+        ));
+
+        assert_eq!(decision.risk_class, Some(RiskClass::DangerousDelete));
+        assert_eq!(decision.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn outside_workspace_write_classification_requires_approval() {
+        let decision = PolicyEngine.decide_classification(classify_workspace_mutation(
+            WorkspacePathScope::OutsideWorkspace,
+        ));
+
+        assert_eq!(decision.risk_class, Some(RiskClass::OutsideWorkspace));
+        assert_eq!(decision.decision, PolicyDecision::RequireApproval);
+    }
+
+    #[test]
+    fn unclassified_workspace_mutation_is_denied() {
+        let decision = PolicyEngine.decide_action(PolicyAction::WorkspaceMutation {
+            target_scope: WorkspacePathScope::Unknown,
+        });
 
         assert_eq!(decision.risk_class, None);
         assert_eq!(decision.decision, PolicyDecision::Deny);

--- a/docs/standards/04_SECURITY_STANDARD.md
+++ b/docs/standards/04_SECURITY_STANDARD.md
@@ -96,6 +96,11 @@ Every tool declares risk class, expected side effects, workspace behavior, netwo
 - Tool failures include actionable metadata after redaction.
 - Tool tests cover allow, deny, timeout, cancellation, and malformed arguments.
 
+`cadis-policy` provides structured classification primitives for workspace
+mutation, shell execution risk hints, secret access, and dangerous delete. These
+helpers classify risk only; they do not execute tools. Unclassified mutations
+must fail closed with a deny decision.
+
 ## 9. Local Protocol Security
 
 - Local-only transport is the default.

--- a/docs/standards/12_APPROVAL_POLICY_STANDARD.md
+++ b/docs/standards/12_APPROVAL_POLICY_STANDARD.md
@@ -114,6 +114,10 @@ Current implementation baseline:
 - `shell.run`, write tools, and mutating git/worktree placeholders require
   approval and are persisted under daemon-owned state.
 - Unknown tools are denied.
+- The policy crate exposes structured classification helpers for workspace
+  mutation, shell execution risk hints, secret access, and dangerous delete.
+  These helpers do not implement execution; unclassified workspace mutations
+  remain denied by default.
 - Approved risky placeholders still fail closed with `tool.failed` until the
   corresponding execution backend is implemented.
 - `approval.respond` uses daemon state and persisted approval records; the first


### PR DESCRIPTION
## Summary
- add structured policy action classifiers for workspace mutation, shell execution, secret access, and dangerous delete
- keep existing policy APIs compatible and default-deny unknown actions
- update policy/security standards for Track D primitives

## Validation
- cargo test -p cadis-policy
- cargo fmt --all --check
- cargo clippy -p cadis-policy --all-targets --all-features -- -D warnings