### PR TITLE
Add automated PR review guardrails

### DIFF
--- a/.github/workflows/pr-autoreview.yml
+++ b/.github/workflows/pr-autoreview.yml
@@ -1,0 +1,77 @@
+name: PR Auto Review
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-autoreview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guardrails:
+    name: Automated PR review
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.draft == false }}
+    steps:
+      - name: Evaluate PR guardrails
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          files="$RUNNER_TEMP/pr-files.txt"
+          patch="$RUNNER_TEMP/pr.patch"
+          reasons="$RUNNER_TEMP/request-changes.md"
+          : > "$reasons"
+
+          add_reason() {
+            printf -- '- %s\n' "$1" >> "$reasons"
+          }
+
+          gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" \
+            --paginate \
+            --jq '.[].filename' > "$files"
+          gh pr diff "$PR_NUMBER" --repo "$REPOSITORY" --patch > "$patch"
+
+          if grep -Eiq -- '(^|/)(\.env(\.|$)|id_rsa|id_dsa|id_ecdsa|id_ed25519|.*\.(pem|p12|pfx|key))$' "$files"; then
+            add_reason "Secret-bearing files are not allowed in the repository. Remove .env, private key, certificate, or credential files from this PR."
+          fi
+
+          if grep -Eiq -- '(^|/)(target|node_modules|dist|coverage|\.cadis|\.claude|\.codex)(/|$)' "$files"; then
+            add_reason "Generated artifacts, local runtime state, and local agent state must not be committed. Remove target, node_modules, dist, coverage, .cadis, .claude, or .codex paths from this PR."
+          fi
+
+          if grep -Eq -- '/home/ramaaditya/|/home/[^[:space:]]+/Project/(ramaclaw-hud|wulan-contribute)|/home/[^[:space:]]+/docs/superpowers' "$patch"; then
+            add_reason "Private local machine paths were found in the diff. Public docs and code must use generic placeholders such as /home/user/project."
+          fi
+
+          if grep -Eiq -- '-----BEGIN (OPENSSH|RSA|DSA|EC|PGP|PRIVATE) KEY-----|github_pat_[A-Za-z0-9_]{20,}|ghp_[A-Za-z0-9_]{20,}|sk-proj-[A-Za-z0-9_-]{20,}|sk-[A-Za-z0-9_-]{24,}|xox[baprs]-[A-Za-z0-9-]{20,}' "$patch"; then
+            add_reason "A token or private key pattern was found in the diff. Remove credentials and rotate anything that may have been exposed."
+          fi
+
+          if grep -Eiq -- '(OPENAI_API_KEY|CADIS_OPENAI_API_KEY|ANTHROPIC_API_KEY|GITHUB_TOKEN|GH_TOKEN|AWS_SECRET_ACCESS_KEY|AWS_ACCESS_KEY_ID)[[:space:]]*=[[:space:]]*["'\'']?[A-Za-z0-9_./+=:-]{12,}' "$patch"; then
+            add_reason "A credential-looking environment assignment was found in the diff. Keep secrets in local environment or secret stores, never in committed files."
+          fi
+
+          if [ -s "$reasons" ]; then
+            {
+              printf 'Automated CADIS review found blocking repository policy issues:\n\n'
+              cat "$reasons"
+              printf '\nPlease fix these before requesting review again. This workflow only performs public-safe metadata and diff checks; normal CI still owns build, test, and format validation.\n'
+            } > "$RUNNER_TEMP/review-body.md"
+
+            gh pr review "$PR_NUMBER" \
+              --repo "$REPOSITORY" \
+              --request-changes \
+              --body-file "$RUNNER_TEMP/review-body.md"
+            exit 1
+          fi
+
+          echo "Automated PR review found no blocking repository policy issues."

--- a/docs/07_MASTER_CHECKLIST.md
+++ b/docs/07_MASTER_CHECKLIST.md
@@ -14,6 +14,7 @@
 - [x] Add discussion template.
 - [x] Add PR template.
 - [x] Add CI hygiene workflow.
+- [x] Add automated PR review guardrails for public-safe diff policy checks.
 - [x] Add macOS/Windows platform baseline workflow.
 - [x] Add Rust workspace placeholder.
 - [x] Add environment example.

--- a/docs/09_OPEN_SOURCE_STANDARD.md
+++ b/docs/09_OPEN_SOURCE_STANDARD.md
@@ -85,6 +85,9 @@ Recommended release stages:
 Planning baseline:
 
 - repository hygiene checks
+- automated PR review guardrails for public-safe diff policy checks, including
+  committed secrets, private local paths, generated artifacts, and local
+  runtime/agent state
 - GitHub repository rulesets for protected `main` and `v*` release tags
 
 After Rust code starts:

--- a/docs/standards/20_CI_CD_STANDARD.md
+++ b/docs/standards/20_CI_CD_STANDARD.md
@@ -32,6 +32,7 @@ Active repository rulesets:
 
 Required `main` status checks:
 
+- `Automated PR review`
 - `Repository hygiene`
 - `Rust workspace`
 - `HUD frontend`
@@ -40,6 +41,8 @@ Required `main` status checks:
 
 Baseline checks:
 
+- automated public-safe PR metadata/diff guardrails for committed secrets,
+  private local paths, generated artifacts, and local runtime/agent state
 - repository hygiene check
 - Markdown and documentation path check where tooling exists
 - no committed secrets
@@ -134,6 +137,7 @@ v0.x.y-rc.N
 
 Recommended workflows:
 
+- `.github/workflows/pr-autoreview.yml`
 - `.github/workflows/ci.yml`
 - `.github/workflows/platform-baseline.yml`
 - `.github/workflows/security.yml`


### PR DESCRIPTION
Adds a GitHub Actions auto-review gate for public-safe PR policy checks. The workflow uses pull_request_target without checking out or executing PR code; it only inspects PR files and patch text through GitHub APIs, then requests changes and fails the status check when it finds committed secrets, private local paths, generated artifacts, or local runtime/agent state.\n\nAlso updates the CI/open-source docs and checklist to document the new guardrail.\n\nValidation run locally:\n- workflow YAML parsed with python yaml\n- extracted shell run block passed bash -n\n- mocked clean and blocked auto-review paths\n- git diff --check