### PR TITLE
Document Track D tool execution semantics

### DIFF
--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -227,11 +227,46 @@ Tasks:
   tools, shell execution, and full policy-gated tool execution remain future
   work.
 
+Execution semantics for the next Track D slice:
+
+- Treat approval as authorization to attempt execution, not as execution
+  itself. After an approval is granted, `cadisd` must revalidate approval
+  expiry, workspace grant, normalized input, denied paths, secret-access policy,
+  and current session/worker state before `tool.started`.
+- `shell.run` must execute only inside a registered workspace or CADIS-owned
+  worker worktree with `exec` or `admin` access, filtered environment, bounded
+  stdout/stderr, exit-code reporting, timeout, and cancellation cleanup.
+- `file.patch` must apply only to normalized workspace-relative paths, preserve
+  unrelated user edits, fail closed on context mismatch, symlink escape, denied
+  path, or concurrent change, and write atomically where practical.
+- Secret access fails closed by default. A tool that may read a secret-bearing
+  path, environment value, config entry, or command output needs explicit policy
+  support and approval metadata before execution.
+- Timeouts must produce a terminal `tool.failed` result with timeout metadata.
+  Cancellation remains incomplete until the protocol and runtime expose a typed
+  terminal tool cancellation path and process/file-operation cleanup.
+
+Worker integration sequence:
+
+1. Track C/I creates an isolated worker worktree and profile-scoped artifacts.
+2. Worker command/test execution runs only inside the worker worktree after
+   Track D policy approval and tool execution support exist.
+3. Worker output produces a review artifact, normally `patch.diff` plus
+   `summary.md`.
+4. Applying that patch to the parent workspace is a separate Track D
+   `file.patch` or future patch-apply tool call with its own approval request.
+5. Worker cleanup is a separate approved flow and must not delete paths without
+   a CADIS-owned worker/worktree record.
+
 Exit criteria:
 
 - Risky tools fail closed without approval.
 - Approval decisions survive client reconnects.
 - Tool events are visible in CLI/HUD and redacted in JSONL logs.
+- Approved `shell.run` and `file.patch` execute only after daemon-side
+  revalidation and emit one terminal result.
+- Worker patch application cannot modify the parent checkout without a separate
+  Track D approval.
 
 ### Track E - Voice as a Daemon-Owned Capability
 

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -167,6 +167,10 @@
 - [ ] Implement `shell.run`.
 - [x] Implement `git.status`.
 - [x] Implement `git.diff`.
+- [ ] Add approved execution continuation after `approval.resolved(approved)`.
+- [ ] Revalidate workspace grants, denied paths, secret posture, and session/worker state before approved execution.
+- [ ] Add `shell.run` cwd, env filtering, stdout/stderr, exit code, timeout, and cancellation cleanup.
+- [ ] Add `file.patch` preview, context validation, atomic write, symlink escape, and concurrent-edit checks.
 - [ ] Add timeouts.
 - [ ] Add cancellation.
 - [x] Add tests for success and failure.
@@ -182,6 +186,8 @@
 - [x] Gate shell execution.
 - [ ] Gate outside-workspace writes.
 - [ ] Gate secret access.
+- [ ] Fail closed on secret-bearing files, env vars, config values, and command output unless explicit policy allows access.
+- [ ] Recheck approval expiry and policy immediately before approved execution.
 - [ ] Gate dangerous delete.
 - [ ] Add race condition tests.
 - [x] Add denial tests.
@@ -243,6 +249,8 @@
 - [ ] Run tests in worker.
 - [ ] Request patch approval.
 - [ ] Apply approved patch.
+- [ ] Route worker patch application through Track D `file.patch` or a future patch-apply tool.
+- [ ] Keep worker cleanup separate from patch approval and require CADIS-owned worktree metadata.
 - [ ] Cleanup worktree.
 - [x] Add worker isolation tests for worktree creation and artifact output.
 
