### PR TITLE
Add HUD code work artifact panel

### DIFF
--- a/apps/cadis-hud/src/App.tsx
+++ b/apps/cadis-hud/src/App.tsx
@@ -9,6 +9,7 @@ import { ConfigDialog } from "./ui/settings/ConfigDialog.js";
 import { AgentRenameDialog } from "./ui/settings/AgentRenameDialog.js";
 import { ApprovalStack } from "./ui/approvals/ApprovalStack.js";
 import { connect, disconnect } from "./ui/cadisActions.js";
+import { CodeWorkPanel } from "./ui/codework/CodeWorkPanel.js";
 
 export function App() {
   const theme = useHud((s) => s.theme);
@@ -39,6 +40,7 @@ export function App() {
       <main className="rama-shell__main">
         <OrbitalHUD />
         <ApprovalStack />
+        <CodeWorkPanel />
       </main>
       <ChatPanel />
       <ConfigDialog />

--- a/apps/cadis-hud/src/styles/globals.css
+++ b/apps/cadis-hud/src/styles/globals.css
@@ -1732,6 +1732,7 @@ html, body, #root {
 }
 .worker-tree__toggle:hover { color: var(--accent); }
 .worker-tree__list { list-style: none; padding: 4px 0 0 14px; margin: 0; }
+.worker-tree__row { margin: 0; padding: 0; }
 .worker-tree__item {
   display: grid;
   grid-template-columns: 8px minmax(68px, auto) auto minmax(0, 1fr) 42px;
@@ -1739,6 +1740,24 @@ html, body, #root {
   align-items: center;
   padding: 2px 0;
   color: var(--dim);
+}
+.worker-tree__item--button {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.worker-tree__item--button:hover {
+  border-color: var(--border-d);
+  background: oklch(0.18 0.03 var(--hue) / 0.34);
+  color: var(--text);
+}
+.worker-tree__item--button[data-selected="true"] {
+  border-color: var(--accent-d);
+  background: oklch(0.20 0.04 var(--hue) / 0.46);
 }
 .worker-tree__dot { width: 6px; height: 6px; border-radius: 50%; }
 .worker-tree__id { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -1770,6 +1789,245 @@ html, body, #root {
 @keyframes worker-progress-pulse {
   0%, 100% { opacity: 0.46; }
   50% { opacity: 0.95; }
+}
+
+/* ─── Code work panel (P14) ─── */
+
+.code-work-panel {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 8;
+  width: min(420px, calc(100% - 24px));
+  max-width: 38vw;
+  min-width: 340px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background:
+    linear-gradient(180deg, oklch(0.15 0.025 var(--hue) / 0.92), oklch(0.09 0.016 var(--hue) / 0.88));
+  box-shadow:
+    0 18px 50px rgba(0, 0, 0, 0.44),
+    inset 0 0 24px oklch(0.78 0.16 var(--hue) / 0.04);
+  font-family: var(--mono);
+  overflow: hidden;
+}
+
+.code-work-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 9px;
+  border-bottom: 1px solid var(--border-d);
+}
+
+.code-work-panel__eyebrow {
+  display: block;
+  color: var(--faint);
+  font-size: 9px;
+  letter-spacing: 0.18em;
+}
+
+.code-work-panel__header h2 {
+  margin: 3px 0 0;
+  max-width: 300px;
+  overflow: hidden;
+  color: var(--accent);
+  font-size: 14px;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.code-work-panel__close {
+  flex: 0 0 auto;
+  min-width: 28px;
+  height: 24px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--dim);
+  font-family: var(--mono);
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.code-work-panel__close:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.code-work-panel__statusline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 22px;
+  color: var(--dim);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.code-work-panel__status {
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  padding: 3px 7px;
+  line-height: 1;
+}
+
+.code-work-panel__status--ok { color: var(--ok); }
+.code-work-panel__status--warn { color: var(--warn); }
+.code-work-panel__status--err { color: var(--err); }
+.code-work-panel__status--dim { color: var(--faint); }
+
+.code-work-panel__section {
+  min-height: 0;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-d);
+}
+
+.code-work-panel__section h3 {
+  margin: 0 0 7px;
+  color: var(--dim);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.code-work-panel__summary,
+.code-work-panel__empty {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.code-work-panel__empty {
+  color: var(--faint);
+}
+
+.code-work-panel__fields {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+}
+
+.code-work-panel__field {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 8px;
+  align-items: start;
+}
+
+.code-work-panel__field dt {
+  color: var(--faint);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.code-work-panel__field dd {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  margin: 0;
+}
+
+.code-work-panel__field code {
+  display: block;
+  overflow: hidden;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 10px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.code-work-panel__field code.code-work-panel__missing {
+  color: var(--faint);
+  font-style: italic;
+}
+
+.code-work-panel__artifact-status {
+  justify-self: start;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  padding: 2px 5px;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+}
+
+.code-work-panel__artifact-status--ok { color: var(--ok); }
+.code-work-panel__artifact-status--warn { color: var(--warn); }
+.code-work-panel__artifact-status--err { color: var(--err); }
+.code-work-panel__artifact-status--dim { color: var(--faint); }
+
+.code-work-panel__log {
+  max-height: 132px;
+  margin: 0;
+  padding: 7px 8px 7px 28px;
+  overflow: auto;
+  border: 1px solid var(--border-d);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.24);
+  color: var(--faint);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.code-work-panel__log li + li { margin-top: 3px; }
+.code-work-panel__log code { color: var(--dim); font-family: var(--mono); }
+
+.code-work-panel__actions {
+  display: grid;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-d);
+}
+
+.code-work-panel__actions p {
+  margin: 0;
+  color: var(--faint);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.code-work-panel__actions div {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.code-work-panel__actions button {
+  border: 1px solid var(--border-d);
+  border-radius: 4px;
+  background: oklch(0.12 0.02 var(--hue) / 0.5);
+  color: var(--faint);
+  padding: 5px 12px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+}
+
+.code-work-panel__actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.56;
+}
+
+@media (max-width: 1120px) {
+  .code-work-panel {
+    left: 12px;
+    max-width: none;
+    min-width: 0;
+  }
 }
 
 /* ─── Theme picker (P5.6) ─── */

--- a/apps/cadis-hud/src/ui/cadisActions.test.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.test.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import {
   _resetCadisActionsForTest,
@@ -12,6 +12,7 @@ import {
   sendVoicePreflight,
 } from "./cadisActions.js";
 import { useHud } from "./hudState.js";
+import { CodeWorkPanel } from "./codework/CodeWorkPanel.js";
 import { WorkerTree } from "./orbital/WorkerTree.js";
 import { mockCadisDaemonWorkerStream } from "./fixtures/mockCadisDaemonEventStream.js";
 
@@ -46,6 +47,8 @@ beforeEach(() => {
     chat: [],
     approvals: [],
     workers: [],
+    selectedWorkerId: null,
+    codeWorkPanelOpen: false,
     voiceStatus: null,
     voiceDoctor: null,
     gateway: "disconnected",
@@ -422,6 +425,7 @@ describe("cadisActions", () => {
         artifacts: {
           summary: "/home/user/.cadis/artifacts/workers/worker_mock_001/summary.md",
           testReport: "/home/user/.cadis/artifacts/workers/worker_mock_001/test-report.json",
+          testReportStatus: "passed",
         },
       },
     ]);
@@ -432,6 +436,48 @@ describe("cadisActions", () => {
     expect(screen.getByText("ags_mock_001")).toBeInTheDocument();
     expect(screen.getByText("worker_mock_001")).toBeInTheDocument();
     expect(screen.getByText(/focused HUD worker tests passed/)).toBeInTheDocument();
+  });
+
+  it("opens a code work panel from the worker tree using mock daemon worker state", () => {
+    for (const frame of mockCadisDaemonWorkerStream) {
+      handleCadisFrameForTest(frame);
+    }
+    useHud.getState().setCodeWorkPanelOpen(false);
+
+    render(
+      createElement(
+        "div",
+        null,
+        createElement(WorkerTree, { agentId: "codex" }),
+        createElement(CodeWorkPanel),
+      ),
+    );
+
+    expect(screen.queryByRole("complementary", { name: "Code work" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open code work for worker_mock_001" }));
+
+    expect(screen.getByRole("complementary", { name: "Code work" })).toBeInTheDocument();
+    expect(screen.getAllByText("worker_mock_001").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("completed: focused HUD worker tests passed").length).toBeGreaterThan(0);
+    expect(screen.getByText(".cadis/worktrees/worker_mock_001")).toBeInTheDocument();
+    expect(screen.getByText("/home/user/.cadis/artifacts/workers/worker_mock_001/patch.diff")).toBeInTheDocument();
+    expect(screen.getByText("/home/user/.cadis/artifacts/workers/worker_mock_001/test-report.json")).toBeInTheDocument();
+    expect(screen.getByText("PASSED")).toBeInTheDocument();
+    expect(screen.getByText("started: Worker Coding: run focused HUD worker tests")).toBeInTheDocument();
+  });
+
+  it("does not execute tools directly from the apply placeholder", () => {
+    for (const frame of mockCadisDaemonWorkerStream) {
+      handleCadisFrameForTest(frame);
+    }
+    invokeMock.mockClear();
+
+    render(createElement(CodeWorkPanel));
+
+    const apply = screen.getByRole("button", { name: "APPLY" });
+    expect(apply).toBeDisabled();
+    fireEvent.click(apply);
+    expect(invokeMock).not.toHaveBeenCalled();
   });
 
   it("computes bounded reconnect backoff", () => {

--- a/apps/cadis-hud/src/ui/cadisActions.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.ts
@@ -1097,8 +1097,12 @@ function readWorkerArtifacts(value: unknown): WorkerArtifactInfo | undefined {
   const summary = stringFrom(artifacts.summary);
   const patch = stringFrom(artifacts.patch);
   const testReport = stringFrom(artifacts.test_report);
-  if (!summary && !patch && !testReport) return undefined;
-  return { summary, patch, testReport };
+  const testReportStatus =
+    stringFrom(artifacts.test_report_status) ??
+    stringFrom(artifacts.test_status) ??
+    stringFrom(artifacts.tests_status);
+  if (!summary && !patch && !testReport && !testReportStatus) return undefined;
+  return { summary, patch, testReport, testReportStatus };
 }
 
 function readSessionId(envelope: CadisEnvelope): string | undefined {

--- a/apps/cadis-hud/src/ui/chat/ChatPanel.test.tsx
+++ b/apps/cadis-hud/src/ui/chat/ChatPanel.test.tsx
@@ -51,6 +51,8 @@ beforeEach(() => {
     chat: [],
     approvals: [],
     workers: [],
+    selectedWorkerId: null,
+    codeWorkPanelOpen: false,
     voiceState: "idle",
     voicePrefs: DEFAULT_VOICE_PREFS,
   });

--- a/apps/cadis-hud/src/ui/codework/CodeWorkPanel.tsx
+++ b/apps/cadis-hud/src/ui/codework/CodeWorkPanel.tsx
@@ -1,0 +1,168 @@
+import { useMemo } from "react";
+import { useHud, type WorkerRecord } from "../hudState.js";
+
+const EMPTY_VALUE = "not reported by daemon";
+
+export function CodeWorkPanel() {
+  const open = useHud((s) => s.codeWorkPanelOpen);
+  const selectedWorkerId = useHud((s) => s.selectedWorkerId);
+  const workers = useHud((s) => s.workers);
+  const agents = useHud((s) => s.agents);
+  const setOpen = useHud((s) => s.setCodeWorkPanelOpen);
+
+  const worker = selectedWorkerId
+    ? workers.find((candidate) => candidate.id === selectedWorkerId)
+    : null;
+  const owner = worker
+    ? agents.find((agent) => agent.spec.id === (worker.agentId ?? worker.parentAgentId))
+    : null;
+  const logLines = useMemo(() => recentLogLines(worker?.logTail ?? []), [worker?.logTail]);
+
+  if (!open) return null;
+
+  return (
+    <aside className="code-work-panel" aria-label="Code work">
+      <header className="code-work-panel__header">
+        <div>
+          <span className="code-work-panel__eyebrow">CODE WORK</span>
+          <h2>{worker ? compactId(worker.id) : "No worker selected"}</h2>
+        </div>
+        <button
+          type="button"
+          className="code-work-panel__close"
+          onClick={() => setOpen(false)}
+          aria-label="Close code work panel"
+        >
+          X
+        </button>
+      </header>
+
+      {worker ? (
+        <>
+          <div className="code-work-panel__statusline">
+            <span className={`code-work-panel__status code-work-panel__status--${statusTone(worker.status)}`}>
+              {worker.status}
+            </span>
+            <span>{owner?.spec.name ?? worker.agentId ?? worker.parentAgentId ?? "daemon worker"}</span>
+          </div>
+
+          <section className="code-work-panel__section" aria-labelledby="code-work-summary">
+            <h3 id="code-work-summary">Summary</h3>
+            <p className="code-work-panel__summary">{workerSummary(worker)}</p>
+          </section>
+
+          <section className="code-work-panel__section" aria-labelledby="code-work-artifacts">
+            <h3 id="code-work-artifacts">Daemon Artifacts</h3>
+            <dl className="code-work-panel__fields">
+              <Field label="Worktree path" value={worker.worktree?.worktreePath} />
+              <Field label="Worker cwd" value={worker.cwd} />
+              <Field label="Diff/Patch" value={worker.artifacts?.patch} />
+              <Field
+                label="Test report"
+                value={worker.artifacts?.testReport}
+                status={worker.artifacts?.testReportStatus}
+              />
+            </dl>
+          </section>
+
+          <section className="code-work-panel__section" aria-labelledby="code-work-log">
+            <h3 id="code-work-log">Recent Log Tail</h3>
+            {logLines.length ? (
+              <ol className="code-work-panel__log">
+                {logLines.map((line, index) => (
+                  <li key={`${index}-${line}`}>
+                    <code>{line}</code>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p className="code-work-panel__empty">No daemon log tail published.</p>
+            )}
+          </section>
+        </>
+      ) : (
+        <p className="code-work-panel__empty">
+          Select a daemon worker from the worker tree to inspect its worktree, artifacts, and log tail.
+        </p>
+      )}
+
+      <footer className="code-work-panel__actions">
+        <p>
+          Placeholders only: apply/discard must be daemon-mediated; this HUD panel does not execute
+          tools directly.
+        </p>
+        <div>
+          <button type="button" disabled title="Placeholder only - no local tool execution">
+            APPLY
+          </button>
+          <button type="button" disabled title="Placeholder only - no local tool execution">
+            DISCARD
+          </button>
+        </div>
+      </footer>
+    </aside>
+  );
+}
+
+function Field({
+  label,
+  value,
+  status,
+}: {
+  label: string;
+  value?: string;
+  status?: string;
+}) {
+  const hasValue = Boolean(value?.trim());
+  const displayValue = value?.trim() || EMPTY_VALUE;
+  const statusLabel = status?.trim();
+
+  return (
+    <div className="code-work-panel__field">
+      <dt>{label}</dt>
+      <dd>
+        <code className={!hasValue ? "code-work-panel__missing" : undefined} title={displayValue}>
+          {displayValue}
+        </code>
+        {label === "Test report" ? (
+          <span className={`code-work-panel__artifact-status code-work-panel__artifact-status--${artifactTone(statusLabel)}`}>
+            {statusLabel ? statusLabel.toUpperCase() : "STATUS NOT REPORTED"}
+          </span>
+        ) : null}
+      </dd>
+    </div>
+  );
+}
+
+function workerSummary(worker: WorkerRecord): string {
+  return worker.summary ?? worker.lastText ?? worker.reason ?? "No worker summary published yet.";
+}
+
+function recentLogLines(chunks: string[]): string[] {
+  return chunks
+    .flatMap((chunk) => chunk.split(/\r?\n/))
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(-6);
+}
+
+function statusTone(status: WorkerRecord["status"]): "ok" | "warn" | "err" | "dim" {
+  if (status === "completed") return "ok";
+  if (status === "failed") return "err";
+  if (status === "cancelled") return "dim";
+  return "warn";
+}
+
+function artifactTone(status: string | undefined): "ok" | "warn" | "err" | "dim" {
+  const normalized = status?.toLowerCase() ?? "";
+  if (normalized.includes("pass") || normalized.includes("ok") || normalized.includes("success")) {
+    return "ok";
+  }
+  if (normalized.includes("fail") || normalized.includes("error")) return "err";
+  if (normalized.includes("run") || normalized.includes("pending")) return "warn";
+  return "dim";
+}
+
+function compactId(id: string): string {
+  return id.length > 28 ? `${id.slice(0, 25)}...` : id;
+}

--- a/apps/cadis-hud/src/ui/fixtures/mockCadisDaemonEventStream.ts
+++ b/apps/cadis-hud/src/ui/fixtures/mockCadisDaemonEventStream.ts
@@ -91,6 +91,7 @@ export const mockCadisDaemonWorkerStream: MockCadisFrame[] = [
           root: "/home/user/.cadis/artifacts/workers/worker_mock_001",
           patch: "/home/user/.cadis/artifacts/workers/worker_mock_001/patch.diff",
           test_report: "/home/user/.cadis/artifacts/workers/worker_mock_001/test-report.json",
+          test_report_status: "passed",
           summary: "/home/user/.cadis/artifacts/workers/worker_mock_001/summary.md",
           changed_files: "/home/user/.cadis/artifacts/workers/worker_mock_001/changed-files.json",
           memory_candidates: "/home/user/.cadis/artifacts/workers/worker_mock_001/memory-candidates.jsonl",

--- a/apps/cadis-hud/src/ui/hudLiveProgress.acceptance.test.tsx
+++ b/apps/cadis-hud/src/ui/hudLiveProgress.acceptance.test.tsx
@@ -52,6 +52,8 @@ beforeEach(() => {
     chat: [],
     approvals: [],
     workers: [],
+    selectedWorkerId: null,
+    codeWorkPanelOpen: false,
     avatarStyle: "orb",
     voiceState: "idle",
     voicePrefs: DEFAULT_VOICE_PREFS,

--- a/apps/cadis-hud/src/ui/hudState.ts
+++ b/apps/cadis-hud/src/ui/hudState.ts
@@ -80,6 +80,7 @@ export type WorkerArtifactInfo = {
   summary?: string;
   patch?: string;
   testReport?: string;
+  testReportStatus?: string;
 };
 
 export type WorkerRecord = {
@@ -139,6 +140,8 @@ export type HudStore = {
   chat: ChatMessage[];
   approvals: ApprovalRecord[];
   workers: WorkerRecord[];
+  selectedWorkerId: string | null;
+  codeWorkPanelOpen: boolean;
   theme: ThemeKey;
   avatarStyle: AvatarStyle;
   voiceState: "idle" | "listening" | "thinking" | "speaking";
@@ -179,6 +182,8 @@ export type HudStore = {
   pushApproval: (a: ApprovalRecord) => void;
   removeApproval: (id: string) => void;
   upsertAgentSession: (session: AgentSessionRecord) => void;
+  selectWorker: (id: string) => void;
+  setCodeWorkPanelOpen: (open: boolean) => void;
   upsertWorker: (w: WorkerRecord) => void;
   removeWorker: (id: string) => void;
 };
@@ -249,6 +254,8 @@ export const useHud = create<HudStore>((set) => ({
   chat: [],
   approvals: [],
   workers: [],
+  selectedWorkerId: null,
+  codeWorkPanelOpen: false,
   theme: "arc",
   avatarStyle: "orb",
   voiceState: "idle",
@@ -354,18 +361,36 @@ export const useHud = create<HudStore>((set) => ({
       next[idx] = { ...next[idx]!, ...definedSession };
       return { agentSessions: next };
     }),
+  selectWorker: (selectedWorkerId) => set({ selectedWorkerId, codeWorkPanelOpen: true }),
+  setCodeWorkPanelOpen: (codeWorkPanelOpen) => set({ codeWorkPanelOpen }),
   upsertWorker: (worker) =>
     set((s) => {
       const idx = s.workers.findIndex((candidate) => candidate.id === worker.id);
-      if (idx === -1) return { workers: [...s.workers, worker] };
+      const shouldAutoSelect = s.selectedWorkerId === null;
+      if (idx === -1) {
+        return {
+          workers: [...s.workers, worker],
+          selectedWorkerId: shouldAutoSelect ? worker.id : s.selectedWorkerId,
+          codeWorkPanelOpen: shouldAutoSelect ? true : s.codeWorkPanelOpen,
+        };
+      }
       const next = [...s.workers];
       const definedWorker = Object.fromEntries(
         Object.entries(worker).filter(([, value]) => value !== undefined),
       ) as WorkerRecord;
       next[idx] = { ...next[idx]!, ...definedWorker };
-      return { workers: next };
+      return {
+        workers: next,
+        selectedWorkerId: shouldAutoSelect ? worker.id : s.selectedWorkerId,
+        codeWorkPanelOpen: shouldAutoSelect ? true : s.codeWorkPanelOpen,
+      };
     }),
-  removeWorker: (id) => set((s) => ({ workers: s.workers.filter((w) => w.id !== id) })),
+  removeWorker: (id) =>
+    set((s) => ({
+      workers: s.workers.filter((w) => w.id !== id),
+      selectedWorkerId: s.selectedWorkerId === id ? null : s.selectedWorkerId,
+      codeWorkPanelOpen: s.selectedWorkerId === id ? false : s.codeWorkPanelOpen,
+    })),
 }));
 
 export const selectApprovals = (s: HudStore): ApprovalRecord[] => s.approvals;

--- a/apps/cadis-hud/src/ui/orbital/WorkerTree.tsx
+++ b/apps/cadis-hud/src/ui/orbital/WorkerTree.tsx
@@ -52,6 +52,8 @@ function sessionBelongsTo(s: AgentSessionRecord, agentId: string): boolean {
 export function WorkerTree({ agentId, defaultOpen }: WorkerTreeProps) {
   const all = useHud(selectWorkers);
   const allSessions = useHud(selectAgentSessions);
+  const selectedWorkerId = useHud((s) => s.selectedWorkerId);
+  const selectWorker = useHud((s) => s.selectWorker);
   const workers = all.filter((w) => workerBelongsTo(w, agentId));
   const sessions = allSessions.filter((s) => sessionBelongsTo(s, agentId));
   const [open, setOpen] = useState(defaultOpen ?? true);
@@ -90,18 +92,28 @@ export function WorkerTree({ agentId, defaultOpen }: WorkerTreeProps) {
             </li>
           ))}
           {workers.map((w) => (
-            <li key={w.id} className="worker-tree__item" data-status={w.status}>
-              <span
-                className="worker-tree__dot"
-                style={{ background: STATUS_COLOR[w.status] }}
-                aria-hidden
-              />
-              <span className="worker-tree__id" title={w.id}>{compactId(w.id)}</span>
-              <span className="worker-tree__status">{w.status}</span>
-              <span className="worker-tree__text" title={workerTitle(w)}>
-                {workerText(w)}
-              </span>
-              <ProgressBar value={workerProgress(w)} indeterminate={w.status === "running"} />
+            <li key={w.id} className="worker-tree__row">
+              <button
+                type="button"
+                className="worker-tree__item worker-tree__item--button"
+                data-status={w.status}
+                data-selected={selectedWorkerId === w.id ? "true" : undefined}
+                onClick={() => selectWorker(w.id)}
+                aria-label={`Open code work for ${w.id}`}
+                aria-current={selectedWorkerId === w.id ? "true" : undefined}
+              >
+                <span
+                  className="worker-tree__dot"
+                  style={{ background: STATUS_COLOR[w.status] }}
+                  aria-hidden
+                />
+                <span className="worker-tree__id" title={w.id}>{compactId(w.id)}</span>
+                <span className="worker-tree__status">{w.status}</span>
+                <span className="worker-tree__text" title={workerTitle(w)}>
+                  {workerText(w)}
+                </span>
+                <ProgressBar value={workerProgress(w)} indeterminate={w.status === "running"} />
+              </button>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- add read-only code work panel driven by worker artifacts and log tail
- allow worker tree rows to select/open a worker review panel
- keep apply/discard placeholders disabled and free of direct tool execution

## Validation
- cd apps/cadis-hud && pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build