### PR TITLE
Document worker execution and code work window plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,15 @@ The repository already includes a meaningful desktop MVP foundation:
 - daemon-visible voice status/doctor/preflight with HUD-local Edge TTS
   playback and `whisper-cli` voice input bridges
 
-Planned work still includes production-grade mutating tool execution, full
-policy coverage, richer worker isolation, Telegram/mobile clients,
-daemon-owned production voice, and code work windows. The workspace
-architecture is partially implemented; real worker worktree creation,
-profile-scoped worker artifacts, and review-pending worker metadata are now in
-place. Checkpoint rollback, dedicated profile/agent doctor commands, and
-project media manifests remain next.
+Approved `shell.run` and structured `file.patch` execution now have a
+daemon-side baseline after approval plus workspace/input revalidation. Planned
+work still includes production hardening for shell environment filtering, async
+tool cancellation, atomic patch writes, full policy coverage, worker command/test
+orchestration, Telegram/mobile clients, daemon-owned production voice, and code
+work windows. The workspace architecture is partially implemented; real worker
+worktree creation, profile-scoped worker artifacts, and review-pending worker
+metadata are now in place. Checkpoint rollback, dedicated profile/agent doctor
+commands, and project media manifests remain next.
 
 ## Platform support
 

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -89,18 +89,21 @@ Implemented in the first runnable baseline:
 
 Still pending:
 
-- Native mutating file/shell tools.
+- Production hardening for native mutating file/shell tools. Approved
+  `shell.run` and structured `file.patch` execution now exist after daemon-side
+  approval plus workspace/input revalidation, but `shell.run` still needs a
+  minimal environment allowlist and typed async cancellation, while `file.patch`
+  still needs atomic temp-file writes and broader concurrent-edit hardening.
 - Agent runtime beyond the current route-and-answer path: model-driven spawn,
   multi-step budgets, full tool cancellation, and a provider/tool-call loop
   remain future work; existing `agent.spawn` is client-requested, not
   agent-driven.
-- Risky tool execution after approval. Approval records now persist and pending
-  approvals are replayed after daemon restart, but approved mutating/shell tools
-  still fail closed until native execution backends are implemented.
-- Worker cancellation/cleanup, Telegram/mobile adapters, daemon-owned
-  production voice output, and code work window. The first worker execution
-  slice now creates git worktrees for session-bound project workspaces and
-  writes profile-scoped worker artifacts.
+- Worker command/test orchestration, actual worktree cleanup removal,
+  Telegram/mobile adapters, daemon-owned production voice output, and code work
+  window. The first worker execution slice now creates git worktrees for
+  session-bound project workspaces, writes profile-scoped worker artifacts, and
+  moves terminal worktrees into review/cleanup planning states without parent
+  checkout patch application.
 - Denied-path enforcement for all mutating tools, checkpoint/rollback manager,
   dedicated profile/agent doctor commands, and media asset manifests.
 - Future daemon-owned memory architecture from `25_MEMORY_CONCEPT.md`, including
@@ -199,8 +202,10 @@ Tasks:
   finalizing as failed or completed after the cancel event.
 - Create worker worktrees and profile-scoped worker artifacts for explicit
   daemon-planned workers. Baseline now creates session-bound project worktrees
-  and writes review artifacts; real command/test execution, cleanup, and patch
-  application remain future work.
+  and writes review artifacts; real worker command/test orchestration, result
+  collection from those commands, cleanup removal, and parent patch application
+  remain future work. Any command/test execution must go through daemon-owned
+  approved tool execution inside the worker worktree, not HUD logic.
 
 Exit criteria:
 
@@ -210,6 +215,9 @@ Exit criteria:
 - Worker logs can be tailed from CLI and HUD.
 - Cancelling a session stops the active provider stream at the next callback
   boundary and preserves the AgentSession as `cancelled`.
+- Worker command/test execution, when introduced, runs inside the CADIS-owned
+  worker worktree and produces review artifacts without touching the parent
+  checkout.
 
 ### Track D - Policy, Approval, and Tool Runtime
 
@@ -224,22 +232,31 @@ Tasks:
 - Add timeouts, cancellation, and redaction boundaries.
 - Baseline now includes tool contract metadata, safe-read `file.read` and
   `file.search`, `git.status`, `git.diff`, workspace grants, approval
-  summaries, approval persistence/recovery, and redaction boundaries. Mutating
-  tools, shell execution, and full policy-gated tool execution remain future
-  work.
+  summaries, approval persistence/recovery, redaction boundaries, approved
+  `shell.run` execution, and approved structured `file.patch` execution after
+  workspace/input revalidation.
+  Remaining Track D hardening includes minimal shell environment filtering,
+  typed async tool cancellation, atomic patch writes, and broader
+  concurrent-edit protection.
 