@@ -337,6 +345,11 @@
 - [x] Track D baseline: tool contract metadata, safe-read `file.read` and
   `file.search`, `git.status`, `git.diff`, workspace grants, approval
   summaries, approval persistence/recovery, and redaction boundaries.
+- [x] Track D docs/protocol alignment: approved execution semantics,
+  `shell.run` and `file.patch` boundaries, timeout/cancellation expectations,
+  denied paths, secret fail-closed behavior, and worker handoff sequence.
+- [ ] Track D implementation: approved `shell.run` and `file.patch` execution
+  after daemon-side revalidation.
 - [ ] Track E: daemon-owned voice provider path, STT language setting, and voice doctor.
 - [x] Track E baseline: daemon-visible voice status/doctor/preflight, separated
   STT language and TTS voice settings, TTS provider stubs, and speech policy

--- a/docs/11_DECISIONS.md
+++ b/docs/11_DECISIONS.md
@@ -275,9 +275,62 @@ Consequence:
 - Generated or curated project media defaults to `<project>/.cadis/media/` with
   manifests and without secrets or raw transcripts.
 - Current code implements the first baseline for default profile initialization,
-  persistent workspace registry/grants, broad-root rejection, and safe-read grant
-  enforcement. Agent homes, worker worktree creation, checkpoint rollback, and
-  mutating-tool enforcement remain future work.
+  persistent workspace registry/grants, broad-root rejection, safe-read grant
+  enforcement, and session-bound worker worktree creation. Agent homes,
+  checkpoint rollback, worker cleanup, and mutating-tool enforcement remain
+  future work.
+
+### ADR-016: Approved Track D tool execution is daemon-revalidated
+
+Status: Accepted.
+
+Decision: Approval is authorization to attempt a risky tool action, not a
+client-side execution grant. After `approval.respond` approves a pending tool,
+`cadisd` must revalidate the request before execution: approval state, expiry,
+workspace grant, normalized input, denied paths, secret-access posture, current
+session/worker state, and the registered tool contract.
+
+Reason:
+
+- Approvals can be resolved minutes after the original request and after
+  workspace, policy, or session state changed.
+- Clients must never turn approval into local shell, patch, or git execution.
+- Worker patch application must preserve the parent checkout and remain
+  reviewable.
+- Secret access and denied paths need a final daemon-side fail-closed check,
+  not only UI warning text.
+
+Execution rules:
+
+- `shell.run` executes only inside a registered workspace or CADIS-owned worker
+  worktree with an active `exec` or `admin` grant, filtered environment, bounded
+  stdout/stderr, timeout, cancellation handling, and no implicit secret
+  injection.
+- `file.patch` applies only to daemon-normalized workspace-relative paths, must
+  preview affected files before approval, must fail closed on context mismatch,
+  symlink escape, denied path, or concurrent user edits, and must write
+  atomically where practical.
+- Secret access is denied by default. A tool that may read secrets must require
+  explicit policy support and approval metadata before any secret-bearing input,
+  environment value, file content, or output can cross the tool boundary.
+- Approved worker patches flow through Track D as a new `file.patch` or future
+  patch-apply tool call using the worker artifact as input; worker completion
+  alone does not modify the parent workspace.
+- Timeout emits a terminal failed result with timeout metadata. Cancellation
+  emits the protocol terminal cancellation path once that event is implemented;
+  until then, async tool cancellation remains pending and must not be marked
+  complete.
+
+Consequence:
+
+- The current implementation may persist approvals and fail closed after
+  approval for risky placeholders. That is correct until the `shell.run` and
+  `file.patch` execution backends implement the revalidation and lifecycle
+  rules above.
+- Worker cleanup, patch apply, and command/test execution must stay separate
+  approval-gated flows.
+- Protocol and standards docs must continue to separate implemented safe-read
+  tools from target approved execution semantics.
 
 ## Pending Decisions
 

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -195,11 +195,10 @@ Example:
 a registered workspace and an active workspace grant before execution or
 approval flow proceeds. `agent_id` is optional; when present, it lets daemon tool
 execution satisfy agent-scoped workspace grants. The initial baseline supports
