### PR TITLE
feat: dynamic progress bar in README

### DIFF
--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -1,0 +1,24 @@
+name: Update progress
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/07_MASTER_CHECKLIST.md']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  progress:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Calculate progress
+        run: bash scripts/update-progress.sh
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/progress.json
+          git diff --cached --quiet || git commit -m "chore: update progress [skip ci]" && git push

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@
 </p>
 
 <p align="center">
+  <a href="docs/07_MASTER_CHECKLIST.md"><img alt="Alpha progress" src="https://progress-bar.xyz/dynamic/json/?url=https%3A%2F%2Fraw.githubusercontent.com%2FGrowth-Circle%2Fcadis%2Fmain%2Fdocs%2Fprogress.json&query=checklist.percent&title=alpha+progress&suffix=%25&width=220&color=0d1117&progress_background=161b22&progress_number_color=58a6ff&style=flat"></a>
+  <a href="docs/07_MASTER_CHECKLIST.md"><img alt="Checklist" src="https://progress-bar.xyz/dynamic/json/?url=https%3A%2F%2Fraw.githubusercontent.com%2FGrowth-Circle%2Fcadis%2Fmain%2Fdocs%2Fprogress.json&query=checklist.done&title=checklist&suffix=%20done&scale=500&width=140&style=flat"></a>
+</p>
+
+<p align="center">
   <img src="docs/assets/readme/cadis-hud-desktop.png" alt="C.A.D.I.S. desktop HUD with orbital agents, voice chat, and model routing" width="920" />
 </p>
 

--- a/docs/progress.json
+++ b/docs/progress.json
@@ -1,0 +1,11 @@
+{
+  "checklist": {
+    "done": 311,
+    "total": 404,
+    "percent": 76
+  },
+  "milestone": "pre-alpha",
+  "next_milestone": "alpha",
+  "next_target_percent": 80,
+  "updated_at": "2026-04-28T11:37:21Z"
+}

--- a/scripts/update-progress.sh
+++ b/scripts/update-progress.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Calculates milestone progress from docs/07_MASTER_CHECKLIST.md
+# and writes docs/progress.json for dynamic README badges.
+set -euo pipefail
+
+CHECKLIST="docs/07_MASTER_CHECKLIST.md"
+OUTPUT="docs/progress.json"
+
+done=$(grep -c '^\- \[x\]' "$CHECKLIST" || true)
+todo=$(grep -c '^\- \[ \]' "$CHECKLIST" || true)
+total=$((done + todo))
+pct=$((done * 100 / total))
+
+# Determine current milestone and next target
+if [ "$pct" -lt 80 ]; then
+  milestone="pre-alpha"
+  next="alpha"
+  # Alpha target: 80% checklist completion
+  target=80
+elif [ "$pct" -lt 92 ]; then
+  milestone="alpha"
+  next="beta"
+  target=92
+elif [ "$pct" -lt 98 ]; then
+  milestone="beta"
+  next="rc"
+  target=98
+else
+  milestone="rc"
+  next="stable"
+  target=100
+fi
+
+cat > "$OUTPUT" <<EOF
+{
+  "checklist": {
+    "done": $done,
+    "total": $total,
+    "percent": $pct
+  },
+  "milestone": "$milestone",
+  "next_milestone": "$next",
+  "next_target_percent": $target,
+  "updated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+echo "Progress: $done/$total ($pct%) — $milestone → $next at ${target}%"


### PR DESCRIPTION
Adds a live progress bar to the README that auto-updates from the master checklist.

**How it works:**
1. `scripts/update-progress.sh` counts `[x]` and `[ ]` in the checklist
2. Writes `docs/progress.json` with done/total/percent/milestone data
3. CI workflow runs on checklist changes and commits updated JSON
4. README uses `progress-bar.xyz/dynamic/json/` to render live SVG badges from the JSON

**Current:** 311/404 (76%) — pre-alpha → alpha at 80%

**Badges:**
- Alpha progress: percentage bar with dark theme
- Checklist: done count out of total