-Execution semantics for the next Track D slice:
+Execution semantics for the Track D execution baseline and next hardening
+slice:
 
 - Treat approval as authorization to attempt execution, not as execution
   itself. After an approval is granted, `cadisd` must revalidate approval
   expiry, workspace grant, normalized input, denied paths, secret-access policy,
   and current session/worker state before `tool.started`.
 - `shell.run` must execute only inside a registered workspace or CADIS-owned
-  worker worktree with `exec` or `admin` access, filtered environment, bounded
-  stdout/stderr, exit-code reporting, timeout, and cancellation cleanup.
+  worker worktree with `exec` or `admin` access, bounded stdout/stderr,
+  exit-code reporting, timeout, and cancellation cleanup. The current baseline
+  provides cwd resolution, bounded redacted output, exit code, and timeout
+  process cleanup; a minimal environment allowlist and typed async cancellation
+  remain required before broad worker command execution is complete.
 - `file.patch` must apply only to normalized workspace-relative paths, preserve
   unrelated user edits, fail closed on context mismatch, symlink escape, denied
-  path, or concurrent change, and write atomically where practical.
+  path, or concurrent change, and write atomically where practical. The current
+  baseline supports structured replace/write operations; atomic writes and
+  richer concurrent-edit detection remain hardening work.
 - Secret access fails closed by default. A tool that may read a secret-bearing
   path, environment value, config entry, or command output needs explicit policy
   support and approval metadata before execution.
@@ -250,14 +267,19 @@ Execution semantics for the next Track D slice:
 Worker integration sequence:
 
 1. Track C/I creates an isolated worker worktree and profile-scoped artifacts.
-2. Worker command/test execution runs only inside the worker worktree after
-   Track D policy approval and tool execution support exist.
-3. Worker output produces a review artifact, normally `patch.diff` plus
-   `summary.md`.
-4. Applying that patch to the parent workspace is a separate Track D
+2. Worker command/test execution uses daemon-owned `tool.call` /
+   approval-gated `shell.run` with cwd inside the worker worktree. The HUD,
+   Tauri shell, and code work window must not run commands directly.
+3. Worker output is collected into review artifacts, normally `summary.md`,
+   `patch.diff`, `changed-files.json`, `test-report.json`, and
+   `memory-candidates.jsonl`, with long stdout/stderr kept out of the main chat.
+4. Applying a worker artifact to the parent workspace is a separate Track D
    `file.patch` or future patch-apply tool call with its own approval request.
+   `worker.completed` never authorizes parent-checkout mutation.
 5. Worker cleanup is a separate approved flow and must not delete paths without
-   a CADIS-owned worker/worktree record.
+   a CADIS-owned worker/worktree record. Terminal worker events may move
+   worktrees to `review_pending` or `cleanup_pending`, but state planning is not
+   deletion.
 
 Exit criteria:
 
@@ -404,8 +426,16 @@ Tasks:
   worktree exists.
 - Write profile-scoped worker artifacts: `summary.md`, `patch.diff`,
   `changed-files.json`, `test-report.json`, and `memory-candidates.jsonl`.
+- Execute worker commands and tests only through daemon-owned approved
+  `shell.run` with cwd inside the active worker worktree; do not run commands
+  from HUD, the code work window, or the parent checkout.
+- Collect command/test results into worker artifacts and summarize long output
+  for `worker.log.delta`, `test.result`, and code work window display.
 - Emit `worker.failed` and `worker.cancelled` with durable failure,
   cancellation, and cleanup-planning metadata.
+- Move terminal worktree metadata to `review_pending` or `cleanup_pending`;
+  actual worktree removal remains a separate approved cleanup flow requiring a
+  CADIS-owned worker/worktree record.
 - Keep the parent checkout untouched; patch application remains gated by Track D
   policy/approval work.
 - Continue surfacing worker lifecycle and log events to CLI/HUD.
@@ -418,6 +448,8 @@ Exit criteria:
   terminal cleanup state.
 - Worker artifacts are written under the profile artifact root and are redacted
   before persistence.
+- Command/test result collection can be inspected from daemon events and worker
+  artifacts without mutating the parent checkout.
 
 ## 3. P0 - Repository Foundation
 
@@ -696,7 +728,9 @@ Tasks:
 - Add git worktree creation. Baseline now creates a project-local worktree for
   session-bound git workspaces before worker execution starts.
 - Add worker log stream.
