### PR TITLE
Make file.patch writes transactional with rollback

### DIFF
--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -3333,16 +3333,8 @@ impl Runtime {
     ) -> Result<ToolExecutionResult, ErrorPayload> {
         let operations = parse_file_patch_operations(input)?;
         let prepared = prepare_file_patch(workspace, &operations)?;
-
-        for change in &prepared {
-            fs::write(&change.path, change.content.as_bytes()).map_err(|error| {
-                tool_error(
-                    "file_patch_write_failed",
-                    format!("could not write {}: {error}", change.display_path),
-                    false,
-                )
-            })?;
-        }
+        let staged = stage_file_patch_transaction(&prepared)?;
+        commit_file_patch_transaction(&staged)?;
 
         let output_files = prepared
             .iter()
@@ -5272,6 +5264,16 @@ struct PreparedFilePatch {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+struct StagedFilePatch {
+    path: PathBuf,
+    display_path: String,
+    action: &'static str,
+    staged_path: PathBuf,
+    backup_path: Option<PathBuf>,
+    had_original: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct BoundedOutput {
     bytes: Vec<u8>,
     truncated: bool,
@@ -6719,6 +6721,172 @@ fn prepare_file_patch(
     }
 
     Ok(prepared)
+}
+
+fn stage_file_patch_transaction(
+    prepared: &[PreparedFilePatch],
+) -> Result<Vec<StagedFilePatch>, ErrorPayload> {
+    let mut staged = Vec::with_capacity(prepared.len());
+    for (index, change) in prepared.iter().enumerate() {
+        let staged_path = match allocate_file_patch_temp_path(&change.path, "tmp", index) {
+            Ok(path) => path,
+            Err(error) => {
+                cleanup_staged_file_patch_paths(&staged);
+                return Err(error);
+            }
+        };
+        if let Err(error) = fs::write(&staged_path, change.content.as_bytes()) {
+            cleanup_staged_file_patch_paths(&staged);
+            let _ = fs::remove_file(&staged_path);
+            return Err(tool_error(
+                "file_patch_write_failed",
+                format!("could not stage {}: {error}", change.display_path),
+                false,
+            ));
+        }
+
+        let had_original = change.path.is_file();
+        let backup_path = if had_original {
+            match allocate_file_patch_temp_path(&change.path, "bak", index) {
+                Ok(path) => Some(path),
+                Err(error) => {
+                    cleanup_staged_file_patch_paths(&staged);
+                    let _ = fs::remove_file(&staged_path);
+                    return Err(error);
+                }
+            }
+        } else {
+            None
+        };
+
+        staged.push(StagedFilePatch {
+            path: change.path.clone(),
+            display_path: change.display_path.clone(),
+            action: change.action,
+            staged_path,
+            backup_path,
+            had_original,
+        });
+    }
+    Ok(staged)
+}
+
+fn commit_file_patch_transaction(staged: &[StagedFilePatch]) -> Result<(), ErrorPayload> {
+    let mut moved_backups = Vec::<(PathBuf, PathBuf)>::new();
+    let mut committed_targets = Vec::<PathBuf>::new();
+    let mut failed = false;
+    let mut failure_message = String::new();
+
+    for change in staged {
+        if change.had_original {
+            let Some(backup_path) = &change.backup_path else {
+                failed = true;
+                failure_message = format!(
+                    "transactional file.patch backup path missing for {}",
+                    change.display_path
+                );
+                break;
+            };
+
+            if let Err(error) = fs::rename(&change.path, backup_path) {
+                failed = true;
+                failure_message =
+                    format!("could not move {} to backup: {error}", change.display_path);
+                break;
+            }
+            moved_backups.push((change.path.clone(), backup_path.clone()));
+        }
+
+        if let Err(error) = fs::rename(&change.staged_path, &change.path) {
+            failed = true;
+            failure_message = format!(
+                "could not commit staged {} {}: {error}",
+                change.action, change.display_path
+            );
+            break;
+        }
+        committed_targets.push(change.path.clone());
+    }
+
+    if failed {
+        rollback_file_patch_transaction(staged, &moved_backups, &committed_targets);
+        return Err(tool_error(
+            "file_patch_write_failed",
+            format!("transactional file.patch commit failed: {failure_message}"),
+            false,
+        ));
+    }
+
+    for (_, backup_path) in moved_backups {
+        let _ = fs::remove_file(backup_path);
+    }
+    cleanup_staged_file_patch_paths(staged);
+
+    Ok(())
+}
+
+fn rollback_file_patch_transaction(
+    staged: &[StagedFilePatch],
+    moved_backups: &[(PathBuf, PathBuf)],
+    committed_targets: &[PathBuf],
+) {
+    for target in committed_targets.iter().rev() {
+        let _ = fs::remove_file(target);
+    }
+
+    for (target, backup_path) in moved_backups.iter().rev() {
+        let _ = fs::rename(backup_path, target);
+    }
+
+    cleanup_staged_file_patch_paths(staged);
+    for (_, backup_path) in moved_backups {
+        let _ = fs::remove_file(backup_path);
+    }
+}
+
+fn cleanup_staged_file_patch_paths(staged: &[StagedFilePatch]) {
+    for change in staged {
+        let _ = fs::remove_file(&change.staged_path);
+    }
+}
+
+fn allocate_file_patch_temp_path(
+    target: &Path,
+    suffix: &str,
+    index: usize,
+) -> Result<PathBuf, ErrorPayload> {
+    let parent = target.parent().ok_or_else(|| {
+        tool_error(
+            "path_resolution_failed",
+            "file.patch target has no parent directory",
+            false,
+        )
+    })?;
+    let file_name = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("target");
+    let pid = std::process::id();
+    let now = Utc::now().timestamp_nanos_opt().unwrap_or_default();
+
+    for attempt in 0..64_usize {
+        let nonce = now.wrapping_add(i64::try_from(attempt).unwrap_or_default());
+        let candidate = parent.join(format!(
+            ".cadis_file_patch_{suffix}_{pid}_{index}_{nonce}_{file_name}"
+        ));
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(tool_error(
+        "file_patch_write_failed",
+        format!(
+            "could not allocate temporary file for {}",
+            target.display()
+        ),
+        false,
+    ))
 }
 
 fn read_patch_target(path: &Path) -> Result<String, ErrorPayload> {
@@ -9247,6 +9415,32 @@ mod tests {
             fs::read_to_string(workspace.join("README.md")).expect("file should read"),
             "hello cadis\n"
         );
+    }
+
+    #[test]
+    fn file_patch_transaction_rolls_back_on_commit_failure() {
+        let workspace = test_workspace("file-patch-rollback");
+        let target = workspace.join("README.md");
+        fs::write(&target, "hello\n").expect("test file should write");
+        let staged_path = workspace.join(".missing_staged_file_patch");
+        let backup_path = workspace.join(".file_patch_backup");
+        let staged = vec![StagedFilePatch {
+            path: target.clone(),
+            display_path: "README.md".to_owned(),
+            action: "write",
+            staged_path,
+            backup_path: Some(backup_path.clone()),
+            had_original: true,
+        }];
+
+        let error =
+            commit_file_patch_transaction(&staged).expect_err("transaction should fail closed");
+        assert_eq!(error.code, "file_patch_write_failed");
+        assert_eq!(
+            fs::read_to_string(&target).expect("target should be restored"),
+            "hello\n"
+        );
+        assert!(!backup_path.exists());
     }
 
     #[test]

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -1,6 +1,8 @@
 //! Core CADIS request handling and event production.
 
 use std::collections::HashMap;
+#[cfg(test)]
+use std::cell::Cell;
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Component, Path, PathBuf};
@@ -11,8 +13,6 @@ use std::time::{Duration as StdDuration, Instant};
 
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
-#[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
 use cadis_models::{
     provider_catalog_for_config, ModelCatalogConfig, ModelInvocation, ModelProvider, ModelRequest,
@@ -69,7 +69,9 @@ const WORKER_COMMAND_LOG_LIMIT_BYTES: usize = 4 * 1024;
 const WORKER_COMMAND_SUMMARY_LIMIT_BYTES: usize = 512;
 
 #[cfg(test)]
-static FILE_PATCH_COMMIT_FAIL_AFTER: AtomicUsize = AtomicUsize::new(usize::MAX);
+thread_local! {
+    static FILE_PATCH_COMMIT_FAIL_AFTER: Cell<usize> = const { Cell::new(usize::MAX) };
+}
 
 /// Runtime options supplied by the daemon process.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -6852,7 +6854,7 @@ fn commit_file_patch_transaction(staged: &[StagedFilePatch]) -> Result<(), Error
 fn should_fail_file_patch_commit(committed_count: usize) -> bool {
     #[cfg(test)]
     {
-        let fail_after = FILE_PATCH_COMMIT_FAIL_AFTER.load(AtomicOrdering::Relaxed);
+        let fail_after = FILE_PATCH_COMMIT_FAIL_AFTER.with(Cell::get);
         fail_after != usize::MAX && committed_count >= fail_after
     }
     #[cfg(not(test))]
@@ -8636,15 +8638,22 @@ mod tests {
         ))
     }
 
-    fn set_file_patch_commit_failure_after(value: Option<usize>) -> usize {
-        FILE_PATCH_COMMIT_FAIL_AFTER.swap(
-            value.unwrap_or(usize::MAX),
-            AtomicOrdering::SeqCst,
-        )
+    struct FilePatchCommitFailureGuard {
+        previous: usize,
     }
 
-    fn restore_file_patch_commit_failure_after(previous: usize) {
-        FILE_PATCH_COMMIT_FAIL_AFTER.store(previous, AtomicOrdering::SeqCst);
+    impl FilePatchCommitFailureGuard {
+        fn new(value: Option<usize>) -> Self {
+            let previous = FILE_PATCH_COMMIT_FAIL_AFTER
+                .with(|fail_after| fail_after.replace(value.unwrap_or(usize::MAX)));
+            Self { previous }
+        }
+    }
+
+    impl Drop for FilePatchCommitFailureGuard {
+        fn drop(&mut self) {
+            FILE_PATCH_COMMIT_FAIL_AFTER.with(|fail_after| fail_after.set(self.previous));
+        }
     }
 
     fn assert_no_file_patch_temp_files(root: &Path) {
@@ -9495,7 +9504,7 @@ mod tests {
             vec![WorkspaceAccess::Write],
         );
 
-        let previous = set_file_patch_commit_failure_after(Some(2));
+        let _failure_guard = FilePatchCommitFailureGuard::new(Some(2));
         let request = runtime.handle_request(RequestEnvelope::new(
             RequestId::from("req_file_patch_rollback_runtime"),
             ClientId::from("cli_1"),
@@ -9522,7 +9531,6 @@ mod tests {
             }),
         ));
         let outcome = approve(&mut runtime, approval_id_from(&request));
-        restore_file_patch_commit_failure_after(previous);
 
         assert!(outcome.events.iter().any(|event| {
             matches!(

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -11,6 +11,8 @@ use std::time::{Duration as StdDuration, Instant};
 
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
 use cadis_models::{
     provider_catalog_for_config, ModelCatalogConfig, ModelInvocation, ModelProvider, ModelRequest,
@@ -65,6 +67,9 @@ const WORKER_DEFAULT_COMMAND: &str = "git status --short";
 const WORKER_COMMAND_TIMEOUT_MS: u64 = 5_000;
 const WORKER_COMMAND_LOG_LIMIT_BYTES: usize = 4 * 1024;
 const WORKER_COMMAND_SUMMARY_LIMIT_BYTES: usize = 512;
+
+#[cfg(test)]
+static FILE_PATCH_COMMIT_FAIL_AFTER: AtomicUsize = AtomicUsize::new(usize::MAX);
 
 /// Runtime options supplied by the daemon process.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -6795,6 +6800,18 @@ fn commit_file_patch_transaction(staged: &[StagedFilePatch]) -> Result<(), Error
                 break;
             }
             moved_backups.push((change.path.clone(), backup_path.clone()));
+
+            if let Err(error) = fs::metadata(backup_path)
+                .map(|metadata| metadata.permissions())
+                .and_then(|permissions| fs::set_permissions(&change.staged_path, permissions))
+            {
+                failed = true;
+                failure_message = format!(
+                    "could not preserve metadata for {}: {error}",
+                    change.display_path
+                );
+                break;
+            }
         }
 
         if let Err(error) = fs::rename(&change.staged_path, &change.path) {
@@ -6806,6 +6823,13 @@ fn commit_file_patch_transaction(staged: &[StagedFilePatch]) -> Result<(), Error
             break;
         }
         committed_targets.push(change.path.clone());
+
+        if should_fail_file_patch_commit(committed_targets.len()) {
+            failed = true;
+            failure_message =
+                "transactional file.patch commit failed due to injected test fault".to_owned();
+            break;
+        }
     }
 
     if failed {
@@ -6823,6 +6847,19 @@ fn commit_file_patch_transaction(staged: &[StagedFilePatch]) -> Result<(), Error
     cleanup_staged_file_patch_paths(staged);
 
     Ok(())
+}
+
+fn should_fail_file_patch_commit(committed_count: usize) -> bool {
+    #[cfg(test)]
+    {
+        let fail_after = FILE_PATCH_COMMIT_FAIL_AFTER.load(AtomicOrdering::Relaxed);
+        fail_after != usize::MAX && committed_count >= fail_after
+    }
+    #[cfg(not(test))]
+    {
+        let _ = committed_count;
+        false
+    }
 }
 
 fn rollback_file_patch_transaction(
@@ -8599,6 +8636,33 @@ mod tests {
         ))
     }
 
+    fn set_file_patch_commit_failure_after(value: Option<usize>) -> usize {
+        FILE_PATCH_COMMIT_FAIL_AFTER.swap(
+            value.unwrap_or(usize::MAX),
+            AtomicOrdering::SeqCst,
+        )
+    }
+
+    fn restore_file_patch_commit_failure_after(previous: usize) {
+        FILE_PATCH_COMMIT_FAIL_AFTER.store(previous, AtomicOrdering::SeqCst);
+    }
+
+    fn assert_no_file_patch_temp_files(root: &Path) {
+        let mut leaked = Vec::new();
+        let entries = fs::read_dir(root).expect("workspace should be readable");
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with(".cadis_file_patch_") {
+                leaked.push(name);
+            }
+        }
+        assert!(
+            leaked.is_empty(),
+            "temporary file.patch artifacts should be cleaned: {:?}",
+            leaked
+        );
+    }
+
     fn send_message_with_kind(
         runtime: &mut Runtime,
         content_kind: ContentKind,
@@ -9415,32 +9479,119 @@ mod tests {
             fs::read_to_string(workspace.join("README.md")).expect("file should read"),
             "hello cadis\n"
         );
+        assert_no_file_patch_temp_files(&workspace);
     }
 
     #[test]
-    fn file_patch_transaction_rolls_back_on_commit_failure() {
-        let workspace = test_workspace("file-patch-rollback");
-        let target = workspace.join("README.md");
-        fs::write(&target, "hello\n").expect("test file should write");
-        let staged_path = workspace.join(".missing_staged_file_patch");
-        let backup_path = workspace.join(".file_patch_backup");
-        let staged = vec![StagedFilePatch {
-            path: target.clone(),
-            display_path: "README.md".to_owned(),
-            action: "write",
-            staged_path,
-            backup_path: Some(backup_path.clone()),
-            had_original: true,
-        }];
+    fn file_patch_transaction_rolls_back_multi_file_daemon_flow() {
+        let workspace = test_workspace("file-patch-rollback-runtime");
+        fs::write(workspace.join("README.md"), "hello\n").expect("README should write");
+        let created_path = workspace.join("NEW.md");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "file-patch-rollback-runtime", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "file-patch-rollback-runtime",
+            vec![WorkspaceAccess::Write],
+        );
 
-        let error =
-            commit_file_patch_transaction(&staged).expect_err("transaction should fail closed");
-        assert_eq!(error.code, "file_patch_write_failed");
+        let previous = set_file_patch_commit_failure_after(Some(2));
+        let request = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_file_patch_rollback_runtime"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "file.patch".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "file-patch-rollback-runtime",
+                    "operations": [
+                        {
+                            "op": "replace",
+                            "path": "README.md",
+                            "old": "hello\n",
+                            "new": "hello cadis\n"
+                        },
+                        {
+                            "op": "write",
+                            "path": "NEW.md",
+                            "content": "created by patch\n"
+                        }
+                    ]
+                }),
+            }),
+        ));
+        let outcome = approve(&mut runtime, approval_id_from(&request));
+        restore_file_patch_commit_failure_after(previous);
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolFailed(payload)
+                    if payload.tool_name == "file.patch"
+                        && payload.error.code == "file_patch_write_failed"
+            )
+        }));
         assert_eq!(
-            fs::read_to_string(&target).expect("target should be restored"),
+            fs::read_to_string(workspace.join("README.md")).expect("README should read"),
             "hello\n"
         );
