### PR TITLE
Add read-only worker result collection

### DIFF
--- a/crates/cadis-cli/src/main.rs
+++ b/crates/cadis-cli/src/main.rs
@@ -12,10 +12,11 @@ use cadis_protocol::{
     ErrorPayload, EventId, EventSubscriptionRequest, EventsSnapshotRequest, MessageSendRequest,
     ModelsListPayload, RequestEnvelope, RequestId, ServerFrame, SessionId,
     SessionSubscriptionRequest, ToolCallRequest, VoiceDoctorPayload, VoiceDoctorRequest,
-    VoiceRuntimeState, VoiceStatusPayload, WorkerTailRequest, WorkspaceAccess,
-    WorkspaceDoctorPayload, WorkspaceDoctorRequest, WorkspaceGrantPayload, WorkspaceGrantRequest,
-    WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest, WorkspaceRecordPayload,
-    WorkspaceRegisterRequest, WorkspaceRevokeRequest,
+    VoiceRuntimeState, VoiceStatusPayload, WorkerArtifactLocations, WorkerEventPayload,
+    WorkerResultRequest, WorkerTailRequest, WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent,
+    WorkerWorktreeState, WorkspaceAccess, WorkspaceDoctorPayload, WorkspaceDoctorRequest,
+    WorkspaceGrantPayload, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceListPayload,
+    WorkspaceListRequest, WorkspaceRecordPayload, WorkspaceRegisterRequest, WorkspaceRevokeRequest,
 };
 use cadis_store::load_config;
 
@@ -333,9 +334,18 @@ fn run_worker(cli: &Cli, command: &WorkerCommand) -> Result<(), Box<dyn Error>> 
                 lines: *lines,
             }),
         )?,
+        WorkerCommand::Result { worker_id } => send_request(
+            cli,
+            ClientRequest::WorkerResult(WorkerResultRequest {
+                worker_id: worker_id.clone(),
+            }),
+        )?,
     };
 
-    render_worker_tail(&frames, cli.json)
+    match command {
+        WorkerCommand::Tail { .. } => render_worker_tail(&frames, cli.json),
+        WorkerCommand::Result { .. } => render_worker_result(&frames, cli.json),
+    }
 }
 
 fn send_request(cli: &Cli, request: ClientRequest) -> Result<Vec<ServerFrame>, Box<dyn Error>> {
@@ -820,6 +830,150 @@ fn render_worker_tail(frames: &[ServerFrame], json: bool) -> Result<(), Box<dyn 
     Ok(())
 }
 