-safe read-only execution
-for `file.read`, `file.search`, and `git.status`; risky placeholders such as
-`shell.run`, `file.write`, and `file.patch` create an approval request after the
-workspace grant check and do not execute until a later runtime implements the
-gated action.
+safe read-only execution for `file.read`, `file.search`, `git.status`, and
+`git.diff`; risky placeholders such as `shell.run`, `file.write`, and
+`file.patch` create an approval request after the workspace grant check and fail
+closed after approval until a later runtime implements the gated action.
 
 Example:
 
@@ -220,6 +219,51 @@ Example:
   }
 }
 ```
+
+Track D approved execution target:
+
+```text
+tool.call
+validate input and resolve workspace
+classify risk and evaluate policy
+tool.requested
+approval.requested, if required
+approval.respond
+approval.resolved
+revalidate approval, grant, denied paths, secret posture, and session/worker state
+tool.started
+tool.output.delta, optional and bounded
+tool.completed, tool.failed, or future tool.cancelled
+```
+
+Approval is not a client-side execution grant. After `approval.respond` approves
+a risky tool, `cadisd` must revalidate the current daemon state before
+execution. If the approval expired, the workspace grant changed, a target path is
+denied, secret access is not explicitly authorized, the session was cancelled,
+or the execution backend is unavailable, the daemon emits `approval.resolved`
+followed by `tool.failed`.
+
+Current v0.1 behavior for approved risky placeholders is
+`tool.failed.error.code = "tool_execution_blocked"`. Denied approvals use
+`approval_denied`; expired approvals use `approval_expired`. Async tool
+cancellation is still future work; until a typed `tool.cancelled` event lands in
+the protocol crate, cancellation must not be marked complete in the checklist.
+
+`shell.run` input must resolve to a registered workspace or CADIS-owned worker
+worktree before execution. The execution backend must use an explicit cwd,
+filtered environment, bounded stdout/stderr, exit-code reporting, timeout, and
+cleanup on cancellation. It must not inject secrets implicitly.
+
+`file.patch` input must be previewable before approval and must apply only to
+daemon-normalized workspace-relative paths. The backend must fail closed on path
+traversal, symlink escape, denied path, mismatched context, or concurrent user
+edits. Patch writes should be atomic where practical.
+
+Worker integration uses the same protocol flow. Worker command/test execution
+runs inside the worker worktree only after Track D tool approval support exists.
+Applying a worker artifact to the parent workspace is a separate `file.patch` or
+future patch-apply tool call with its own approval; `worker.completed` alone
+does not authorize parent-checkout mutation.
 
 `workspace.register` adds or replaces a profile-local project workspace registry
 entry. CADIS persists the registry under
@@ -580,12 +624,19 @@ Safe-read tools emit `tool.requested`, `tool.started`, and then
 `approval.resolved` and `tool.failed` because risky execution is intentionally
 blocked in this baseline.
 
+The approved execution target keeps the same ordering, but inserts daemon-side
+revalidation after `approval.resolved` and before `tool.started`. A successful
+approved tool emits exactly one terminal event. Timeout is represented as
+`tool.failed` with timeout metadata. Future async tool cancellation should emit a
+typed terminal cancellation event once the protocol crate supports it.
+
 `tool.completed` may include a redacted structured `output` object. The current
 safe-read outputs are:
 
 - `file.read`: `path`, `content`, `truncated`
 - `file.search`: `query`, `matches[]`, `truncated`
 - `git.status`: `cwd`, `status`
+- `git.diff`: `cwd`, `pathspec`, `diff`, `truncated`
 
 ## 8. Compatibility Rules
 

--- a/docs/standards/11_TOOL_RUNTIME_STANDARD.md
+++ b/docs/standards/11_TOOL_RUNTIME_STANDARD.md
@@ -76,13 +76,14 @@ Example classes:
 | Risk Class | Examples | Default |
 | --- | --- | --- |
 | safe-read | file reads inside workspace, git status | auto-allow |
-| bounded-write | patch inside workspace | policy decision |
-| command | shell command without obvious destructive behavior | policy decision |
+| workspace-edit | patch inside workspace | policy decision |
+| system-change | shell command or process execution | approval required |
 | secret-access | environment or config secret access | approval required |
-| outside-workspace-write | writing outside allowed roots | approval required |
+| outside-workspace | writing outside allowed roots | approval required |
 | dangerous-delete | recursive delete, destructive cleanup | approval required |
-| system-change | sudo, package manager, service mutation | approval required |
-| protected-git-write | push to protected branches, force push | approval required |
+| git-push-main | push to protected main branch | approval required |
+| git-force-push | force push | approval required |
+| sudo-system | sudo, package manager, service mutation | approval required |
 
 Risk classification must be conservative. If classification is ambiguous, choose the higher-risk class.
 
@@ -107,6 +108,9 @@ Rules:
 Every tool call must emit lifecycle events:
 
 ```text