-- Add worker cleanup.
+- Add worker command/test execution through approved `shell.run` with cwd inside
+  the worker worktree.
+- Add worker cleanup planning; actual removal is a separate approved flow.
 - Add patch collection. Baseline now writes `patch.diff`, `changed-files.json`,
   `test-report.json`, `summary.md`, and `memory-candidates.jsonl` artifact files
   under the profile worker artifact root.
@@ -706,7 +740,9 @@ Exit criteria:
 
 - Coding worker edits in separate worktree.
 - Diff can be generated.
+- Command output and test results are collected as worker artifacts.
 - Patch is not applied without approval.
+- Cleanup cannot delete a worktree without CADIS-owned metadata and approval.
 
 ## 13.1 Workspace Architecture Phases
 
@@ -715,9 +751,10 @@ Goal: implement the accepted profile, agent, workspace, and worktree design in
 
 Status: partially implemented. The current implementation initializes the
 default profile home, persists workspace registry/grants, exposes workspace
-protocol/CLI commands, and gates safe-read tools behind active grants. Agent
-homes, worker worktree creation, checkpoint rollback, and full denied-path
-coverage remain future phases.
+protocol/CLI commands, gates safe-read tools behind active grants, initializes
+daemon-known agent homes, creates worker worktrees, and writes worker artifacts.
+Worker command/test execution, cleanup removal, checkpoint rollback, and full
+denied-path coverage remain future phases.
 
 Tasks:
 
@@ -731,8 +768,8 @@ Tasks:
   Baseline complete for registry/grants, broad-root rejection, and safe-read
   path guards.
 - W5: add worker worktree creation, artifact storage, and cleanup rules.
-  Baseline worktree creation and artifact storage now exist; cleanup remains
-  future work.
+  Baseline worktree creation, artifact storage, and terminal cleanup planning
+  states now exist; approved cleanup removal remains future work.
 - W6: add checkpoint/rollback before destructive or mutating operations.
 - W7: integrate workspace, grant, worker, checkpoint, and rollback events.
 - W8: add deterministic channel and cwd/project routing.
@@ -814,18 +851,27 @@ Goal: keep coding work visual and separate from chat.
 
 Tasks:
 
+- First slice: open a read-only artifact view for worker output from daemon
+  events and profile-scoped artifact references.
 - Open/focus code work window for code-heavy tasks.
 - Show file tree.
-- Show diff.
-- Show terminal output.
-- Show test results.
-- Provide apply/discard actions.
+- Show diff from `patch.diff` or daemon-provided patch preview.
+- Show terminal output summaries and bounded logs from `worker.log.delta` /
+  artifact previews.
+- Show test results from `test-report.json` and `test.result` summaries.
+- Provide apply/discard request actions that route back through daemon
+  protocol; the window must not apply patches or delete worktrees directly.
 - Link to external editor.
 
 Exit criteria:
 
 - Coding output does not flood main chat.
-- User can inspect diff and approve patch.
+- User can inspect diff, command summaries, and test results in a read-only
+  view.
+- Parent checkout patch application still goes through approval-gated
+  `file.patch` or a future patch-apply tool.
+- The code work window does not execute tools; it is a protocol client of
+  `cadisd`.
 
 ## 18. P15 - Alpha Hardening
 

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -163,14 +163,16 @@
 - [x] Define tool lifecycle events.
 - [x] Implement `file.read`.
 - [x] Implement `file.search`.
-- [ ] Implement `file.patch`.
-- [ ] Implement `shell.run`.
+- [x] Implement `file.patch`.
+- [x] Implement `shell.run`.
 - [x] Implement `git.status`.
 - [x] Implement `git.diff`.
-- [ ] Add approved execution continuation after `approval.resolved(approved)`.
+- [x] Add approved execution continuation after `approval.resolved(approved)`.
 - [ ] Revalidate workspace grants, denied paths, secret posture, and session/worker state before approved execution.
-- [ ] Add `shell.run` cwd, env filtering, stdout/stderr, exit code, timeout, and cancellation cleanup.
-- [ ] Add `file.patch` preview, context validation, atomic write, symlink escape, and concurrent-edit checks.
+- [x] Add `shell.run` approved execution with cwd, bounded stdout/stderr, exit code, timeout failure, and process cleanup on timeout.
+- [ ] Add `shell.run` minimal environment filtering and typed async cancellation cleanup.
+- [x] Add `file.patch` structured replace/write execution with replace-context validation, symlink escape, protected-path, and secret-like path checks.
+- [ ] Add `file.patch` preview UX, atomic writes, and concurrent-edit hardening.
 - [ ] Add timeouts.
 - [ ] Add cancellation.
 - [x] Add tests for success and failure.
