### PR TITLE
Implement approved file.patch execution slice

### DIFF
--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -48,6 +48,9 @@ use serde::{Deserialize, Serialize};
 const FILE_READ_LIMIT_BYTES: usize = 64 * 1024;
 const FILE_SEARCH_LIMIT_BYTES: u64 = 1024 * 1024;
 const FILE_SEARCH_DEFAULT_LIMIT: usize = 50;
+const FILE_PATCH_MAX_OPERATIONS: usize = 64;
+const FILE_PATCH_MAX_FILE_BYTES: usize = 1024 * 1024;
+const FILE_PATCH_OUTPUT_MAX_FILES: usize = 64;
 const GIT_DIFF_LIMIT_BYTES: usize = 128 * 1024;
 const APPROVAL_TIMEOUT_MINUTES: i64 = 5;
 const WORKER_TAIL_DEFAULT_LINES: usize = 64;
@@ -688,6 +691,21 @@ impl Runtime {
             }
         };
 
+        if request.tool_name == "file.patch" {
+            if let Err(error) = validate_file_patch_input(&workspace.root, &request.input) {
+                events.push(self.session_event(
+                    session_id,
+                    CadisEvent::ToolFailed(ToolFailedPayload {
+                        tool_call_id,
+                        tool_name: request.tool_name,
+                        error,
+                        risk_class: Some(risk_class),
+                    }),
+                ));
+                return self.accept(request_id, events);
+            }
+        }
+
         match policy_decision {
             PolicyDecision::Allow => {
                 events.push(self.session_event(
@@ -729,7 +747,7 @@ impl Runtime {
                 let requested_at = now_timestamp();
                 let expires_at = timestamp_after_minutes(APPROVAL_TIMEOUT_MINUTES);
                 let command = tool_command_summary(&request.tool_name, &request.input);
-                let workspace = Some(workspace.root.display().to_string());
+                let workspace_summary = Some(workspace.root.display().to_string());
                 let record = ApprovalRecord {
                     approval_id: approval_id.clone(),
                     session_id: session_id.clone(),
@@ -739,13 +757,22 @@ impl Runtime {
                     title: format!("Approve {}", request.tool_name),
                     summary: approval_summary,
                     command: command.clone(),
-                    workspace: workspace.clone(),
+                    workspace: workspace_summary.clone(),
                     requested_at,
                     expires_at: expires_at.clone(),
                     state: ApprovalState::Pending,
                     decision: None,
                     reason: None,
                     resolved_at: None,
+                };
+                let tool_execution = if request.tool_name == "file.patch" {
+                    Some(PendingToolExecution {
+                        request: request.clone(),
+                        workspace_id: workspace.id.clone(),
+                        workspace_root: workspace.root.clone(),
+                    })
+                } else {
+                    None
                 };
 
                 if let Err(error) = self.approval_store.save(&record) {
@@ -760,6 +787,7 @@ impl Runtime {
                     approval_id.clone(),
                     PendingApproval {
                         record: record.clone(),
+                        tool_execution,
                     },
                 );
 
@@ -783,8 +811,9 @@ impl Runtime {
         request_id: RequestId,
         request: ApprovalResponseRequest,
     ) -> RequestOutcome {
-        let mut record = match self.pending_approvals.remove(&request.approval_id) {
-            Some(pending) => pending.record,
+        let pending_approval = self.pending_approvals.remove(&request.approval_id);
+        let mut record = match &pending_approval {
+            Some(pending) => pending.record.clone(),
             None => match self.approval_store.load(&request.approval_id) {
                 Ok(Some(record)) => record,
                 Ok(None) => {
@@ -843,31 +872,95 @@ impl Runtime {
                 decision: effective_decision,
             }),
         )];
-        let error = match effective_decision {
-            ApprovalDecision::Approved => ErrorPayload {
-                code: "tool_execution_blocked".to_owned(),
-                message: "approval was recorded, but risky tool execution is not implemented in this baseline".to_owned(),
-                retryable: false,
-            },
-            ApprovalDecision::Denied => ErrorPayload {
-                code: if record.state == ApprovalState::Expired {
-                    "approval_expired".to_owned()
-                } else {
-                    "approval_denied".to_owned()
-                },
-                message: "approval did not authorize tool execution".to_owned(),
-                retryable: false,
-            },
-        };
-        events.push(self.session_event(
-            session_id,
-            CadisEvent::ToolFailed(ToolFailedPayload {
-                tool_call_id: record.tool_call_id,
-                tool_name: record.tool_name,
-                error,
-                risk_class: Some(record.risk_class),
-            }),
-        ));
+
+        match effective_decision {
+            ApprovalDecision::Approved if record.tool_name == "file.patch" => {
+                let context = self.approved_file_patch_context(
+                    &record,
+                    pending_approval
+                        .as_ref()
+                        .and_then(|pending| pending.tool_execution.as_ref()),
+                );
+                match context {
+                    Ok((workspace, input)) => {
+                        events.push(self.session_event(
+                            session_id.clone(),
+                            CadisEvent::ToolStarted(ToolEventPayload {
+                                tool_call_id: record.tool_call_id.clone(),
+                                tool_name: record.tool_name.clone(),
+                                summary: Some("tool execution started".to_owned()),
+                                risk_class: Some(record.risk_class),
+                                output: None,
+                            }),
+                        ));
+                        match self.execute_file_patch(&workspace, &input) {
+                            Ok(result) => events.push(self.session_event(
+                                session_id,
+                                CadisEvent::ToolCompleted(ToolEventPayload {
+                                    tool_call_id: record.tool_call_id,
+                                    tool_name: record.tool_name,
+                                    summary: Some(result.summary),
+                                    risk_class: Some(record.risk_class),
+                                    output: Some(result.output),
+                                }),
+                            )),
+                            Err(error) => events.push(self.session_event(
+                                session_id,
+                                CadisEvent::ToolFailed(ToolFailedPayload {
+                                    tool_call_id: record.tool_call_id,
+                                    tool_name: record.tool_name,
+                                    error,
+                                    risk_class: Some(record.risk_class),
+                                }),
+                            )),
+                        }
+                    }
+                    Err(error) => events.push(self.session_event(
+                        session_id,
+                        CadisEvent::ToolFailed(ToolFailedPayload {
+                            tool_call_id: record.tool_call_id,
+                            tool_name: record.tool_name,
+                            error,
+                            risk_class: Some(record.risk_class),
+                        }),
+                    )),
+                }
+            }
+            ApprovalDecision::Approved => {
+                events.push(self.session_event(
+                    session_id,
+                    CadisEvent::ToolFailed(ToolFailedPayload {
+                        tool_call_id: record.tool_call_id,
+                        tool_name: record.tool_name,
+                        error: ErrorPayload {
+                            code: "tool_execution_blocked".to_owned(),
+                            message: "approval was recorded, but risky tool execution is not implemented in this baseline".to_owned(),
+                            retryable: false,
+                        },
+                        risk_class: Some(record.risk_class),
+                    }),
+                ));
+            }
+            ApprovalDecision::Denied => {
+                events.push(self.session_event(
+                    session_id,
+                    CadisEvent::ToolFailed(ToolFailedPayload {
+                        tool_call_id: record.tool_call_id,
+                        tool_name: record.tool_name,
+                        error: ErrorPayload {
+                            code: if record.state == ApprovalState::Expired {
+                                "approval_expired".to_owned()
+                            } else {
+                                "approval_denied".to_owned()
+                            },
+                            message: "approval did not authorize tool execution".to_owned(),
+                            retryable: false,
+                        },
+                        risk_class: Some(record.risk_class),
+                    }),
+                ));
+            }
+        }
 
         self.accept(request_id, events)
     }
@@ -2826,6 +2919,88 @@ impl Runtime {
         })
     }
 
+    fn approved_file_patch_context(
+        &self,
+        record: &ApprovalRecord,
+        pending_execution: Option<&PendingToolExecution>,
+    ) -> Result<(PathBuf, serde_json::Value), ErrorPayload> {
+        let Some(pending) = pending_execution else {
+            return Err(tool_error(
+                "approved_tool_context_unavailable",
+                "approved file.patch request context is unavailable after restart",
+                false,
+            ));
+        };
+        if pending.request.tool_name != "file.patch" {
+            return Err(tool_error(
+                "approved_tool_context_mismatch",
+                "approval context does not match file.patch",
+                false,
+            ));
+        }
+
+        let workspace = self.resolved_granted_workspace(
+            &record.session_id,
+            pending.request.agent_id.as_ref(),
+            &pending.request.input,
+            WorkspaceAccess::Write,
+        )?;
+        if workspace.id != pending.workspace_id || workspace.root != pending.workspace_root {
+            return Err(tool_error(
+                "workspace_changed",
+                "approved file.patch workspace changed before execution",
+                false,
+            ));
+        }
+
+        validate_file_patch_input(&pending.workspace_root, &pending.request.input)?;
+        Ok((
+            pending.workspace_root.clone(),
+            pending.request.input.clone(),
+        ))
+    }
+
+    fn execute_file_patch(
+        &self,
+        workspace: &Path,
+        input: &serde_json::Value,
+    ) -> Result<ToolExecutionResult, ErrorPayload> {
+        let operations = parse_file_patch_operations(input)?;
+        let prepared = prepare_file_patch(workspace, &operations)?;
+
+        for change in &prepared {
+            fs::write(&change.path, change.content.as_bytes()).map_err(|error| {
+                tool_error(
+                    "file_patch_write_failed",
+                    format!("could not write {}: {error}", change.display_path),
+                    false,
+                )
+            })?;
+        }
+
+        let output_files = prepared
+            .iter()
+            .take(FILE_PATCH_OUTPUT_MAX_FILES)
+            .map(|change| {
+                serde_json::json!({
+                    "path": redact(&change.display_path),
+                    "action": change.action,
+                })
+            })
+            .collect::<Vec<_>>();
+        let truncated = prepared.len() > FILE_PATCH_OUTPUT_MAX_FILES;
+        let summary = format!("patched {} file{}", prepared.len(), plural(prepared.len()));
+
+        Ok(ToolExecutionResult {
+            summary,
+            output: serde_json::json!({
+                "schema": "structured_replace_write_v1",
+                "files": output_files,
+                "truncated": truncated
+            }),
+        })
+    }
+
     fn resolved_granted_workspace(
         &self,
         session_id: &SessionId,
@@ -2846,6 +3021,7 @@ impl Runtime {
         let workspace = self.resolve_registered_workspace(&workspace_ref)?;
         if self.has_workspace_grant(&workspace.id, agent_id, required_access) {
             Ok(ResolvedWorkspace {
+                id: workspace.id.clone(),
                 root: workspace.root.clone(),
             })
         } else {
@@ -3565,6 +3741,7 @@ impl WorkspaceGrantRecord {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ResolvedWorkspace {
+    id: WorkspaceId,
     root: PathBuf,
 }
 
@@ -3725,9 +3902,17 @@ impl WorkerMetadata {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 struct PendingApproval {
     record: ApprovalRecord,
+    tool_execution: Option<PendingToolExecution>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct PendingToolExecution {
+    request: ToolCallRequest,
+    workspace_id: WorkspaceId,
+    workspace_root: PathBuf,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -4368,6 +4553,42 @@ struct ToolExecutionResult {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+enum FilePatchOperation {
+    Write {
+        path: String,
+        content: String,
+    },
+    Replace {
+        path: String,
+        old: String,
+        new: String,
+    },
+}
+
+impl FilePatchOperation {
+    fn path(&self) -> &str {
+        match self {
+            Self::Write { path, .. } | Self::Replace { path, .. } => path,
+        }
+    }
+
+    fn action(&self) -> &'static str {
+        match self {
+            Self::Write { .. } => "write",
+            Self::Replace { .. } => "replace",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PreparedFilePatch {
+    path: PathBuf,
+    display_path: String,
+    action: &'static str,
+    content: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct SearchMatch {
     path: String,
     line_number: usize,
@@ -4507,7 +4728,15 @@ fn pending_approval_records(
         .into_iter()
         .filter(|(_, record)| record.state == ApprovalState::Pending)
         .filter(|(_, record)| !approval_is_expired(record))
-        .map(|(approval_id, record)| (approval_id, PendingApproval { record }))
+        .map(|(approval_id, record)| {
+            (
+                approval_id,
+                PendingApproval {
+                    record,
+                    tool_execution: None,
+                },
+            )
+        })
         .collect()
 }
 
@@ -4920,6 +5149,13 @@ fn input_usize(input: &serde_json::Value, key: &str) -> Option<usize> {
         .and_then(|value| usize::try_from(value).ok())
 }
 
+fn input_raw_string(input: &serde_json::Value, key: &str) -> Option<String> {
+    input
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+}
+
 fn normalize_voice_checks(checks: Vec<VoiceDoctorCheck>) -> Vec<VoiceDoctorCheck> {
     checks
         .into_iter()
@@ -5327,9 +5563,408 @@ fn tool_command_summary(tool_name: &str, input: &serde_json::Value) -> Option<St
                 })
             })
         }),
+        "file.patch" => file_patch_path_summary(input),
         _ => input_string(input, "path"),
     }
     .map(|value| redact(&value))
+}
+
+fn file_patch_path_summary(input: &serde_json::Value) -> Option<String> {
+    if let Some(path) = input_string(input, "path").or_else(|| input_string(input, "target")) {
+        return Some(path);
+    }
+
+    input
+        .get("operations")
+        .and_then(serde_json::Value::as_array)
+        .map(|operations| {
+            operations
+                .iter()
+                .filter_map(|operation| {
+                    input_string(operation, "path").or_else(|| input_string(operation, "target"))
+                })
+                .take(FILE_PATCH_OUTPUT_MAX_FILES)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .filter(|summary| !summary.is_empty())
+}
+
+fn parse_file_patch_operations(
+    input: &serde_json::Value,
+) -> Result<Vec<FilePatchOperation>, ErrorPayload> {
+    let operations = if let Some(operations) = input.get("operations") {
+        let Some(items) = operations.as_array() else {
+            return Err(tool_error(
+                "invalid_tool_input",
+                "file.patch operations must be an array",
+                false,
+            ));
+        };
+        items
+            .iter()
+            .map(parse_file_patch_operation)
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        vec![parse_file_patch_operation(input)?]
+    };
+
+    if operations.is_empty() {
+        return Err(tool_error(
+            "invalid_tool_input",
+            "file.patch requires at least one operation",
+            false,
+        ));
+    }
+    if operations.len() > FILE_PATCH_MAX_OPERATIONS {
+        return Err(tool_error(
+            "invalid_tool_input",
+            format!("file.patch supports at most {FILE_PATCH_MAX_OPERATIONS} operations"),
+            false,
+        ));
+    }
+
+    Ok(operations)
+}
+
+fn parse_file_patch_operation(
+    input: &serde_json::Value,
+) -> Result<FilePatchOperation, ErrorPayload> {
+    let path = input_string(input, "path")
+        .or_else(|| input_string(input, "target"))
+        .ok_or_else(|| tool_error("invalid_tool_input", "file.patch requires path", false))?;
+    let action = input_string(input, "op")
+        .or_else(|| input_string(input, "action"))
+        .map(|value| value.to_ascii_lowercase());
+
+    match action.as_deref() {
+        Some("write") | Some("replace_file") | Some("create") => {
+            let content = input_raw_string(input, "content").ok_or_else(|| {
+                tool_error(
+                    "invalid_tool_input",
+                    "file.patch write operation requires content",
+                    false,
+                )
+            })?;
+            validate_patch_text_size("content", &content)?;
+            Ok(FilePatchOperation::Write { path, content })
+        }
+        Some("replace") => parse_file_patch_replace(path, input),
+        Some(other) => Err(tool_error(
+            "invalid_tool_input",
+            format!("unsupported file.patch operation '{other}'"),
+            false,
+        )),
+        None if input.get("content").is_some() => {
+            let content = input_raw_string(input, "content").ok_or_else(|| {
+                tool_error(
+                    "invalid_tool_input",
+                    "file.patch content must be a string",
+                    false,
+                )
+            })?;
+            validate_patch_text_size("content", &content)?;
+            Ok(FilePatchOperation::Write { path, content })
+        }
+        None => parse_file_patch_replace(path, input),
+    }
+}
+
+fn parse_file_patch_replace(
+    path: String,
+    input: &serde_json::Value,
+) -> Result<FilePatchOperation, ErrorPayload> {
+    let old = input_raw_string(input, "old").ok_or_else(|| {
+        tool_error(
+            "invalid_tool_input",
+            "file.patch replace operation requires old",
+            false,
+        )
+    })?;
+    let new = input_raw_string(input, "new").ok_or_else(|| {
+        tool_error(
+            "invalid_tool_input",
+            "file.patch replace operation requires new",
+            false,
+        )
+    })?;
+    if old.is_empty() {
+        return Err(tool_error(
+            "invalid_tool_input",
+            "file.patch replace operation old cannot be empty",
+            false,
+        ));
+    }
+    validate_patch_text_size("old", &old)?;
+    validate_patch_text_size("new", &new)?;
+    Ok(FilePatchOperation::Replace { path, old, new })
+}
+
+fn validate_patch_text_size(label: &str, value: &str) -> Result<(), ErrorPayload> {
+    if value.len() > FILE_PATCH_MAX_FILE_BYTES {
+        Err(tool_error(
+            "file_patch_too_large",
+            format!("file.patch {label} exceeds {FILE_PATCH_MAX_FILE_BYTES} bytes"),
+            false,
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_file_patch_input(
+    workspace: &Path,
+    input: &serde_json::Value,
+) -> Result<(), ErrorPayload> {
+    let operations = parse_file_patch_operations(input)?;
+    for operation in &operations {
+        let target = resolve_file_patch_target(workspace, operation.path())?;
+        validate_file_patch_target(operation, &target)?;
+    }
+    Ok(())
+}
+
+fn validate_file_patch_target(
+    operation: &FilePatchOperation,
+    target: &Path,
+) -> Result<(), ErrorPayload> {
+    match operation {
+        FilePatchOperation::Write { .. } => {
+            if let Ok(metadata) = fs::metadata(target) {
+                if !metadata.is_file() {
+                    return Err(tool_error(
+                        "unsupported_file_type",
+                        "file.patch can only write regular files",
+                        false,
+                    ));
+                }
+            }
+            Ok(())
+        }
+        FilePatchOperation::Replace { .. } => {
+            let metadata = fs::metadata(target).map_err(|error| {
+                tool_error(
+                    "path_resolution_failed",
+                    format!("could not read file.patch target: {error}"),
+                    false,
+                )
+            })?;
+            if !metadata.is_file() {
+                return Err(tool_error(
+                    "unsupported_file_type",
+                    "file.patch can only replace regular files",
+                    false,
+                ));
+            }
+            if metadata.len() > FILE_PATCH_MAX_FILE_BYTES as u64 {
+                return Err(tool_error(
+                    "file_patch_too_large",
+                    format!("file.patch target exceeds {FILE_PATCH_MAX_FILE_BYTES} bytes"),
+                    false,
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
+fn prepare_file_patch(
+    workspace: &Path,
+    operations: &[FilePatchOperation],
+) -> Result<Vec<PreparedFilePatch>, ErrorPayload> {
+    let mut staged = HashMap::<PathBuf, String>::new();
+    let mut prepared = Vec::new();
+
+    for operation in operations {
+        let path = resolve_file_patch_target(workspace, operation.path())?;
+        validate_file_patch_target(operation, &path)?;
+        let content = match operation {
+            FilePatchOperation::Write { content, .. } => content.clone(),
+            FilePatchOperation::Replace { old, new, .. } => {
+                let current = match staged.get(&path) {
+                    Some(content) => content.clone(),
+                    None => read_patch_target(&path)?,
+                };
+                replace_once(&current, old, new)?
+            }
+        };
+        validate_patch_text_size("result", &content)?;
+        staged.insert(path.clone(), content.clone());
+        prepared.push(PreparedFilePatch {
+            display_path: display_relative_path(workspace, &path),
+            path,
+            action: operation.action(),
+            content,
+        });
+    }
+
+    Ok(prepared)
+}
+
+fn read_patch_target(path: &Path) -> Result<String, ErrorPayload> {
+    fs::read_to_string(path).map_err(|error| {
+        tool_error(
+            "file_patch_read_failed",
+            format!("could not read patch target: {error}"),
+            false,
+        )
+    })
+}
+
+fn replace_once(content: &str, old: &str, new: &str) -> Result<String, ErrorPayload> {
+    let matches = content.match_indices(old).take(2).count();
+    match matches {
+        0 => Err(tool_error(
+            "file_patch_replace_mismatch",
+            "file.patch old text was not found exactly once",
+            false,
+        )),
+        1 => Ok(content.replacen(old, new, 1)),
+        _ => Err(tool_error(
+            "file_patch_replace_ambiguous",
+            "file.patch old text matched more than once",
+            false,
+        )),
+    }
+}
+
+fn resolve_file_patch_target(workspace: &Path, user_path: &str) -> Result<PathBuf, ErrorPayload> {
+    let relative = Path::new(user_path);
+    if relative.is_absolute() || path_has_parent_or_root(relative) {
+        return Err(tool_error(
+            "outside_workspace",
+            "file.patch paths must be relative to the workspace",
+            false,
+        ));
+    }
+    if relative.file_name().is_none() {
+        return Err(tool_error(
+            "invalid_tool_input",
+            "file.patch path must name a file",
+            false,
+        ));
+    }
+    if file_patch_path_is_protected(relative) {
+        return Err(tool_error(
+            "protected_path",
+            "file.patch refuses to modify protected workspace metadata paths",
+            false,
+        ));
+    }
+    if file_patch_path_is_secret_like(relative) {
+        return Err(tool_error(
+            "secret_path_rejected",
+            "file.patch refuses to modify secret-like paths",
+            false,
+        ));
+    }
+
+    let workspace = workspace.canonicalize().map_err(|error| {
+        tool_error(
+            "path_resolution_failed",
+            format!("could not resolve workspace: {error}"),
+            false,
+        )
+    })?;
+    let candidate = workspace.join(relative);
+    if let Ok(resolved) = candidate.canonicalize() {
+        if !resolved.starts_with(&workspace) {
+            return Err(tool_error(
+                "outside_workspace",
+                "file.patch target resolves outside the workspace",
+                false,
+            ));
+        }
+        if resolved.is_dir() {
+            return Err(tool_error(
+                "unsupported_file_type",
+                "file.patch target must be a file",
+                false,
+            ));
+        }
+        return Ok(resolved);
+    }
+
+    let parent = candidate.parent().ok_or_else(|| {
+        tool_error(
+            "invalid_tool_input",
+            "file.patch path must have a parent directory",
+            false,
+        )
+    })?;
+    let parent = parent.canonicalize().map_err(|error| {
+        tool_error(
+            "path_resolution_failed",
+            format!("could not resolve file.patch parent: {error}"),
+            false,
+        )
+    })?;
+    if !parent.starts_with(&workspace) {
+        return Err(tool_error(
+            "outside_workspace",
+            "file.patch parent resolves outside the workspace",
+            false,
+        ));
+    }
+    let file_name = candidate.file_name().ok_or_else(|| {
+        tool_error(
+            "invalid_tool_input",
+            "file.patch path must name a file",
+            false,
+        )
+    })?;
+    Ok(parent.join(file_name))
+}
+
+fn path_has_parent_or_root(path: &Path) -> bool {
+    path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    })
+}
+
+fn file_patch_path_is_protected(path: &Path) -> bool {
+    path.components().any(|component| match component {
+        Component::Normal(value) => matches!(value.to_str(), Some(".git" | ".cadis")),
+        _ => false,
+    })
+}
+
+fn file_patch_path_is_secret_like(path: &Path) -> bool {
+    path.components().any(|component| {
+        let Component::Normal(value) = component else {
+            return false;
+        };
+        let name = value.to_string_lossy().to_ascii_lowercase();
+        name == ".env"
+            || name.starts_with(".env.")
+            || matches!(
+                name.as_str(),
+                ".netrc"
+                    | ".npmrc"
+                    | ".pypirc"
+                    | ".git-credentials"
+                    | "id_rsa"
+                    | "id_dsa"
+                    | "id_ecdsa"
+                    | "id_ed25519"
+                    | ".ssh"
+                    | ".aws"
+                    | ".gnupg"
+            )
+            || name.ends_with(".pem")
+            || name.ends_with(".key")
+            || name.ends_with(".p12")
+            || name.ends_with(".pfx")
+            || name.contains("secret")
+            || name.contains("credential")
+            || name.contains("token")
+            || name.contains("api_key")
+            || name.contains("apikey")
+            || name.contains("private_key")
+    })
 }
 
 fn validate_git_pathspec(pathspec: &str) -> Result<String, ErrorPayload> {
@@ -6339,6 +6974,17 @@ mod tests {
         ));
     }
 
+    fn approval_id_from(outcome: &RequestOutcome) -> ApprovalId {
+        outcome
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::ApprovalRequested(payload) => Some(payload.approval_id.clone()),
+                _ => None,
+            })
+            .expect("approval.requested should be emitted")
+    }
+
     fn send_message_with_kind(
         runtime: &mut Runtime,
         content_kind: ContentKind,
@@ -6973,6 +7619,315 @@ mod tests {
                     if payload.error.code == "workspace_grant_required"
             )
         }));
+    }
+
+    #[test]
+    fn file_patch_requests_approval_without_execution() {
+        let workspace = test_workspace("file-patch-approval");
+        fs::write(workspace.join("README.md"), "hello\n").expect("test file should write");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "file-patch-approval", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "file-patch-approval",
+            vec![WorkspaceAccess::Write],
+        );
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_file_patch_approval"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "file.patch".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "file-patch-approval",
+                    "path": "README.md",
+                    "old": "hello\n",
+                    "new": "hello cadis\n"
+                }),
+            }),
+        ));
+
+        assert!(matches!(
+            outcome.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ApprovalRequested(payload)
+                    if payload.tool_call_id.as_str() == "tool_000001"
+                        && payload.summary.contains("edit_workspace")
+            )
+        }));
+        assert!(!outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ToolStarted(_))));
+        assert_eq!(
+            fs::read_to_string(workspace.join("README.md")).expect("file should read"),
+            "hello\n"
+        );
+    }
+
+    #[test]
+    fn file_patch_denial_does_not_apply_patch() {
+        let workspace = test_workspace("file-patch-denial");
+        fs::write(workspace.join("README.md"), "hello\n").expect("test file should write");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "file-patch-denial", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "file-patch-denial",
+            vec![WorkspaceAccess::Write],
+        );
+
+        let request = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_file_patch_denial"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "file.patch".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "file-patch-denial",
+                    "path": "README.md",
+                    "content": "patched\n"
+                }),
+            }),
+        ));
+        let approval_id = approval_id_from(&request);
+
+        let denial = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_file_patch_deny"),
+            ClientId::from("cli_1"),
+            ClientRequest::ApprovalRespond(ApprovalResponseRequest {
+                approval_id,
+                decision: ApprovalDecision::Denied,
+                reason: Some("not this patch".to_owned()),
+            }),
+        ));
+
+        assert!(denial.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ApprovalResolved(payload)
+                    if payload.decision == ApprovalDecision::Denied
+            )
+        }));
+        assert!(denial.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolFailed(payload)
+                    if payload.tool_name == "file.patch"
+                        && payload.error.code == "approval_denied"
+            )
+        }));
+        assert_eq!(
+            fs::read_to_string(workspace.join("README.md")).expect("file should read"),
+            "hello\n"
+        );
+    }
+
+    #[test]
+    fn approved_file_patch_applies_inside_workspace() {
+        let workspace = test_workspace("file-patch-approved");
+        fs::write(workspace.join("README.md"), "hello\n").expect("test file should write");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "file-patch-approved", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "file-patch-approved",
+            vec![WorkspaceAccess::Write],
+        );
+
+        let request = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_file_patch_apply"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "file.patch".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "file-patch-approved",
+                    "operations": [
+                        {
+                            "op": "replace",
+                            "path": "README.md",
+                            "old": "hello\n",
+                            "new": "hello cadis\n"
+                        }
+                    ]
+                }),
+            }),
+        ));
+        let approval_id = approval_id_from(&request);
+
+        let approved = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_file_patch_approve"),
+            ClientId::from("cli_1"),
+            ClientRequest::ApprovalRespond(ApprovalResponseRequest {
+                approval_id,
+                decision: ApprovalDecision::Approved,
+                reason: Some("apply".to_owned()),
+            }),
+        ));
+
+        assert!(approved.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ApprovalResolved(payload)
+                    if payload.decision == ApprovalDecision::Approved
+            )
+        }));
+        assert!(approved
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ToolStarted(_))));
+        assert!(approved.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolCompleted(payload)
+                    if payload.tool_name == "file.patch"
+                        && payload.summary.as_deref() == Some("patched 1 file")
+                        && payload.output.as_ref().is_some_and(|output| {
+                            output["schema"] == "structured_replace_write_v1"
+                                && output["truncated"] == false
+                        })
+            )
+        }));
+        assert_eq!(
+            fs::read_to_string(workspace.join("README.md")).expect("file should read"),
+            "hello cadis\n"
+        );
+    }
+
+    #[test]
+    fn file_patch_requires_workspace_write_grant() {
+        let workspace = test_workspace("file-patch-grant");
+        fs::write(workspace.join("README.md"), "hello\n").expect("test file should write");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "file-patch-grant", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "file-patch-grant",
+            vec![WorkspaceAccess::Read],
+        );
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_file_patch_grant"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "file.patch".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "file-patch-grant",
+                    "path": "README.md",
+                    "content": "patched\n"
+                }),
+            }),
+        ));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolFailed(payload)
+                    if payload.tool_name == "file.patch"
+                        && payload.error.code == "workspace_grant_required"
+            )
+        }));
+        assert!(!outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ApprovalRequested(_))));
+    }
+
+    #[test]
+    fn file_patch_rejects_outside_workspace_path() {
+        let workspace = test_workspace("file-patch-outside");
+        fs::write(workspace.join("README.md"), "hello\n").expect("test file should write");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "file-patch-outside", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "file-patch-outside",
+            vec![WorkspaceAccess::Write],
+        );
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_file_patch_outside"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "file.patch".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "file-patch-outside",
+                    "path": "../README.md",
+                    "content": "patched\n"
+                }),
+            }),
+        ));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolFailed(payload)
+                    if payload.tool_name == "file.patch"
+                        && payload.error.code == "outside_workspace"
+            )
+        }));
+        assert!(!outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ApprovalRequested(_))));
+    }
+
+    #[test]
+    fn file_patch_rejects_secret_like_path() {
+        let workspace = test_workspace("file-patch-secret");
+        fs::write(workspace.join(".env"), "TOKEN=secret\n").expect("test file should write");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "file-patch-secret", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "file-patch-secret",
+            vec![WorkspaceAccess::Write],
+        );
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_file_patch_secret"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "file.patch".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "file-patch-secret",
+                    "path": ".env",
+                    "content": "TOKEN=patched\n"
+                }),
+            }),
+        ));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolFailed(payload)
+                    if payload.tool_name == "file.patch"
+                        && payload.error.code == "secret_path_rejected"
+            )
+        }));
+        assert!(!outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ApprovalRequested(_))));
+        assert_eq!(
+            fs::read_to_string(workspace.join(".env")).expect("file should read"),
+            "TOKEN=secret\n"
+        );
     }
 
     #[test]

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -194,12 +194,13 @@ Example:
 `tool.call` requests daemon-owned native tool execution. Tool calls must resolve
 a registered workspace and an active workspace grant before execution or
 approval flow proceeds. `agent_id` is optional; when present, it lets daemon tool