+tool.requested
+approval.requested, when required
+approval.resolved, when required
 tool.started
 tool.output.delta
 tool.completed
@@ -126,6 +130,31 @@ Events must include:
 
 Output events must be bounded. Long stdout, stderr, diffs, and logs should be chunked, summarized, or routed to appropriate log storage.
 
+Current protocol support includes `tool.requested`, `tool.started`,
+`tool.completed`, `tool.failed`, `approval.requested`, and
+`approval.resolved`. A typed `tool.cancelled` event is the target terminal event
+for async tool cancellation, but it must not be treated as implemented until the
+protocol crate and runtime emit it.
+
+## 7.1 Approved Execution Revalidation
+
+Approval authorizes a daemon attempt; it does not bypass policy or grant a
+client permission to run the action.
+
+Before an approved risky tool starts, `cadisd` must revalidate:
+
+- approval exists, is still pending at response time, and is not expired
+- tool name still resolves to the same registered contract
+- normalized input still matches the approved action summary
+- workspace ID resolves to the same registered root
+- active workspace grant still permits the required access
+- target paths do not hit denied paths or symlink escapes
+- secret access is explicitly allowed by policy and approval metadata
+- linked session, AgentSession, and worker state still allow execution
+
+If any revalidation fails, the tool must emit `tool.failed` and must not emit
+`tool.started`.
+
 ## 8. Shell Tool
 
 `shell.run` is high risk and must be policy-gated.
@@ -144,6 +173,13 @@ Requirements:
 
 Commands that mutate system state, use `sudo`, install packages, delete files, alter protected git refs, or access secrets must require approval.
 
+Track D implementation must keep `shell.run` inside a registered workspace or
+CADIS-owned worker worktree. The environment starts from a minimal allowlist;
+provider keys, auth tokens, SSH agent details, and CADIS secrets are not passed
+unless a later explicit secret-access policy permits it. Cancellation must stop
+the child process and clean up any process group or temporary files where the
+platform supports it.
+
 ## 9. File Tools
 
 `file.read` and `file.search` should be safe by default only inside allowed workspaces and after secret policy checks.
@@ -161,8 +197,16 @@ the returned match list.
 - writes must be atomic where practical
 - generated patches must not overwrite unrelated edits
 - outside-workspace writes require approval
+- denied paths and symlink escapes must fail closed
+- secret-bearing paths require explicit secret-access policy
+- context mismatch or concurrent user edits must fail closed
 
 Patch application must preserve user changes and should fail closed on mismatched context.
+
+Worker patch application is not implicit. A worker may create `patch.diff` and
+`summary.md` artifacts, but applying that patch to the parent workspace is a
+separate `file.patch` or future patch-apply tool call with its own policy
+decision and approval.
 
 ## 10. Git Tools
 