@@ -248,10 +250,13 @@
 - [ ] Add worker cancellation.
 - [x] Generate worker diff artifact.
 - [ ] Run tests in worker.
+- [ ] Execute worker commands through approval-gated `shell.run` with cwd inside the worker worktree.
+- [ ] Collect command stdout/stderr and test results into worker artifacts.
 - [ ] Request patch approval.
 - [ ] Apply approved patch.
 - [ ] Route worker patch application through Track D `file.patch` or a future patch-apply tool.
-- [ ] Keep worker cleanup separate from patch approval and require CADIS-owned worktree metadata.
+- [x] Plan terminal worker worktree states as `review_pending` or `cleanup_pending` without parent checkout patch application.
+- [ ] Remove worker worktrees only through an approved cleanup flow requiring CADIS-owned metadata.
 - [ ] Cleanup worktree.
 - [x] Add worker isolation tests for worktree creation and artifact output.
 
@@ -340,8 +345,8 @@
   Baselines landed: AgentSession state/events, explicit daemon-owned spawn,
   spawn limits, worker registry, worker tail, and provider-stream cancellation
   on `session.cancel`. Remaining: implicit model-driven spawn, worker
-  failed/cancelled events, and real command/test execution inside worker
-  worktrees.
+  command/test orchestration, result collection from real commands, and
+  cleanup removal.
 - [ ] Track D: policy-backed tools and approval persistence.
 - [x] Track D baseline: tool contract metadata, safe-read `file.read` and
   `file.search`, `git.status`, `git.diff`, workspace grants, approval
@@ -349,8 +354,10 @@
 - [x] Track D docs/protocol alignment: approved execution semantics,
   `shell.run` and `file.patch` boundaries, timeout/cancellation expectations,
   denied paths, secret fail-closed behavior, and worker handoff sequence.
-- [ ] Track D implementation: approved `shell.run` and `file.patch` execution
-  after daemon-side revalidation.
+- [x] Track D approved execution baseline: approved `shell.run` and structured
+  `file.patch` execution after workspace/input revalidation.
+- [ ] Track D hardening: minimal shell environment allowlist, typed async tool
+  cancellation, atomic patch writes, and broader concurrent-edit protection.
 - [ ] Track E: daemon-owned voice provider path, STT language setting, and voice doctor.
 - [x] Track E baseline: daemon-visible voice status/doctor/preflight, separated
   STT language and TTS voice settings, TTS provider stubs, and speech policy
@@ -372,6 +379,10 @@
 - [x] Track I event baseline: worker failed/cancelled events carry durable
   failure, cancellation, and cleanup-planning metadata without parent checkout
   patch application.
+- [ ] Track I command/test execution: run approved worker commands in isolated
+  worktrees, collect results into artifacts, and keep parent checkout untouched.
+- [ ] Track P14 artifact view: code work window renders worker artifacts
+  read-only and routes apply/cleanup actions back through daemon approvals.
 
 ## 15.2 Workspace Architecture
 
@@ -393,6 +404,9 @@
 - [x] Add profile `artifacts/workers/` worker artifact path helpers.
 - [x] Implement worker worktree creation under project `.cadis/worktrees/`.
 - [x] Persist worker artifacts under profile `artifacts/workers/`.
+- [ ] Execute worker command/test runs inside CADIS-owned worker worktrees.
+- [ ] Collect command/test result details into worker artifacts.
+- [ ] Implement approved worker worktree cleanup/removal flow.
 - [ ] Add project `.cadis/media/` manifests for generated media.
 - [x] Add workspace doctor checks for project metadata mismatch and duplicate roots.
 - [x] Add workspace doctor checks for stale worker worktree metadata and missing artifact roots.
@@ -402,13 +416,16 @@
 
 - [ ] Detect code-heavy task.
 - [ ] Open code work window.
+- [ ] Render read-only worker artifact view from daemon events/artifact metadata.
 - [ ] Show diff viewer.
 - [ ] Show terminal logs.
 - [ ] Show test results.
+- [ ] Show changed files and worker summary artifacts.
 - [ ] Show file tree.
-- [ ] Add apply action.
-- [ ] Add discard action.
+- [ ] Add apply request action routed through approval-gated `file.patch` or a future patch-apply tool.
+- [ ] Add discard/cleanup request action routed through an approved cleanup flow.
 - [ ] Add external editor action.