+fn render_worker_result(frames: &[ServerFrame], json: bool) -> Result<(), Box<dyn Error>> {
+    if json {
+        return print_json_frames(frames);
+    }
+
+    render_rejections(frames)?;
+    let mut worker_result = None;
+    let mut agent_session_result = None;
+
+    for frame in frames {
+        let ServerFrame::Event(event) = frame else {
+            continue;
+        };
+        match &event.event {
+            cadis_protocol::CadisEvent::WorkerCompleted(payload)
+            | cadis_protocol::CadisEvent::WorkerFailed(payload)
+            | cadis_protocol::CadisEvent::WorkerCancelled(payload) => {
+                worker_result = Some(payload);
+            }
+            cadis_protocol::CadisEvent::AgentSessionCompleted(payload)
+            | cadis_protocol::CadisEvent::AgentSessionFailed(payload)
+            | cadis_protocol::CadisEvent::AgentSessionCancelled(payload) => {
+                agent_session_result = Some(payload);
+            }
+            _ => {}
+        }
+    }
+
+    let worker =
+        worker_result.ok_or_else(|| invalid_data("daemon did not return a worker result"))?;
+    print_worker_result(worker);
+    if let Some(agent_session) = agent_session_result {
+        println!("agent_session: {}", agent_session.agent_session_id);
+        println!(
+            "agent_session_status: {}",
+            agent_session_status_label(agent_session.status)
+        );
+        if let Some(result) = &agent_session.result {
+            println!("agent_result: {result}");
+        }
+        if let Some(error_code) = &agent_session.error_code {
+            println!("agent_error_code: {error_code}");
+        }
+        if let Some(error) = &agent_session.error {
+            println!("agent_error: {error}");
+        }
+    }
+    Ok(())
+}
+
+fn print_worker_result(worker: &WorkerEventPayload) {
+    println!("worker: {}", worker.worker_id);
+    println!("status: {}", worker.status.as_deref().unwrap_or("unknown"));
+    if let Some(agent_id) = &worker.agent_id {
+        println!("agent: {agent_id}");
+    }
+    if let Some(parent_agent_id) = &worker.parent_agent_id {
+        println!("parent_agent: {parent_agent_id}");
+    }
+    if let Some(agent_session_id) = &worker.agent_session_id {
+        println!("linked_agent_session: {agent_session_id}");
+    }
+    if let Some(summary) = &worker.summary {
+        println!("summary: {summary}");
+    }
+    if let Some(error_code) = &worker.error_code {
+        println!("error_code: {error_code}");
+    }
+    if let Some(error) = &worker.error {
+        println!("error: {error}");
+    }
+    if let Some(cancelled_at) = &worker.cancellation_requested_at {
+        println!("cancellation_requested_at: {cancelled_at}");
+    }
+    if let Some(worktree) = &worker.worktree {
+        print_worker_worktree(worktree);
+    }
+    if let Some(artifacts) = &worker.artifacts {
+        print_worker_artifacts(artifacts);
+    }
+}
+
+fn print_worker_worktree(worktree: &WorkerWorktreeIntent) {
+    if let Some(workspace_id) = &worktree.workspace_id {
+        println!("workspace: {workspace_id}");
+    }
+    if let Some(project_root) = &worktree.project_root {
+        println!("project_root: {project_root}");
+    }
+    println!("worktree_root: {}", worktree.worktree_root);
+    println!("worktree: {}", worktree.worktree_path);
+    println!("branch: {}", worktree.branch_name);
+    if let Some(base_ref) = &worktree.base_ref {
+        println!("base_ref: {base_ref}");
+    }
+    println!(
+        "worktree_state: {}",
+        worker_worktree_state_label(worktree.state)
+    );
+    println!(
+        "cleanup_policy: {}",
+        worker_cleanup_policy_label(worktree.cleanup_policy)
+    );
+}
+
+fn print_worker_artifacts(artifacts: &WorkerArtifactLocations) {
+    println!("artifact_root: {}", artifacts.root);
+    println!("summary_path: {}", artifacts.summary);
+    println!("patch_path: {}", artifacts.patch);
+    println!("test_report_path: {}", artifacts.test_report);
+    println!("changed_files_path: {}", artifacts.changed_files);
+    println!("memory_candidates_path: {}", artifacts.memory_candidates);
+}
+
+fn agent_session_status_label(status: cadis_protocol::AgentSessionStatus) -> &'static str {
+    match status {
+        cadis_protocol::AgentSessionStatus::Started => "started",
+        cadis_protocol::AgentSessionStatus::Running => "running",
+        cadis_protocol::AgentSessionStatus::Completed => "completed",
+        cadis_protocol::AgentSessionStatus::Failed => "failed",
+        cadis_protocol::AgentSessionStatus::Cancelled => "cancelled",
+        cadis_protocol::AgentSessionStatus::TimedOut => "timed_out",
+        cadis_protocol::AgentSessionStatus::BudgetExceeded => "budget_exceeded",
+    }
+}
+
+fn worker_worktree_state_label(state: WorkerWorktreeState) -> &'static str {
+    match state {
+        WorkerWorktreeState::Planned => "planned",
+        WorkerWorktreeState::Active => "active",
+        WorkerWorktreeState::ReviewPending => "review_pending",
+        WorkerWorktreeState::CleanupPending => "cleanup_pending",
+        WorkerWorktreeState::Removed => "removed",
+    }
+}
+
+fn worker_cleanup_policy_label(policy: WorkerWorktreeCleanupPolicy) -> &'static str {
+    match policy {
+        WorkerWorktreeCleanupPolicy::Explicit => "explicit",
+        WorkerWorktreeCleanupPolicy::AfterApply => "after_apply",
+        WorkerWorktreeCleanupPolicy::OnCompletion => "on_completion",
+    }
+}
+
 fn render_rejections_or_json(frames: &[ServerFrame], json: bool) -> Result<(), Box<dyn Error>> {
     if json {
         return print_json_frames(frames);
@@ -1038,6 +1192,9 @@ enum WorkerCommand {
         worker_id: String,
         lines: Option<u32>,
     },
+    Result {
+        worker_id: String,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1076,6 +1233,7 @@ fn parse_worker(args: Vec<String>) -> Result<WorkerCommand, Box<dyn Error>> {
     let mut args = args.into_iter();
     match args.next().as_deref() {
         Some("tail") => parse_worker_tail(args.collect()),
+        Some("result") => parse_worker_result(args.collect()),
         Some(other) => Err(invalid_input(format!("unknown worker command: {other}")).into()),
         None => Err(invalid_input("worker requires a subcommand").into()),
     }
@@ -1109,6 +1267,24 @@ fn parse_worker_tail(args: Vec<String>) -> Result<WorkerCommand, Box<dyn Error>>
             .cloned()
             .ok_or_else(|| invalid_input("worker tail requires a worker ID"))?,
         lines,
+    })
+}
+
+fn parse_worker_result(args: Vec<String>) -> Result<WorkerCommand, Box<dyn Error>> {
+    let mut positionals = Vec::new();
+
+    for arg in args {
+        if arg.starts_with("--") {
+            return Err(invalid_input(format!("unknown worker result option: {arg}")).into());
+        }
+        positionals.push(arg);
+    }
+
+    Ok(WorkerCommand::Result {
+        worker_id: positionals
+            .first()
+            .cloned()
+            .ok_or_else(|| invalid_input("worker result requires a worker ID"))?,
     })
 }
 
@@ -1648,7 +1824,7 @@ fn invalid_data(message: impl Into<String>) -> io::Error {
 
 fn print_help() {
     println!(
-        "cadis {}\n\nUSAGE:\n  cadis [--socket PATH] [--json] <COMMAND>\n\nCOMMANDS:\n  daemon [ARGS...]       Launch cadisd from PATH or sibling target directory\n  status                 Show daemon status\n  doctor                 Check local config and daemon connectivity\n  models                 List model provider options\n  agents                 List daemon-owned agents\n  worker <COMMAND>       Inspect daemon-owned workers\n  workspace <COMMAND>    Manage registered workspaces and grants\n  session <COMMAND>      Manage session event streams\n  voice [COMMAND]        Show daemon-visible voice status or doctor checks\n  events [OPTIONS]       Subscribe to daemon runtime events\n  spawn <ROLE> [OPTIONS] Spawn a child/subagent\n  chat <MESSAGE>         Send a one-shot chat message\n  run [--cwd PATH] <TASK> Send a desktop MVP task as a chat request\n  tool [OPTIONS] <NAME>  Request a daemon-owned tool call\n  approve <ID>           Respond to an approval request\n  deny <ID>              Deny an approval request\n\nWORKER COMMANDS:\n  worker tail <ID> [--lines COUNT]\n\nWORKSPACE COMMANDS:\n  workspace list [--grants]\n  workspace register <ID> <ROOT> [--kind project|documents|sandbox|worktree]\n  workspace grant <ID> [--access read,write,exec,admin] [--agent AGENT]\n  workspace revoke (--grant ID | --workspace ID)\n  workspace doctor [--workspace ID] [--root PATH]\n\nSESSION COMMANDS:\n  session subscribe <ID> [--replay COUNT] [--since EVENT_ID] [--no-snapshot]\n\nVOICE COMMANDS:\n  voice status           Show daemon-visible voice status\n  voice doctor           Show voice doctor and local bridge preflight state\n\nEVENT OPTIONS:\n  --snapshot             Print one daemon-owned state snapshot and exit\n  --replay <COUNT>       Replay up to COUNT buffered events before live events\n  --since <EVENT_ID>     Replay retained events after EVENT_ID\n  --no-snapshot          Subscribe without initial state snapshot\n\nSPAWN OPTIONS:\n  --name <NAME>          Display name for the new agent\n  --parent <AGENT>       Parent agent ID, default main\n  --model <MODEL>        Provider/model identifier\n\nTOOL OPTIONS:\n  --cwd <PATH>           Workspace root for file and git tools\n  --workspace <ID>       Registered workspace ID for file and git tools\n  --session <ID>         Attach the tool call to a session\n  --agent <ID>           Use an agent context for scoped workspace grants\n  --input <JSON>         Structured tool input\n\nGLOBAL OPTIONS:\n  --socket <PATH>        Unix socket path\n  --json                 Print NDJSON server frames\n  --version, -V          Print version\n  --help, -h             Print help",
+        "cadis {}\n\nUSAGE:\n  cadis [--socket PATH] [--json] <COMMAND>\n\nCOMMANDS:\n  daemon [ARGS...]       Launch cadisd from PATH or sibling target directory\n  status                 Show daemon status\n  doctor                 Check local config and daemon connectivity\n  models                 List model provider options\n  agents                 List daemon-owned agents\n  worker <COMMAND>       Inspect daemon-owned workers\n  workspace <COMMAND>    Manage registered workspaces and grants\n  session <COMMAND>      Manage session event streams\n  voice [COMMAND]        Show daemon-visible voice status or doctor checks\n  events [OPTIONS]       Subscribe to daemon runtime events\n  spawn <ROLE> [OPTIONS] Spawn a child/subagent\n  chat <MESSAGE>         Send a one-shot chat message\n  run [--cwd PATH] <TASK> Send a desktop MVP task as a chat request\n  tool [OPTIONS] <NAME>  Request a daemon-owned tool call\n  approve <ID>           Respond to an approval request\n  deny <ID>              Deny an approval request\n\nWORKER COMMANDS:\n  worker tail <ID> [--lines COUNT]\n  worker result <ID>\n\nWORKSPACE COMMANDS:\n  workspace list [--grants]\n  workspace register <ID> <ROOT> [--kind project|documents|sandbox|worktree]\n  workspace grant <ID> [--access read,write,exec,admin] [--agent AGENT]\n  workspace revoke (--grant ID | --workspace ID)\n  workspace doctor [--workspace ID] [--root PATH]\n\nSESSION COMMANDS:\n  session subscribe <ID> [--replay COUNT] [--since EVENT_ID] [--no-snapshot]\n\nVOICE COMMANDS:\n  voice status           Show daemon-visible voice status\n  voice doctor           Show voice doctor and local bridge preflight state\n\nEVENT OPTIONS:\n  --snapshot             Print one daemon-owned state snapshot and exit\n  --replay <COUNT>       Replay up to COUNT buffered events before live events\n  --since <EVENT_ID>     Replay retained events after EVENT_ID\n  --no-snapshot          Subscribe without initial state snapshot\n\nSPAWN OPTIONS:\n  --name <NAME>          Display name for the new agent\n  --parent <AGENT>       Parent agent ID, default main\n  --model <MODEL>        Provider/model identifier\n\nTOOL OPTIONS:\n  --cwd <PATH>           Workspace root for file and git tools\n  --workspace <ID>       Registered workspace ID for file and git tools\n  --session <ID>         Attach the tool call to a session\n  --agent <ID>           Use an agent context for scoped workspace grants\n  --input <JSON>         Structured tool input\n\nGLOBAL OPTIONS:\n  --socket <PATH>        Unix socket path\n  --json                 Print NDJSON server frames\n  --version, -V          Print version\n  --help, -h             Print help",
         env!("CARGO_PKG_VERSION")
     );
 }

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -30,11 +30,11 @@ use cadis_protocol::{
     ToolFailedPayload, UiPreferencesPayload, VoiceDoctorCheck, VoiceDoctorPayload,
     VoicePreferences, VoicePreflightRequest, VoicePreflightSummary, VoicePreviewRequest,
     VoiceRuntimeState, VoiceStatusPayload, WorkerArtifactLocations, WorkerEventPayload,
-    WorkerLogDeltaPayload, WorkerTailRequest, WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent,
-    WorkerWorktreeState, WorkspaceAccess, WorkspaceDoctorCheck, WorkspaceDoctorPayload,
-    WorkspaceDoctorRequest, WorkspaceGrantId, WorkspaceGrantPayload, WorkspaceGrantRequest,
-    WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest, WorkspaceRecordPayload,
-    WorkspaceRegisterRequest, WorkspaceRevokeRequest,
+    WorkerLogDeltaPayload, WorkerResultRequest, WorkerTailRequest, WorkerWorktreeCleanupPolicy,
+    WorkerWorktreeIntent, WorkerWorktreeState, WorkspaceAccess, WorkspaceDoctorCheck,
+    WorkspaceDoctorPayload, WorkspaceDoctorRequest, WorkspaceGrantId, WorkspaceGrantPayload,
+    WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest,
+    WorkspaceRecordPayload, WorkspaceRegisterRequest, WorkspaceRevokeRequest,
 };
 use cadis_store::{
     redact, AgentHomeDiagnostic, AgentHomeDoctorOptions, AgentHomeTemplate, ApprovalRecord,
@@ -577,6 +577,7 @@ impl Runtime {
             ClientRequest::VoicePreview(request) => self.handle_voice_preview(request_id, request),
             ClientRequest::VoiceStop(_) => self.handle_voice_stop(request_id),
             ClientRequest::WorkerTail(request) => self.worker_tail(request_id, request),
+            ClientRequest::WorkerResult(request) => self.worker_result(request_id, request),
             ClientRequest::SessionUnsubscribe(_) => self.reject(
                 request_id,
                 "not_implemented",
@@ -1071,6 +1072,7 @@ impl Runtime {
         let worker = route.worker_summary.as_ref().map(|summary| {
             let worker_id = self.next_worker_id();
             WorkerDelegation {
+                agent_session_id: agent_session_id.clone(),
                 worktree: planned_worker_worktree(
                     &worker_id,
                     session_workspace.as_deref(),
@@ -1425,6 +1427,53 @@ impl Runtime {
                 )
             })
             .collect();
+
+        self.accept(request_id, events)
+    }
+
+    fn worker_result(
+        &mut self,
+        request_id: RequestId,
+        request: WorkerResultRequest,
+    ) -> RequestOutcome {
+        let Some(worker) = self.workers.get(&request.worker_id).cloned() else {
+            return self.reject(
+                request_id,
+                "worker_not_found",
+                format!("worker '{}' was not found", request.worker_id),
+                false,
+            );
+        };
+
+        if !worker.is_terminal() {
+            return self.reject(
+                request_id,
+                "worker_result_unavailable",
+                format!(
+                    "worker '{}' has not reached a terminal result",
+                    worker.worker_id
+                ),
+                true,
+            );
+        }
+
+        let mut events = Vec::new();
+        if let Some(agent_session) = worker
+            .agent_session_id
+            .as_ref()
+            .and_then(|agent_session_id| self.agent_sessions.get(agent_session_id))
+            .cloned()
+        {
+            events.push(self.session_event(
+                agent_session.session_id.clone(),
+                agent_session_lifecycle_event(agent_session.event_payload()),
+            ));
+        }
+
+        events.push(self.session_event(
+            worker.session_id.clone(),
+            worker_lifecycle_event(worker.event_payload()),
+        ));
 
         self.accept(request_id, events)
     }
@@ -4008,6 +4057,7 @@ enum ExplicitOrchestratorAction {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct WorkerDelegation {
     worker_id: String,
+    agent_session_id: AgentSessionId,
     parent_agent_id: Option<AgentId>,
     summary: String,
     worktree: WorkerWorktreeIntent,
@@ -4020,6 +4070,7 @@ struct WorkerRecord {
     session_id: SessionId,
     agent_id: Option<AgentId>,
     parent_agent_id: Option<AgentId>,
+    agent_session_id: Option<AgentSessionId>,
     status: String,
     cli: Option<String>,
     cwd: Option<String>,
@@ -4047,6 +4098,7 @@ struct WorkerMetadata {
     session_id: SessionId,
     agent_id: Option<AgentId>,
     parent_agent_id: Option<AgentId>,
+    agent_session_id: Option<AgentSessionId>,
     status: String,
     cli: Option<String>,
     cwd: Option<String>,
@@ -4070,6 +4122,7 @@ impl WorkerRecord {
             session_id,
             agent_id,
             parent_agent_id: worker.parent_agent_id.clone(),
+            agent_session_id: Some(worker.agent_session_id.clone()),
             status: "running".to_owned(),
             cli: None,
             cwd: None,
@@ -4089,6 +4142,7 @@ impl WorkerRecord {
             worker_id: self.worker_id.clone(),
             agent_id: self.agent_id.clone(),
             parent_agent_id: self.parent_agent_id.clone(),
+            agent_session_id: self.agent_session_id.clone(),
             status: Some(self.status.clone()),
             cli: self.cli.clone(),
             cwd: self.cwd.clone(),
@@ -4113,6 +4167,7 @@ impl WorkerMetadata {
             session_id: record.session_id.clone(),
             agent_id: record.agent_id.clone(),
             parent_agent_id: record.parent_agent_id.clone(),
+            agent_session_id: record.agent_session_id.clone(),
             status: record.status.clone(),
             cli: record.cli.clone(),
             cwd: record.cwd.clone(),
@@ -4135,6 +4190,7 @@ impl WorkerMetadata {
                 session_id: self.session_id,
                 agent_id: self.agent_id,
                 parent_agent_id: self.parent_agent_id,
+                agent_session_id: self.agent_session_id,
                 status: self.status,
                 cli: self.cli,
                 cwd: self.cwd,
@@ -5199,6 +5255,19 @@ fn worker_status_is_terminal(status: &str) -> bool {
         status,
         "completed" | "failed" | "cancelled" | "canceled" | "expired"
     )
+}
+
+fn agent_session_lifecycle_event(payload: AgentSessionEventPayload) -> CadisEvent {
+    match payload.status {
+        AgentSessionStatus::Completed => CadisEvent::AgentSessionCompleted(payload),
+        AgentSessionStatus::Failed
+        | AgentSessionStatus::TimedOut
+        | AgentSessionStatus::BudgetExceeded => CadisEvent::AgentSessionFailed(payload),
+        AgentSessionStatus::Cancelled => CadisEvent::AgentSessionCancelled(payload),
+        AgentSessionStatus::Started | AgentSessionStatus::Running => {
+            CadisEvent::AgentSessionUpdated(payload)
+        }
+    }
 }
 
 fn worker_lifecycle_event(payload: WorkerEventPayload) -> CadisEvent {
@@ -7241,8 +7310,8 @@ mod tests {
         ClientId, ContentKind, EmptyPayload, EventSubscriptionRequest, EventsSnapshotRequest,
         MessageSendRequest, RequestId, ServerFrame, SessionCreateRequest,
         SessionSubscriptionRequest, SessionTargetRequest, ToolCallRequest, VoiceDoctorCheck,
-        VoiceDoctorRequest, VoicePreflightRequest, WorkerTailRequest, WorkspaceAccess,
-        WorkspaceDoctorRequest, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind,
+        VoiceDoctorRequest, VoicePreflightRequest, WorkerResultRequest, WorkerTailRequest,
+        WorkspaceAccess, WorkspaceDoctorRequest, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind,
         WorkspaceRegisterRequest, WorkspaceRevokeRequest,
     };
     use std::sync::{
@@ -7553,6 +7622,16 @@ mod tests {
                 target_agent_id: None,
                 content: content.to_owned(),
                 content_kind,
+            }),
+        ))
+    }
+
+    fn collect_worker_result(runtime: &mut Runtime, worker_id: &str) -> RequestOutcome {
+        runtime.handle_request(RequestEnvelope::new(
+            RequestId::from(format!("req_result_{worker_id}")),
+            ClientId::from("cli_1"),
+            ClientRequest::WorkerResult(WorkerResultRequest {
+                worker_id: worker_id.to_owned(),
             }),
         ))
     }
@@ -8972,6 +9051,7 @@ mod tests {
                     session_id: SessionId::from("ses_stale"),
                     agent_id: Some(AgentId::from("codex")),
                     parent_agent_id: Some(AgentId::from("main")),
+                    agent_session_id: None,
                     status: "running".to_owned(),
                     cli: None,
                     cwd: None,
@@ -9240,6 +9320,240 @@ mod tests {
             .expect("worker worktree metadata should exist");
         assert_eq!(project_metadata.workspace_id, "worker-git");
         assert_eq!(project_metadata.state, ProjectWorkerWorktreeState::Ready);
+    }
+
+    #[test]
+    fn completed_worker_result_collects_summary_and_artifact_paths_without_logs() {
+        let cadis_home = test_workspace("completed-worker-result-home");
+        let workspace = test_workspace("completed-worker-result-workspace");
+        init_git_workspace(&workspace);
+
+        let mut runtime = runtime_with_home(cadis_home);
+        register_workspace(&mut runtime, "worker-result-git", &workspace);
+        let session_id = runtime
+            .handle_request(RequestEnvelope::new(
+                RequestId::from("req_worker_result_session"),
+                ClientId::from("cli_1"),
+                ClientRequest::SessionCreate(SessionCreateRequest {
+                    title: Some("Worker result".to_owned()),
+                    cwd: Some(workspace.display().to_string()),
+                }),
+            ))
+            .events
+            .into_iter()
+            .find_map(|event| match event.event {
+                CadisEvent::SessionStarted(payload) => Some(payload.session_id),
+                _ => None,
+            })
+            .expect("session.started should be emitted");
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_completed_worker"),
+            ClientId::from("hud_1"),
+            ClientRequest::MessageSend(MessageSendRequest {
+                session_id: Some(session_id),
+                target_agent_id: None,
+                content: "/route @codex run focused tests".to_owned(),
+                content_kind: ContentKind::Chat,
+            }),
+        ));
+        let completed = outcome
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::WorkerCompleted(payload) => Some(payload.clone()),
+                _ => None,
+            })
+            .expect("worker.completed should be emitted");
+        let worker_id = completed.worker_id.clone();
+        let raw_log_marker = "RAW-LARGE-WORKER-LOG-SHOULD-NOT-APPEAR";
+        let _ = runtime.append_worker_log(
+            &worker_id,
+            format!("{raw_log_marker} {}\n", "x".repeat(4096)),
+        );
+
+        let result = collect_worker_result(&mut runtime, &worker_id);
+
+        assert!(matches!(
+            result.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(!result
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::WorkerLogDelta(_))));
+        let agent_session = result
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::AgentSessionCompleted(payload) => Some(payload),
+                _ => None,
+            })
+            .expect("agent.session.completed should be replayed");
+        assert_eq!(
+            completed.agent_session_id.as_ref(),
+            Some(&agent_session.agent_session_id)
+        );
+        assert!(agent_session
+            .result
+            .as_deref()
+            .is_some_and(|result| result.contains("run focused tests")));
+        let worker = result
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::WorkerCompleted(payload) => Some(payload),
+                _ => None,
+            })
+            .expect("worker.completed result should be replayed");
+        let artifacts = worker
+            .artifacts
+            .as_ref()
+            .expect("worker result should include artifact paths");
+        assert!(Path::new(&artifacts.summary).is_file());
+        assert!(Path::new(&artifacts.test_report).is_file());
+        assert!(artifacts.test_report.ends_with("test-report.json"));
+        let serialized = serde_json::to_string(&result.events).expect("events should serialize");
+        assert!(!serialized.contains(raw_log_marker));
+    }
+
+    #[test]
+    fn failed_worker_result_collects_agent_error_and_artifact_paths() {
+        let mut runtime = runtime();
+        let pending = runtime
+            .begin_message_request(RequestEnvelope::new(
+                RequestId::from("req_failed_worker_result"),
+                ClientId::from("hud_1"),
+                ClientRequest::MessageSend(MessageSendRequest {
+                    session_id: None,
+                    target_agent_id: None,
+                    content: "/route @codex run focused tests".to_owned(),
+                    content_kind: ContentKind::Chat,
+                }),
+            ))
+            .expect("worker route should prepare model generation");
+        let worker_id = pending
+            .context
+            .worker
+            .as_ref()
+            .expect("route should create a worker")
+            .worker_id
+            .clone();
+
+        let _ = runtime.fail_message_generation(
+            pending,
+            cadis_models::ModelError::with_code(
+                "provider_client_error",
+                "provider request failed",
+                true,
+            ),
+        );
+        let result = collect_worker_result(&mut runtime, &worker_id);
+
+        assert!(matches!(
+            result.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(!result
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::WorkerLogDelta(_))));
+        assert!(result.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentSessionFailed(payload)
+                    if payload.error_code.as_deref() == Some("provider_client_error")
+                        && payload.error.as_deref() == Some("provider request failed")
+            )
+        }));
+        let worker = result
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::WorkerFailed(payload) => Some(payload),
+                _ => None,
+            })
+            .expect("worker.failed result should be replayed");
+        assert_eq!(worker.status.as_deref(), Some("failed"));
+        assert_eq!(worker.error_code.as_deref(), Some("provider_client_error"));
+        let artifacts = worker
+            .artifacts
+            .as_ref()
+            .expect("failed worker result should include artifact paths");
+        assert!(Path::new(&artifacts.test_report).is_file());
+        assert!(artifacts.test_report.ends_with("test-report.json"));
+    }
+
+    #[test]
+    fn cancelled_worker_result_collects_agent_cancellation_and_artifact_paths() {
+        let mut runtime = runtime();
+        let pending = runtime
+            .begin_message_request(RequestEnvelope::new(
+                RequestId::from("req_cancelled_worker_result"),
+                ClientId::from("hud_1"),
+                ClientRequest::MessageSend(MessageSendRequest {
+                    session_id: None,
+                    target_agent_id: None,
+                    content: "/route @codex wait for cancellation".to_owned(),
+                    content_kind: ContentKind::Chat,
+                }),
+            ))
+            .expect("worker route should prepare model generation");
+        let session_id = pending.context.session_id.clone();
+        let worker_id = pending
+            .context
+            .worker
+            .as_ref()
+            .expect("route should create a worker")
+            .worker_id
+            .clone();
+
+        let _ = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_cancel_worker_result_session"),
+            ClientId::from("hud_1"),
+            ClientRequest::SessionCancel(SessionTargetRequest { session_id }),
+        ));
+        let result = collect_worker_result(&mut runtime, &worker_id);
+
+        assert!(matches!(
+            result.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(!result
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::WorkerLogDelta(_))));
+        assert!(result.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::AgentSessionCancelled(payload)
+                    if payload.status == AgentSessionStatus::Cancelled
+                        && payload.cancellation_requested_at.is_some()
+            )
+        }));
+        let worker = result
+            .events
+            .iter()
+            .find_map(|event| match &event.event {
+                CadisEvent::WorkerCancelled(payload) => Some(payload),
+                _ => None,
+            })
+            .expect("worker.cancelled result should be replayed");
+        assert_eq!(worker.status.as_deref(), Some("cancelled"));
+        assert_eq!(worker.error_code.as_deref(), Some("session_cancelled"));
+        let artifacts = worker
+            .artifacts
+            .as_ref()
+            .expect("cancelled worker result should include artifact paths");
+        assert!(artifacts.test_report.ends_with("test-report.json"));
+    }
+
+    #[test]
+    fn worker_result_rejects_unknown_worker() {
+        let mut runtime = runtime();
+        let outcome = collect_worker_result(&mut runtime, "worker_missing");
+
+        assert_rejected(outcome, "worker_not_found");
     }
 
     #[test]