-execution satisfy agent-scoped workspace grants. The initial baseline supports
-safe read-only execution
-for `file.read`, `file.search`, and `git.status`; risky placeholders such as
-`shell.run`, `file.write`, and `file.patch` create an approval request after the
-workspace grant check and do not execute until a later runtime implements the
-gated action.
+execution satisfy agent-scoped workspace grants. The current baseline supports
+safe read-only execution for `file.read`, `file.search`, `git.status`, and
+`git.diff`. `file.patch` requires an active write grant and approval, then
+executes a conservative structured replace/write patch. Other risky placeholders
+such as `shell.run` and `file.write` still create an approval request after the
+workspace grant check and remain blocked after approval until their execution
+backends are implemented.
 
 Example:
 
@@ -220,6 +221,38 @@ Example:
   }
 }
 ```
+
+`file.patch` accepts a structured patch object compatible with CLI `--input`
+JSON. Single-operation forms:
+
+```json
+{ "workspace_id": "example-project", "path": "README.md", "old": "before", "new": "after" }
+```
+
+```json
+{ "workspace_id": "example-project", "path": "README.md", "content": "full file contents\n" }
+```
+
+Multi-operation form:
+
+```json
+{
+  "workspace_id": "example-project",
+  "operations": [
+    { "op": "replace", "path": "README.md", "old": "before", "new": "after" },
+    { "op": "write", "path": "notes.txt", "content": "new file contents\n" }
+  ]
+}
+```
+
+Paths must be workspace-relative. Absolute paths, `..` escapes, protected
+workspace metadata paths such as `.git` and `.cadis`, and secret-like paths such
+as `.env`, key files, token files, credential files, and secret-named paths are
+rejected before approval. Unified diff application is intentionally not part of
+this slice; callers should submit the structured schema above. Approved
+execution context is in-memory for this slice; if the daemon restarts with a
+pending `file.patch` approval, approving that recovered request fails closed
+because the patch body is not persisted.
 
 `workspace.register` adds or replaces a profile-local project workspace registry
 entry. CADIS persists the registry under
@@ -575,17 +608,21 @@ tool.completed or tool.failed
 ```
 
 Safe-read tools emit `tool.requested`, `tool.started`, and then