+- [ ] Confirm code work window does not execute tools or read arbitrary filesystem paths directly.
 - [ ] Add code window routing tests.
 
 ## 17. Multi-Agent Tree

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -156,6 +156,14 @@ before `worker.completed` or `worker.failed`. Terminal worker events move active
 worktrees to `review_pending` or `cleanup_pending` according to cleanup policy;
 patch apply and cleanup remain separate approval-gated flows.
 
+The next worker command/test slice uses this same event shape. Commands and
+tests must be executed by `cadisd` through approval-gated `shell.run` with cwd
+inside the CADIS-owned worker worktree. HUD, Tauri, and code work window clients
+must not spawn local shells, run tests, apply patches, or delete worktrees.
+Command/test output is collected as bounded `worker.log.delta` summaries and
+profile-scoped artifacts such as `summary.md`, `patch.diff`,
+`changed-files.json`, `test-report.json`, and `memory-candidates.jsonl`.
+
 Example:
 
 ```json
@@ -258,8 +266,10 @@ the checklist.
 
 `shell.run` input must resolve to a registered workspace or CADIS-owned worker
 worktree before execution. The execution backend must use an explicit cwd,
-filtered environment, bounded stdout/stderr, exit-code reporting, timeout, and
-cleanup on cancellation. It must not inject secrets implicitly.
+bounded stdout/stderr, exit-code reporting, timeout, and cleanup on
+cancellation. A minimal environment allowlist is required before broad worker
+command/test execution is considered complete; provider keys, auth tokens, SSH
+agent details, and CADIS secrets must not be passed implicitly.
 
 `file.patch` input must be previewable before approval and must apply only to
 daemon-normalized workspace-relative paths. The current supported schema is a
@@ -290,10 +300,18 @@ mismatches. Unified diff application is reserved for a later patch backend.
 Patch writes should be atomic where practical.
 
 Worker integration uses the same protocol flow. Worker command/test execution
-runs inside the worker worktree only after Track D tool approval support exists.
+runs inside the worker worktree through daemon-owned approved `shell.run`.
 Applying a worker artifact to the parent workspace is a separate `file.patch` or
 future patch-apply tool call with its own approval; `worker.completed` alone
-does not authorize parent-checkout mutation.
+does not authorize parent-checkout mutation. Cleanup/removal of a worker
+worktree is also a separate approval-gated flow and must require a CADIS-owned
+worker/worktree record.
+
+`patch.created` and `test.result` are summary events for code-work presentation.
+They do not carry authority to mutate the parent checkout. `patch.created`
+identifies a daemon-known patch or artifact summary; `test.result` carries a
+redacted status and summary. Full review details belong in worker artifacts or a
+future daemon read-only artifact projection, not direct HUD filesystem reads.
 
 `workspace.register` adds or replaces a profile-local project workspace registry
 entry. CADIS persists the registry under

--- a/docs/21_UI_FEATURE_PARITY_CHECKLIST.md
+++ b/docs/21_UI_FEATURE_PARITY_CHECKLIST.md
@@ -210,6 +210,8 @@ This checklist tracks RamaClaw-to-CADIS UI parity. A checked item means the CADI
 - [ ] Handle streaming messages.
 - [ ] Handle approvals.
 - [x] Handle worker lifecycle.
+- [ ] Handle worker worktree and artifact metadata.
+- [ ] Handle `patch.created` and `test.result` summaries.
 - [ ] Handle route log.
 - [ ] Send message through `message.send`.
 - [ ] Send model update.
@@ -223,13 +225,29 @@ This checklist tracks RamaClaw-to-CADIS UI parity. A checked item means the CADI
 - [ ] Prototype does not use localStorage, browser storage, or UI files as authoritative durable state.
 - [ ] Prototype shows daemon connected, disconnected, and reconnecting states.
 - [ ] Prototype renders active, idle, waiting, failed, and cancelled agent states.
-- [x] Prototype renders worker lifecycle updates through `worker.event` / `worker.*` daemon events.
+- [x] Prototype renders worker lifecycle updates through `worker.*` daemon events.
+- [ ] Prototype renders worker worktree state and artifact references without
+  reading arbitrary local files.
 - [ ] Prototype renders approval lifecycle from `approval.requested` to `approval.resolved`.
 - [ ] Prototype keeps approval card visible after click until daemon resolution event.
 - [ ] Prototype confirms rename and model changes only after daemon events/responses.
 - [ ] Prototype disables unsafe actions while disconnected.
 
-## 18. Testing
+## 18. Code Work Artifact View
+
+- [ ] Open read-only code work window for code-heavy worker output.
+- [ ] Render worker summary artifact.
+- [ ] Render patch preview from `patch.diff` or daemon-provided patch summary.
+- [ ] Render changed files from `changed-files.json`.
+- [ ] Render test results from `test-report.json` and `test.result`.
+- [ ] Render bounded terminal log summaries from `worker.log.delta`.
+- [ ] Keep apply action as a daemon request that requires patch approval.
+- [ ] Keep cleanup/discard action as a daemon request that requires cleanup approval.
+- [ ] Confirm HUD/code work window never executes tools directly.
+- [ ] Confirm parent checkout patch apply still goes through approval-gated
+  `file.patch` or a future patch-apply tool.
+
+## 19. Testing
 
 - [ ] Theme helper tests.
 - [ ] Agent name normalization tests.
@@ -239,11 +257,12 @@ This checklist tracks RamaClaw-to-CADIS UI parity. A checked item means the CADI
 - [ ] Approval card waits for resolved event.
 - [ ] Gateway reconnect/backoff test.
 - [ ] Protocol event mapping tests.
+- [ ] Code work artifact view reducer/render tests.
 - [ ] Screenshot parity: 1600x1000.
 - [ ] Screenshot parity: 1920x1080.
 - [ ] No OpenClaw text/path remains in UI.
 
-## 19. Open-Source Cleanup
+## 20. Open-Source Cleanup
 
 - [ ] Replace RamaClaw brand text with CADIS.
 - [ ] Replace OpenClaw wording with CADIS daemon wording.

--- a/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
+++ b/docs/22_UI_STATE_PROTOCOL_CONTRACT.md
@@ -8,7 +8,10 @@ This document defines the daemon-backed state contract required to adapt the Ram
 
 The HUD may cache state for rendering, but `cadisd` owns durable state and all authoritative operational state.
 
-The UI must never execute tools, approve actions locally, mutate agent runtime state directly, or treat local browser storage as the source of truth.
+The UI must never execute tools, approve actions locally, mutate agent runtime
+state directly, apply worker patches, delete worktrees, or treat local browser
+storage as the source of truth. The HUD and future code work window are protocol
+clients of `cadisd`, not execution surfaces.
 
 ## 3. View Model
 
@@ -503,7 +506,25 @@ Updates worker tree and optional transient worker card.
   "status": "running",
   "cli": "cadis",
   "cwd": "/home/user/Project/app",
-  "summary": "running cargo test"
+  "summary": "running cargo test",
+  "worktree": {
+    "workspace_id": "app",
+    "project_root": "/home/user/Project/app",
+    "worktree_root": "/home/user/Project/app/.cadis/worktrees",
+    "worktree_path": "/home/user/Project/app/.cadis/worktrees/worker_auth_01",
+    "branch_name": "cadis/worker_auth_01/fix-auth",
+    "base_ref": "HEAD",
+    "state": "active",
+    "cleanup_policy": "explicit"
+  },
+  "artifacts": {
+    "root": "/home/user/.cadis/profiles/default/artifacts/workers/worker_auth_01",
+    "patch": "/home/user/.cadis/profiles/default/artifacts/workers/worker_auth_01/patch.diff",
+    "test_report": "/home/user/.cadis/profiles/default/artifacts/workers/worker_auth_01/test-report.json",
+    "summary": "/home/user/.cadis/profiles/default/artifacts/workers/worker_auth_01/summary.md",
+    "changed_files": "/home/user/.cadis/profiles/default/artifacts/workers/worker_auth_01/changed-files.json",
+    "memory_candidates": "/home/user/.cadis/profiles/default/artifacts/workers/worker_auth_01/memory-candidates.jsonl"
+  }
 }
 ```
 