@@ -194,6 +238,11 @@ Rules:
 - Cancellation must produce `tool.cancelled`.
 - Child processes must be cleaned up when possible.
 - The agent must receive a structured result after cancellation.
+
+Current implementation declares timeout and cancellation metadata in the tool
+registry, but approved mutating tools and async tool cancellation are not yet
+implemented. Until they are, risky approved placeholders must continue to fail
+closed.
 
 ## 12. Redaction and Logging
 

--- a/docs/standards/12_APPROVAL_POLICY_STANDARD.md
+++ b/docs/standards/12_APPROVAL_POLICY_STANDARD.md
@@ -28,6 +28,7 @@ evaluate policy
 auto-allow, auto-deny, or request approval
 persist approval request when needed
 wait for resolution
+revalidate policy, workspace, denied paths, and secret posture if approved
 execute only after approved
 persist resolution and execution result
 ```
@@ -77,6 +78,8 @@ Resolution rules:
 - Later responses must be rejected or reported as already resolved.
 - Denied approvals must prevent execution.
 - Expired approvals must prevent execution.
+- Approved responses must still pass final daemon-side revalidation before
+  execution.
 - Approval state must not depend on UI-local state.
 - Clients must remove approval cards only after `approval.resolved`.
 
@@ -109,8 +112,8 @@ Open-source defaults should be conservative and understandable.
 
 Current implementation baseline:
 
-- `file.read`, `file.search`, and `git.status` are auto-allowed only after
-  daemon-side tool classification and workspace path validation.
+- `file.read`, `file.search`, `git.status`, and `git.diff` are auto-allowed
+  only after daemon-side tool classification and workspace path validation.
 - `shell.run`, write tools, and mutating git/worktree placeholders require
   approval and are persisted under daemon-owned state.
 - Unknown tools are denied.
@@ -118,6 +121,22 @@ Current implementation baseline:
   corresponding execution backend is implemented.
 - `approval.respond` uses daemon state and persisted approval records; the first
   valid pending response wins, later responses are rejected as already resolved.
+
+Approved execution target:
+
+- Approval records the user's decision; it does not let CLI, HUD, Telegram,
+  voice, or any worker run a local action directly.
+- `cadisd` must revalidate approval expiry, tool contract, normalized input,
+  workspace grant, denied paths, secret-access policy, and session/worker state
+  immediately before emitting `tool.started`.
+- If revalidation fails, the daemon emits `tool.failed` and does not execute.
+- `shell.run` requires an `exec` or `admin` workspace grant and a filtered
+  environment with secrets excluded by default.
+- `file.patch` requires write access, a previewable patch, context validation,
+  atomic write behavior where practical, and fail-closed handling for denied
+  paths, symlinks, and concurrent edits.
+- Worker patch application is a separate approval-gated tool call; worker
+  completion does not authorize mutation of the parent workspace.
 
 ## 8. Configuration
 
@@ -165,6 +184,11 @@ The baseline persists one JSON approval record per approval under
 `~/.cadis/state/approvals`. Records include request metadata, risk class,
 expiration, decision, redacted reason, and resolution timestamp.
 
+Secret access is fail-closed by default. A request that targets secret-looking
+paths, secret-bearing environment variables, credential config, auth headers, or
+unredacted command output must be denied unless a future explicit
+`secret-access` policy and approval metadata authorizes that exact access.
+
 ## 11. UX Requirements
 
 Approval prompts must be concise but complete.
@@ -191,7 +215,7 @@ Required tests:
 - dangerous delete requires approval
 - sudo/system change requires approval
 - protected git write requires approval
-- approval allow executes action
+- approval allow executes action after backend support and final revalidation
 - approval deny prevents action
 - expiry prevents action
 - duplicate responses are first-response-wins


### PR DESCRIPTION
## Summary
- document approved tool execution lifecycle and fail-closed behavior
- specify shell.run/file.patch safety, timeout, cancellation, and denied-path semantics
- keep pending implementation checklist items pending

## Validation
- git diff --check
- rg path/protocol sanity checks