-`tool.completed` or `tool.failed`. Approval-gated placeholders emit
-`tool.requested` and `approval.requested`; `approval.respond` emits
-`approval.resolved` and `tool.failed` because risky execution is intentionally
-blocked in this baseline.
+`tool.completed` or `tool.failed`. `file.patch` emits `tool.requested` and
+`approval.requested`; an approved `approval.respond` emits `approval.resolved`,
+`tool.started`, and then `tool.completed` or `tool.failed`. Other approval-gated
+placeholders emit `tool.requested` and `approval.requested`; `approval.respond`
+emits `approval.resolved` and `tool.failed` because those risky execution
+backends are intentionally blocked in this baseline.
 
 `tool.completed` may include a redacted structured `output` object. The current
-safe-read outputs are:
+tool outputs are:
 
 - `file.read`: `path`, `content`, `truncated`
 - `file.search`: `query`, `matches[]`, `truncated`
 - `git.status`: `cwd`, `status`
+- `git.diff`: `cwd`, `pathspec`, `diff`, `truncated`
+- `file.patch`: `schema`, `files[]`, `truncated`
 
 ## 8. Compatibility Rules
 


### PR DESCRIPTION
## Summary
- add approval-backed structured file.patch execution
- require workspace write grants and reject outside/protected/secret-like paths
- emit bounded redacted lifecycle output and document schema

## Validation
- cargo test -p cadis-core file_patch
- cargo test -p cadis-core approval
- cargo fmt --all --check
- git diff --check