@@ -513,12 +534,24 @@ Updates worker tree and optional transient worker card.
 `worker.cancelled` may include `cancellation_requested_at`. `worker.tail` returns
 recent daemon-owned log lines as `worker.log.delta` events for an existing
 worker; clients should apply those events through the same worker reducer used
-for live updates.
+for live updates. Terminal worktree states such as `review_pending` and
+`cleanup_pending` are planning states; they do not authorize patch application
+or deletion by the UI.
 
 HUD worker progress is derived from daemon events only. The worker tree may
 combine `agent.session.*` progress (`steps_used` / `budget_steps`) with
 `worker.*` status, log tail, worktree metadata, and artifact paths, but it must
 not create, execute, cancel, or approve workers locally.
+
+The P14 code work window uses the same rule. Its first slice is a read-only
+artifact view over daemon worker events, bounded log summaries, and
+daemon-provided or profile-scoped artifact references. It may render
+`summary.md`, `patch.diff`, `changed-files.json`, `test-report.json`, and
+`memory-candidates.jsonl` previews only through daemon-sanctioned read-only
+projections. It must not run commands, invoke `shell.run` directly from the
+renderer, read arbitrary filesystem paths, edit files, apply patches, or remove
+worker worktrees. Apply and cleanup buttons send daemon requests and wait for
+approval-gated results.
 
 ### `orchestrator.route`
 