--- a/crates/cadis-protocol/src/lib.rs
+++ b/crates/cadis-protocol/src/lib.rs
@@ -435,6 +435,9 @@ pub enum ClientRequest {
     /// Tail a worker log stream.
     #[serde(rename = "worker.tail")]
     WorkerTail(WorkerTailRequest),
+    /// Collect a worker terminal result summary without replaying raw logs.
+    #[serde(rename = "worker.result")]
+    WorkerResult(WorkerResultRequest),
     /// List available model descriptors.
     #[serde(rename = "models.list")]
     ModelsList(EmptyPayload),
@@ -622,6 +625,13 @@ pub struct WorkerTailRequest {
     /// Optional number of recent lines.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lines: Option<u32>,
+}
+
+/// Payload for collecting a worker terminal result.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct WorkerResultRequest {
+    /// Worker identifier.
+    pub worker_id: String,
 }
 
 /// Payload for listing registered workspaces.
@@ -1385,6 +1395,9 @@ pub struct WorkerEventPayload {
     /// Parent agent for tree display.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_agent_id: Option<AgentId>,
+    /// Agent runtime session associated with this worker.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_session_id: Option<AgentSessionId>,
     /// Worker status label.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
@@ -1787,6 +1800,32 @@ mod tests {
     }
 
     #[test]
+    fn worker_result_request_matches_documented_shape() {
+        let envelope = RequestEnvelope::new(
+            RequestId::from("req_1"),
+            ClientId::from("cli_1"),
+            ClientRequest::WorkerResult(WorkerResultRequest {
+                worker_id: "worker_000001".to_owned(),
+            }),
+        );
+
+        let value = serde_json::to_value(&envelope).expect("request should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "protocol_version": CURRENT_PROTOCOL_VERSION,
+                "request_id": "req_1",
+                "client_id": "cli_1",
+                "type": "worker.result",
+                "payload": {
+                    "worker_id": "worker_000001"
+                }
+            })
+        );
+    }
+
+    #[test]
     fn tool_call_request_matches_documented_shape() {
         let envelope = RequestEnvelope::new(
             RequestId::from("req_1"),
@@ -1999,6 +2038,7 @@ mod tests {
                 worker_id: "worker_000001".to_owned(),
                 agent_id: Some(AgentId::from("coder")),
                 parent_agent_id: Some(AgentId::from("main")),
+                agent_session_id: Some(AgentSessionId::from("ags_000001")),
                 status: Some("running".to_owned()),
                 cli: None,
                 cwd: None,
@@ -2053,6 +2093,7 @@ mod tests {
                     "worker_id": "worker_000001",
                     "agent_id": "coder",
                     "parent_agent_id": "main",
+                    "agent_session_id": "ags_000001",
                     "status": "running",
                     "summary": "implement worktree baseline",
                     "worktree": {
@@ -2118,6 +2159,7 @@ mod tests {
                 worker_id: "worker_000001".to_owned(),
                 agent_id: Some(AgentId::from("coder")),
                 parent_agent_id: Some(AgentId::from("main")),
+                agent_session_id: Some(AgentSessionId::from("ags_000001")),
                 status: Some("failed".to_owned()),
                 cli: None,
                 cwd: None,

--- a/docs/06_IMPLEMENTATION_PLAN.md
+++ b/docs/06_IMPLEMENTATION_PLAN.md
@@ -65,8 +65,10 @@ Implemented in the first runnable baseline:
   provider response cannot later overwrite a cancelled AgentSession.
 - Track C worker baseline: in-memory daemon worker registry, route-time
   `worker.log.delta` lifecycle logs, `events.snapshot` worker lifecycle
-  snapshots, `worker.failed` / `worker.cancelled` terminal metadata, and
-  one-shot `worker.tail` replay.
+  snapshots, `worker.failed` / `worker.cancelled` terminal metadata,
+  one-shot `worker.tail` replay, and compact `worker.result` collection that
+  returns terminal worker/AgentSession summaries plus artifact paths without
+  replaying raw logs.
 - P13 HUD subset: Tauri + React `apps/cadis-hud` desktop app, orbital shell,
   chat command panel, agent cards, mention picker, config dialog, six themes,
   model controls, rename dialog, local mic debug, HUD-local voice doctor,
@@ -193,6 +195,8 @@ Tasks:
 - Add a worker registry with `worker.started`, `worker.log.delta`,
   `worker.completed`, `worker.failed`, and `worker.cancelled`.
 - Implement `worker.tail` from daemon-owned worker logs.
+- Implement `worker.result` from daemon-owned terminal worker metadata and
+  linked AgentSession result summaries, excluding raw worker logs.
 - Propagate `session.cancel` into active provider streams. Baseline now checks
   pending AgentSession cancellation inside daemon provider callbacks, returns
   `ModelStreamControl::Cancel`, and prevents cancelled generations from
@@ -208,6 +212,8 @@ Exit criteria:
   limits.
 - HUD worker tree is driven by daemon worker events.
 - Worker logs can be tailed from CLI and HUD.
+- Worker terminal result summaries and artifact paths can be collected without
+  replaying raw logs.
 - Cancelling a session stops the active provider stream at the next callback
   boundary and preserves the AgentSession as `cancelled`.
 

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -242,6 +242,8 @@
 - [ ] Define worker state.
 - [x] Implement daemon worker registry.
 - [x] Implement `worker.tail`.
+- [x] Implement compact `worker.result` collection for terminal summaries and
+  artifact paths without raw log replay.
 - [x] Create git worktree for session-bound project workers.
 - [x] Add worker failed/cancelled event and metadata baseline.
 - [ ] Stream worker logs.
@@ -338,10 +340,10 @@
 - [x] Track B: provider readiness, effective model metadata, selected-model routing, and provider streaming/cancellation contract.
 - [ ] Track C: `AgentSession`, agent-driven spawn, limits, and worker registry.
   Baselines landed: AgentSession state/events, explicit daemon-owned spawn,
-  spawn limits, worker registry, worker tail, and provider-stream cancellation
-  on `session.cancel`. Remaining: implicit model-driven spawn, worker
-  failed/cancelled events, and real command/test execution inside worker
-  worktrees.
+  spawn limits, worker registry, worker tail, worker result collection,
+  worker failed/cancelled events, and provider-stream cancellation on
+  `session.cancel`. Remaining: implicit model-driven spawn and real
+  command/test execution inside worker worktrees.
 - [ ] Track D: policy-backed tools and approval persistence.
 - [x] Track D baseline: tool contract metadata, safe-read `file.read` and
   `file.search`, `git.status`, `git.diff`, workspace grants, approval
@@ -421,7 +423,7 @@
 - [x] Support spawn baseline.
 - [ ] Support kill.
 - [ ] Support tail.
-- [ ] Support result collection.
+- [x] Support result collection baseline through daemon `worker.result`.
 - [ ] Add fan-out tests.
 
 ## 18. Release Readiness

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -96,6 +96,7 @@ workspace.grant
 workspace.revoke
 workspace.doctor
 worker.tail
+worker.result
 models.list
 ui.preferences.get
 ui.preferences.set
@@ -146,15 +147,24 @@ The desktop MVP replays log lines from the in-memory worker registry as
 up to 64 recent lines, capped at 1000. Unknown workers are rejected with
 `worker_not_found`.
 
+`worker.result` is a one-shot request for compact daemon-owned worker result
+collection. It returns the linked terminal `agent.session.*` event when known,
+then the terminal `worker.completed`, `worker.failed`, or `worker.cancelled`
+event. It does not replay `worker.log.delta` lines. Unknown workers are
+rejected with `worker_not_found`; workers without a terminal result are rejected
+with `worker_result_unavailable`.
+
 `worker.started`, `worker.completed`, `worker.failed`, and `worker.cancelled`
 may include worktree and artifact metadata. Failed worker events include optional
 `error_code` and redacted `error`; cancelled worker events include optional
-`cancellation_requested_at`. For session-bound project workspaces, the daemon
-worker runtime creates `<project>/.cadis/worktrees/<worker-id>/`, emits the
-active worktree path in `worker.started`, and writes profile-scoped artifacts
-before `worker.completed` or `worker.failed`. Terminal worker events move active
-worktrees to `review_pending` or `cleanup_pending` according to cleanup policy;
-patch apply and cleanup remain separate approval-gated flows.
+`cancellation_requested_at`. Worker lifecycle events include optional
+`agent_session_id` when the worker was created for a daemon-owned AgentSession.
+For session-bound project workspaces, the daemon worker runtime creates
+`<project>/.cadis/worktrees/<worker-id>/`, emits the active worktree path in
+`worker.started`, and writes profile-scoped artifacts before `worker.completed`
+or `worker.failed`. Terminal worker events move active worktrees to
+`review_pending` or `cleanup_pending` according to cleanup policy; patch apply
+and cleanup remain separate approval-gated flows.
 
 Example:
 
@@ -167,6 +177,20 @@ Example:
   "payload": {
     "worker_id": "worker_000001",
     "lines": 20
+  }
+}
+```
+
+Example:
+
+```json
+{
+  "protocol_version": "0.1",
+  "request_id": "req_...",
+  "client_id": "cli_...",
+  "type": "worker.result",
+  "payload": {
+    "worker_id": "worker_000001"
   }
 }
 ```


### PR DESCRIPTION
## Summary
- add worker.result protocol request and CLI command
- return compact terminal worker/agent-session result metadata and artifact paths
- reject unknown and non-terminal workers fail-closed

## Validation
- cargo test -p cadis-core worker_result -- --nocapture
- cargo test -p cadis-protocol worker_result -- --nocapture
- cargo check -p cadis-cli
- cargo test -p cadis-cli
- cargo fmt --all --check
- cargo test --all-targets --all-features
- cargo clippy --all-targets --all-features -- -D warnings