-        assert!(!backup_path.exists());
+        assert!(
+            !created_path.exists(),
+            "created file should be removed by rollback"
+        );
+        assert_no_file_patch_temp_files(&workspace);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn approved_file_patch_preserves_existing_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let workspace = test_workspace("file-patch-permissions");
+        let target = workspace.join("script.sh");
+        fs::write(&target, "#!/bin/sh\necho cadis\n").expect("script should write");
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o755))
+            .expect("mode should set");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "file-patch-permissions", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "file-patch-permissions",
+            vec![WorkspaceAccess::Write],
+        );
+
+        let request = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_file_patch_permissions"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "file.patch".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "file-patch-permissions",
+                    "path": "script.sh",
+                    "old": "echo cadis\n",
+                    "new": "echo preserved\n"
+                }),
+            }),
+        ));
+        let outcome = approve(&mut runtime, approval_id_from(&request));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolCompleted(payload)
+                    if payload.tool_name == "file.patch"
+            )
+        }));
+        let mode = fs::metadata(&target)
+            .expect("metadata should load")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o755, "existing executable mode should be preserved");
+        assert_no_file_patch_temp_files(&workspace);
     }
 
     #[test]


### PR DESCRIPTION
Hi! This PR improves the reliability of `file.patch` by making writes transactional.

Previously, when multiple files were patched, a failure in the middle could leave the workspace in a partially updated state.  
With this change, patches are staged first and then committed safely, with rollback behavior if commit fails.

## Changes

- Added transactional staging for `file.patch` writes
- Added commit phase with rollback on failure
- Added cleanup for staged/backup temp files
- Added a regression test to verify rollback behavior on commit failure

## Why this helps

This keeps workspace state consistent and avoids partial writes when an error happens during patch application.

Thanks for reviewing.