@@ -605,7 +638,7 @@ validate speech policy and emit lifecycle events without external API calls.
 | `agent.*.status` | `agent.status.changed` |
 | `agent.*.task` | `agent.task.changed` |
 | `session.*.message` | `message.delta` / `message.completed` |
-| `worker.*.event` | `worker.event` |
+| `worker.*.event` | `worker.started` / `worker.log.delta` / `worker.completed` / `worker.failed` / `worker.cancelled` |
 | `approval.requested` | `approval.requested` |
 | `approval.resolved` | `approval.resolved` |
 | `orchestrator.route` | `orchestrator.route` |
@@ -670,6 +703,8 @@ Protocol adaptation is valid when:
 - All RamaClaw UI features have CADIS request/event equivalents.
 - UI preferences persist through daemon config, not localStorage.
 - Approval card lifecycle is server-confirmed.
+- Code work artifact views are read-only and route apply/cleanup back through
+  daemon approvals.
 - Rename and model selection survive HUD restart.
 - Disconnection and reconnect behavior are visible and tested.
 - `apps/cadis-hud` passes pnpm lint, typecheck, unit tests, frontend build, and

--- a/docs/standards/11_TOOL_RUNTIME_STANDARD.md
+++ b/docs/standards/11_TOOL_RUNTIME_STANDARD.md
@@ -35,14 +35,23 @@ Current implementation baseline:
 
 - `file.read`, `file.search`, `git.status`, and `git.diff` are native
   safe-read tools.
-- `shell.run`, `file.write`, `file.patch`, `git.worktree.create`, and
-  `git.worktree.remove` are classified and approval-gated placeholders.
+- `shell.run` is an approval-gated native execution backend with explicit cwd,
+  bounded redacted stdout/stderr, exit-code reporting, timeout failure, and
+  process cleanup on timeout.
+- `file.patch` is an approval-gated structured replace/write backend with
+  workspace-relative path checks, replace-context validation,
+  symlink/protected-path guards, and secret-like path rejection.
+- `file.write`, `git.worktree.create`, and `git.worktree.remove` are classified
+  and approval-gated placeholders.
 - Unknown tool names are denied before execution.
-- Approval-gated placeholders fail closed after approval resolution until their
-  execution backends are implemented.
+- Approval-gated placeholders without native execution backends fail closed
+  after approval resolution.
 - Worker orchestration may emit planned worktree and artifact metadata without
   invoking `git.worktree.create`; that event metadata is intent, not filesystem
   mutation.
+- Worker command/test execution is not complete until it runs through
+  daemon-owned approved `shell.run` inside CADIS-owned worker worktrees and
+  records result artifacts.
 
 ## 3. Naming
 
@@ -174,11 +183,18 @@ Requirements:
 Commands that mutate system state, use `sudo`, install packages, delete files, alter protected git refs, or access secrets must require approval.
 
 Track D implementation must keep `shell.run` inside a registered workspace or
-CADIS-owned worker worktree. The environment starts from a minimal allowlist;
-provider keys, auth tokens, SSH agent details, and CADIS secrets are not passed
-unless a later explicit secret-access policy permits it. Cancellation must stop
-the child process and clean up any process group or temporary files where the
-platform supports it.
+CADIS-owned worker worktree. The target environment starts from a minimal
+allowlist; provider keys, auth tokens, SSH agent details, and CADIS secrets are
+not passed unless a later explicit secret-access policy permits it.
+Cancellation must stop the child process and clean up any process group or
+temporary files where the platform supports it.
+
+Current baseline note: approved `shell.run` can execute after approval and
+daemon-side workspace/grant revalidation, captures bounded redacted output,
+reports exit code, and kills the process group on timeout. Minimal environment
+filtering and typed async cancellation remain hardening requirements, so broad
+worker command/test execution must not be considered complete until those are
+covered.
 
 ## 9. File Tools
 
@@ -206,7 +222,14 @@ Patch application must preserve user changes and should fail closed on mismatche
 Worker patch application is not implicit. A worker may create `patch.diff` and
 `summary.md` artifacts, but applying that patch to the parent workspace is a
 separate `file.patch` or future patch-apply tool call with its own policy
-decision and approval.
+decision and approval. `worker.completed` is never authorization to mutate the
+parent checkout.
+
+Current baseline note: approved `file.patch` supports structured `replace` and
+`write` operations after approval, validates workspace-relative targets,
+rejects protected metadata paths and secret-like paths, and fails closed when
+replace context is missing or ambiguous. Atomic temp-file writes, full preview
+UX, and broader concurrent-edit hardening remain required.
 
 ## 10. Git Tools
 
@@ -226,6 +249,9 @@ Rules:
   `planned` to `active` only after successful creation.
 - `git.worktree.remove` must require a CADIS-owned worker/worktree record and
   preserve artifacts unless an explicit cleanup policy says otherwise.
+- Terminal worker states such as `review_pending` and `cleanup_pending` are
+  cleanup planning metadata, not deletion. Actual worktree removal must be a
+  separate approval-gated flow.
 - Push, force-push, rebase, reset, and branch deletion are not initial native tool actions unless policy and approval coverage exist.
 
 ## 11. Cancellation and Timeouts
@@ -268,6 +294,9 @@ Required tests:
 - symlink boundary handling
 - shell timeout and cancellation
 - file patch conflict handling
+- worker command/test execution stays inside the worker worktree
+- worker result artifacts are redacted before persistence
+- worker cleanup refuses paths without CADIS-owned worktree metadata
 - tool lifecycle event ordering
 - redaction before persistence
 - policy denial prevents execution

--- a/docs/standards/15_UI_HUD_STANDARD.md
+++ b/docs/standards/15_UI_HUD_STANDARD.md
@@ -16,6 +16,8 @@ Rules:
 - The HUD may keep ephemeral render state.
 - The HUD must not execute tools.
 - The HUD must not approve actions locally.
+- The HUD and future code work window must not spawn shells, run tests, apply
+  patches, or remove worker worktrees directly.
 - The HUD must not treat browser local storage as authoritative.
 - All config writes must route through daemon protocol.
 - All agent, model, approval, and voice state must be derived from daemon responses and events.
@@ -264,7 +266,13 @@ message.delta
 message.completed
 approval.requested
 approval.resolved
-worker.event
+worker.started
+worker.log.delta
+worker.completed
+worker.failed
+worker.cancelled
+patch.created
+test.result
 orchestrator.route
 ui.preferences.updated
 voice.preview.started
@@ -272,7 +280,27 @@ voice.preview.completed
 voice.preview.failed
 ```
 
-## 14. Open-Source Cleanup
+## 14. Code Work Artifact View
+
+The P14 code work window is a protocol client and a read-only review surface for
+the first implementation slice.
+
+Rules:
+
+- Render worker status, worktree state, and artifact metadata from daemon
+  `worker.*`, `patch.created`, and `test.result` events.
+- Show `summary.md`, `patch.diff`, `changed-files.json`, `test-report.json`,
+  and bounded terminal log previews only through daemon-sanctioned read-only
+  projections.
+- Do not read arbitrary local filesystem paths from the renderer.
+- Do not execute `shell.run`, run tests, edit files, apply patches, or delete
+  worktrees from the UI process.
+- Apply actions must route to approval-gated `file.patch` or a future
+  patch-apply tool owned by `cadisd`.
+- Discard or cleanup actions must route to a separate approved cleanup flow that
+  verifies CADIS-owned worker/worktree metadata.
+
+## 15. Open-Source Cleanup
 
 Before public release:
 
@@ -283,7 +311,7 @@ Before public release:
 - recreate icons as CADIS assets when needed
 - verify no provider keys or local config values are committed
 
-## 15. Testing Requirements
+## 16. Testing Requirements
 
 Required HUD tests:
 
@@ -295,6 +323,7 @@ Required HUD tests:
 - approval card waits for resolved event
 - reconnect and backoff test
 - protocol event mapping tests
+- code work artifact view reducer/render tests
 - screenshot parity at 1600x1000
 - screenshot parity at 1920x1080
 - minimum size check at 1200x760


### PR DESCRIPTION
## Summary
- align docs/checklists with Track I/C/P14 worker execution and artifact review boundaries
- clarify read-only HUD code work window behavior and approval-gated parent patch apply
- keep pending items unchecked where implementation remains partial

## Validation
- git diff --check HEAD~1..HEAD
- rg protocol/checklist sanity scans
- touched docs secret/local-path scan