### PR TITLE
docs: v1.0 RC prep — protocol freeze, stable CLI, storage format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,42 @@ jobs:
           name: binaries-${{ matrix.target }}
           path: dist/
 
+  build-hud:
+    name: Build HUD (Tauri)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build HUD
+        run: |
+          cd apps/cadis-hud
+          corepack enable
+          pnpm install
+          pnpm tauri build
+      - name: Package HUD artifacts
+        run: |
+          mkdir -p dist
+          cp apps/cadis-hud/src-tauri/target/release/bundle/appimage/*.AppImage dist/ || true
+          cp apps/cadis-hud/src-tauri/target/release/bundle/deb/*.deb dist/ || true
+      - name: Generate checksums
+        working-directory: dist
+        run: |
+          for f in *; do
+            sha256sum "$f" > "$f.sha256"
+          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: hud-linux
+          path: dist/
+
   release:
     name: Create GitHub Release
-    needs: build
+    needs: [build, build-hud]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to CADIS will be documented in this file.
 
 The format follows Keep a Changelog style, and the project will use Semantic Versioning once the first release exists.
 
-## [Unreleased] — v0.9.2 RC
+## [Unreleased]
+
+## [0.9.2] - 2026-04-29
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,9 @@ cadis/
 - [Wulan Avatar Engine](docs/26_WULAN_AVATAR_ENGINE.md)
 - [Workspace Architecture](docs/27_WORKSPACE_ARCHITECTURE.md)
 - [Platform Baseline](docs/28_PLATFORM_BASELINE.md)
+- [Protocol Freeze](docs/29_PROTOCOL_FREEZE.md)
+- [Storage Format and Migration](docs/31_STORAGE_FORMAT.md)
+- [Stable CLI Reference](docs/30_STABLE_CLI.md)
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,11 +4,26 @@ CADIS will execute tools, edit files, call models, and coordinate agents. Securi
 
 ## Supported Versions
 
-C.A.D.I.S. v0.9 is the current beta release. Security reports are welcome.
+| Version | Supported |
+| ------- | --------- |
+| 0.9.x   | ✅ Current beta — security fixes applied |
+| 1.0.x   | ✅ Will receive security fixes on release |
+| < 0.9   | ❌ No longer supported |
 
 ## Reporting a Vulnerability
 
-Until a public security contact is created, report privately to the maintainers. Do not open public issues for vulnerabilities involving:
+**Use GitHub Security Advisories.** File a private vulnerability report at:
+
+> <https://github.com/Growth-Circle/cadis/security/advisories/new>
+
+Private vulnerability reporting is enabled on this repository. Do not open
+public issues for security vulnerabilities.
+
+We aim to **acknowledge reports within 48 hours** and provide an initial
+assessment within 7 days. Critical issues affecting approval bypass, command
+execution, or credential leakage will be prioritized for expedited fixes.
+
+Report categories include but are not limited to:
 
 - approval bypass
 - command execution

--- a/docs/29_PROTOCOL_FREEZE.md
+++ b/docs/29_PROTOCOL_FREEZE.md
@@ -1,0 +1,161 @@
+# Protocol Freeze — v1.0 Stable Subset
+
+This document defines the stable protocol surface for C.A.D.I.S. protocol
+version `0.1`. Types listed here will not receive breaking changes in any
+v1.x release without a major version bump.
+
+## Protocol version
+
+Current: **`0.1`** (`CURRENT_PROTOCOL_VERSION`).
+
+## Transport format
+
+NDJSON (newline-delimited JSON) over a Unix domain socket. Each message is
+exactly one JSON object per line. Clients send `RequestEnvelope` objects; the
+daemon replies with `ServerFrame` objects.
+
+## ServerFrame envelope
+
+Every line sent by `cadisd` is a `ServerFrame`, tagged by `frame`:
+
+| Frame        | Description                                      |
+|--------------|--------------------------------------------------|
+| `response`   | Immediate `ResponseEnvelope` for a client request |
+| `event`      | Asynchronous `EventEnvelope` from the daemon      |
+
+```json
+{ "frame": "response", "payload": { "protocol_version": "0.1", "request_id": "…", "type": "…", "payload": {…} } }
+{ "frame": "event",    "payload": { "protocol_version": "0.1", "event_id": "…", "timestamp": "…", "source": "cadisd", "type": "…", "payload": {…} } }
+```
+
+## Stable request set — `ClientRequest`
+
+| Wire type                  | Variant               | Description                                              |
+|----------------------------|-----------------------|----------------------------------------------------------|
+| `events.subscribe`         | EventsSubscribe       | Subscribe to daemon runtime events with optional replay  |
+| `events.snapshot`          | EventsSnapshot        | Request a one-shot daemon runtime state snapshot         |
+| `daemon.status`            | DaemonStatus          | Query daemon health and runtime status                   |
+| `session.create`           | SessionCreate         | Create a new session                                     |
+| `session.cancel`           | SessionCancel         | Cancel an existing session                               |
+| `session.subscribe`        | SessionSubscribe      | Subscribe to a session's event stream                    |
+| `session.unsubscribe`      | SessionUnsubscribe    | Unsubscribe from a session's event stream                |
+| `message.send`             | MessageSend           | Send a user message to the daemon                        |
+| `tool.call`                | ToolCall              | Request daemon-owned tool execution                      |
+| `approval.respond`         | ApprovalRespond       | Respond to a pending approval request                    |
+| `agent.list`               | AgentList             | List all known agents                                    |
+| `agent.rename`             | AgentRename           | Rename an agent's display name                           |
+| `agent.model.set`          | AgentModelSet         | Set an agent's model provider/identifier                 |
+| `agent.specialist.set`     | AgentSpecialistSet    | Set an agent's specialist persona                        |
+| `agent.spawn`              | AgentSpawn            | Spawn a new agent                                        |
+| `agent.kill`               | AgentKill             | Kill a running agent                                     |
+| `agent.tail`               | AgentTail             | Tail an agent's recent session events                    |
+| `workspace.list`           | WorkspaceList         | List registered workspaces and active grants             |
+| `workspace.register`       | WorkspaceRegister     | Register or replace a project workspace                  |
+| `workspace.grant`          | WorkspaceGrant        | Grant an agent access to a workspace                     |
+| `workspace.revoke`         | WorkspaceRevoke       | Revoke one or more workspace grants                      |
+| `workspace.doctor`         | WorkspaceDoctor       | Run workspace registry health checks                     |
+| `worker.tail`              | WorkerTail            | Tail a worker's log stream                               |
+| `worker.result`            | WorkerResult          | Collect a worker terminal result summary                 |
+| `worker.cleanup`           | WorkerCleanup         | Request worker worktree cleanup planning                 |
+| `models.list`              | ModelsList            | List available model descriptors                         |
+| `ui.preferences.get`       | UiPreferencesGet      | Get daemon-owned UI preferences                          |
+| `ui.preferences.set`       | UiPreferencesSet      | Patch daemon-owned UI preferences                        |
+| `voice.status`             | VoiceStatus           | Query daemon-visible voice capability status             |
+| `voice.doctor`             | VoiceDoctor           | Run daemon-visible voice diagnostics                     |
+| `voice.preflight`          | VoicePreflight        | Report local bridge preflight checks to the daemon       |
+| `voice.preview`            | VoicePreview          | Preview voice output with optional preferences           |
+| `voice.stop`               | VoiceStop             | Stop current voice output                                |
+| `config.reload`            | ConfigReload          | Reload daemon configuration from disk                    |
+| `daemon.shutdown`          | DaemonShutdown        | Request graceful daemon shutdown                         |
+
+## Stable event set — `CadisEvent`
+
+| Wire type                       | Variant                  | Description                                              |
+|---------------------------------|--------------------------|----------------------------------------------------------|
+| `daemon.started`                | DaemonStarted            | Daemon process started                                   |
+| `daemon.stopping`              | DaemonStopping           | Daemon is shutting down                                  |
+| `daemon.error`                  | DaemonError              | Daemon-level error                                       |
+| `session.started`               | SessionStarted           | Session was created                                      |
+| `session.updated`               | SessionUpdated           | Session state changed                                    |
+| `session.completed`             | SessionCompleted         | Session completed                                        |
+| `session.failed`                | SessionFailed            | Session failed                                           |
+| `message.delta`                 | MessageDelta             | Streaming message content delta                          |
+| `message.completed`             | MessageCompleted         | Message generation completed                             |
+| `agent.spawned`                 | AgentSpawned             | Agent was spawned                                        |
+| `agent.list.response`           | AgentListResponse        | Agent roster snapshot                                    |
+| `agent.renamed`                 | AgentRenamed             | Agent display name changed                               |
+| `agent.model.changed`           | AgentModelChanged        | Agent model provider changed                             |
+| `agent.specialist.changed`      | AgentSpecialistChanged   | Agent specialist persona changed                         |
+| `agent.status.changed`          | AgentStatusChanged       | Agent lifecycle status changed                           |
+| `agent.completed`               | AgentCompleted           | Agent completed its task                                 |
+| `agent.killed`                  | AgentKilled              | Agent was killed by a client                             |
+| `agent.session.started`         | AgentSessionStarted      | Agent runtime session started                            |
+| `agent.session.updated`         | AgentSessionUpdated      | Agent runtime session state changed                      |
+| `agent.session.completed`       | AgentSessionCompleted    | Agent runtime session completed                          |
+| `agent.session.failed`          | AgentSessionFailed       | Agent runtime session failed                             |
+| `agent.session.cancelled`       | AgentSessionCancelled    | Agent runtime session was cancelled                      |
+| `workspace.list.response`       | WorkspaceListResponse    | Workspace registry snapshot                              |
+| `workspace.registered`          | WorkspaceRegistered      | Workspace was registered                                 |
+| `workspace.grant.created`       | WorkspaceGrantCreated    | Workspace grant was created                              |
+| `workspace.grant.revoked`       | WorkspaceGrantRevoked    | Workspace grant was revoked                              |
+| `workspace.doctor.response`     | WorkspaceDoctorResponse  | Workspace doctor result                                  |
+| `models.list.response`          | ModelsListResponse       | Model catalog snapshot                                   |
+| `ui.preferences.updated`        | UiPreferencesUpdated     | UI preferences changed                                   |
+| `voice.status.updated`          | VoiceStatusUpdated       | Voice capability status changed                          |
+| `voice.doctor.response`         | VoiceDoctorResponse      | Voice diagnostics result                                 |
+| `voice.preflight.response`      | VoicePreflightResponse   | Bridge voice preflight was recorded                      |
+| `orchestrator.route`            | OrchestratorRoute        | Orchestrator routed a request to an agent                |
+| `tool.requested`                | ToolRequested            | Tool execution was requested                             |
+| `tool.started`                  | ToolStarted              | Tool execution started                                   |
+| `tool.completed`                | ToolCompleted            | Tool execution completed                                 |
+| `tool.failed`                   | ToolFailed               | Tool execution failed                                    |
+| `approval.requested`            | ApprovalRequested        | Approval is required for a risky action                  |
+| `approval.resolved`             | ApprovalResolved         | Approval was resolved                                    |
+| `worker.started`                | WorkerStarted            | Worker started                                           |
+| `worker.log.delta`              | WorkerLogDelta           | Worker log content delta                                 |
+| `worker.completed`              | WorkerCompleted          | Worker completed                                         |
+| `worker.failed`                 | WorkerFailed             | Worker failed                                            |
+| `worker.cancelled`              | WorkerCancelled          | Worker was cancelled                                     |
+| `worker.cleanup.requested`      | WorkerCleanupRequested   | Worker cleanup was requested and recorded                |
+| `patch.created`                 | PatchCreated             | Patch was created                                        |
+| `test.result`                   | TestResult               | Test result emitted                                      |
+| `voice.preview.started`         | VoicePreviewStarted      | Voice preview started                                    |
+| `voice.preview.completed`       | VoicePreviewCompleted    | Voice preview completed                                  |
+| `voice.preview.failed`          | VoicePreviewFailed       | Voice preview failed                                     |
+| `voice.started`                 | VoiceStarted             | Voice playback started                                   |
+| `voice.completed`               | VoiceCompleted           | Voice playback completed                                 |
+
+## Stable response set — `DaemonResponse`
+
+| Wire type                  | Variant          | Description                                              |
+|----------------------------|------------------|----------------------------------------------------------|
+| `request.accepted`         | RequestAccepted  | Request was accepted; follow-up state arrives via events  |
+| `daemon.status.response`   | DaemonStatus     | Current daemon health and runtime status                 |
+| `request.rejected`         | RequestRejected  | Request was rejected before execution                    |
+
+## Stability guarantees
+
+The types, wire names, and payload shapes listed above are frozen for the v1.x
+release line. Specifically:
+
+- No variant will be removed or renamed.
+- No required payload field will be removed or change type.
+- New optional fields may be added to existing payloads.
+- New variants may be added to `ClientRequest`, `CadisEvent`, and `DaemonResponse`.
+- Clients must tolerate unknown event types and unknown fields.
+
+A breaking change to any frozen type requires a major protocol version bump.
+
+## What is NOT frozen
+
+The following are explicitly outside the stability contract and may change
+between any releases:
+
+- Internal daemon behavior and implementation details
+- Model provider selection, fallback logic, and provider adapters
+- Tool execution internals, shell environment filtering, and sandbox policy
+- UI rendering, HUD layout, and client-side presentation
+- JSONL persistence format and redaction boundaries
+- Worker orchestration scheduling and concurrency limits
+- Avatar engine internals and renderer adapters
+- Configuration file schema beyond what the protocol exposes

--- a/docs/30_STABLE_CLI.md
+++ b/docs/30_STABLE_CLI.md
@@ -1,0 +1,356 @@
+# Stable CLI Reference — v1.0
+
+CLI binary: `cadis`. Communicates with the `cadisd` daemon over a Unix socket.
+
+## Global flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--json` | | Print raw NDJSON server frames instead of human-readable output |
+| `--socket <PATH>` | | Override the Unix socket path to `cadisd` |
+| `--help` | `-h` | Print help and exit |
+| `--version` | `-V` | Print version and exit |
+
+Global flags must appear **before** the subcommand.
+
+---
+
+## Commands
+
+### status — stable
+
+Show daemon status (version, uptime, model provider, sessions, voice state).
+
+```bash
+cadis status
+cadis --json status
+```
+
+### doctor — stable
+
+Check local config, daemon connectivity, and voice subsystem health.
+
+```bash
+cadis doctor
+cadis --json doctor
+```
+
+### chat — stable
+
+Send a one-shot chat message to the daemon.
+
+```bash
+cadis chat "hello world"
+cadis --json chat "summarize this project"
+```
+
+**Arguments:** `<MESSAGE>` (required, may be multiple words joined by space)
+
+### models — stable
+
+List configured model providers and their readiness.
+
+```bash
+cadis models
+cadis --json models
+```
+
+### agents — stable
+
+List daemon-owned agents.
+
+```bash
+cadis agents
+cadis --json agents
+```
+
+### approve — stable
+
+Approve a pending approval request.
+
+```bash
+cadis approve <APPROVAL_ID>
+```
+
+**Arguments:** `<APPROVAL_ID>` (required)
+
+### deny — stable
+
+Deny a pending approval request.
+
+```bash
+cadis deny <APPROVAL_ID>
+```
+
+**Arguments:** `<APPROVAL_ID>` (required)
+
+### spawn — stable
+
+Spawn a new child or subagent.
+
+```bash
+cadis spawn worker
+cadis spawn worker --name w1 --model gpt-4
+cadis spawn researcher --parent agent_main --name r1
+```
+
+**Arguments:** `<ROLE>` (required)
+
+| Flag | Description |
+|------|-------------|
+| `--name <NAME>` | Display name for the new agent |
+| `--parent <AGENT_ID>` | Parent agent ID (default: main) |
+| `--model <MODEL>` | Provider/model identifier |
+
+### events — stable
+
+Subscribe to daemon runtime events (streams until interrupted).
+
+```bash
+cadis events
+cadis events --snapshot
+cadis events --replay 50
+cadis events --since evt_abc123
+cadis events --no-snapshot
+```
+
+| Flag | Description |
+|------|-------------|
+| `--snapshot` | Print one state snapshot and exit |
+| `--replay <COUNT>` | Replay up to COUNT buffered events before live (default: 128) |
+| `--since <EVENT_ID>` | Replay retained events after EVENT_ID |
+| `--no-snapshot` | Subscribe without initial state snapshot |
+
+### worker tail — stable
+
+Stream recent log output from a worker.
+
+```bash
+cadis worker tail <WORKER_ID>
+cadis worker tail w1 --lines 50
+```
+
+**Arguments:** `<WORKER_ID>` (required)
+
+| Flag | Description |
+|------|-------------|
+| `--lines <COUNT>` | Number of log lines to return |
+
+### worker result — stable
+
+Retrieve the final result of a completed worker.
+
+```bash
+cadis worker result <WORKER_ID>
+cadis --json worker result w1
+```
+
+**Arguments:** `<WORKER_ID>` (required)
+
+### workspace list — stable
+
+List registered workspaces.
+
+```bash
+cadis workspace list
+cadis workspace list --grants
+```
+
+| Flag | Description |
+|------|-------------|
+| `--grants` | Include workspace grants in the output |
+
+### workspace doctor — stable
+
+Run health checks on a workspace.
+
+```bash
+cadis workspace doctor
+cadis workspace doctor --workspace my-project
+cadis workspace doctor --root /home/user/project
+cadis workspace doctor my-project
+```
+
+| Flag | Description |
+|------|-------------|
+| `--workspace <ID>` | Workspace ID to check (also accepted as positional) |
+| `--root <PATH>` | Workspace root path to check |
+
+### voice status — stable
+
+Show daemon-visible voice subsystem status.
+
+```bash
+cadis voice
+cadis voice status
+```
+
+### voice doctor — stable
+
+Show voice doctor checks and local bridge preflight state.
+
+```bash
+cadis voice doctor
+cadis --json voice doctor
+```
+
+---
+
+## Experimental commands
+
+These commands may change or be removed in future v1.x releases.
+
+### run — experimental
+
+Send a desktop task as a chat request, optionally scoped to a directory.
+
+```bash
+cadis run "build all"
+cadis run --cwd /tmp build all
+```
+
+**Arguments:** `<TASK>` (required, remaining args joined)
+
+| Flag | Description |
+|------|-------------|
+| `--cwd <PATH>` | Working directory context for the task |
+
+### worker cleanup — experimental
+
+Not yet implemented as a CLI subcommand. Worker worktree cleanup is managed through the daemon protocol.
+
+### workspace register — experimental
+
+Register a new workspace with the daemon.
+
+```bash
+cadis workspace register my-project /home/user/project
+cadis workspace register my-project /home/user/project --kind sandbox --untrusted
+```
+
+**Arguments:** `<ID>` (required), `<ROOT>` (required)
+
+| Flag | Description |
+|------|-------------|
+| `--kind <KIND>` | `project`, `documents`, `sandbox`, or `worktree` (default: project) |
+| `--alias <ALIAS>` | Alias for the workspace (repeatable) |
+| `--vcs <VCS>` | VCS type (default: git) |
+| `--no-vcs` | Mark workspace as having no VCS |
+| `--trusted` / `--untrusted` | Trust level (default: trusted) |
+| `--worktree-root <PATH>` | Worktree root (default: `.cadis/worktrees`) |
+| `--artifact-root <PATH>` | Artifact root (default: `.cadis/artifacts`) |
+
+### workspace grant — experimental
+
+Grant workspace access to an agent.
+
+```bash
+cadis workspace grant my-project --access read,write --agent agent_w1
+```
+
+**Arguments:** `<WORKSPACE_ID>` (required)
+
+| Flag | Description |
+|------|-------------|
+| `--agent <AGENT_ID>` | Agent to grant access to |
+| `--access <LIST>` | Comma-separated: `read`, `write`, `exec`, `admin` |
+| `--source <SOURCE>` | Grant source label (default: `user`) |
+
+### workspace revoke — experimental
+
+Revoke a workspace grant.
+
+```bash
+cadis workspace revoke --grant grant_abc123
+cadis workspace revoke --workspace my-project --agent agent_w1
+cadis workspace revoke my-project
+```
+
+| Flag | Description |
+|------|-------------|
+| `--grant <GRANT_ID>` | Specific grant ID to revoke |
+| `--workspace <ID>` | Workspace ID (also accepted as positional) |
+| `--agent <AGENT_ID>` | Agent whose grants to revoke |
+
+---
+
+## Internal commands
+
+These are not part of the public CLI contract.
+
+| Command | Description |
+|---------|-------------|
+| `daemon [ARGS...]` | Launch `cadisd` from sibling path or `$PATH` |
+| `tool [OPTIONS] <NAME>` | Direct daemon tool call (internal/debug) |
+| `session subscribe <ID>` | Subscribe to a session event stream (internal/debug) |
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success |
+| `1` | General error (connection failure, invalid input, daemon rejection) |
+
+All errors print a message to stderr in the format: `cadis: <message>`.
+
+---
+
+## JSON output format (`--json`)
+
+When `--json` is passed, the CLI prints one NDJSON line per server frame instead of human-readable output. Each line is a `ServerFrame` — either a `Response` or an `Event`.
+
+### Response frame
+
+```json
+{
+  "type": "response",
+  "payload": {
+    "request_id": "req_12345_1700000000000",
+    "response": {
+      "type": "daemon.status",
+      "status": "running",
+      "version": "0.9.0",
+      "protocol_version": "1",
+      "cadis_home": "/home/user/.cadis",
+      "sessions": 1,
+      "model_provider": "ollama",
+      "uptime_seconds": 3600
+    }
+  }
+}
+```
+
+### Event frame
+
+```json
+{
+  "type": "event",
+  "payload": {
+    "event_id": "evt_abc123",
+    "session_id": "sess_001",
+    "type": "message.completed",
+    ...
+  }
+}
+```
+
+### Rejection frame
+
+```json
+{
+  "type": "response",
+  "payload": {
+    "request_id": "req_12345_1700000000000",
+    "response": {
+      "type": "request.rejected",
+      "code": "invalid_request",
+      "message": "unknown command",
+      "retryable": false
+    }
+  }
+}
+```
+
+For streaming commands (`events`, `session subscribe`), frames are emitted as they arrive, one per line.

--- a/docs/31_STORAGE_FORMAT.md
+++ b/docs/31_STORAGE_FORMAT.md
@@ -1,0 +1,297 @@
+# Storage Format and Migration — v1.0
+
+## 1. `~/.cadis` Directory Layout
+
+```text
+~/.cadis/
+├── config.toml                        # Global daemon configuration (TOML)
+├── profiles/
+│   └── {profile_id}/                  # One profile home per identity
+│       ├── profile.toml
+│       ├── agents/{agent_id}/         # Persistent agent homes
+│       ├── workspaces/
+│       │   ├── registry.toml          # Workspace registry
+│       │   ├── aliases.toml           # Workspace aliases
+│       │   └── grants.jsonl           # Append-only workspace grants
+│       ├── artifacts/workers/{id}/    # Worker artifact outputs
+│       ├── checkpoints/               # Checkpoint snapshots
+│       ├── sessions/                  # Profile session data
+│       ├── workers/                   # Worker state records
+│       ├── memory/                    # Profile-wide memory
+│       ├── skills/                    # Profile-level skills
+│       ├── eventlog/                  # Append-only event streams
+│       ├── secrets/                   # Encrypted/keyring secret handles
+│       ├── logs/                      # Profile-scoped redacted logs
+│       ├── locks/                     # State mutation locks
+│       └── run/                       # Profile runtime files
+├── state/
+│   ├── sessions/{session_id}.json     # Session metadata
+│   ├── agents/{agent_id}.json         # Agent metadata
+│   ├── agent-sessions/{id}.json       # AgentSession metadata
+│   ├── workers/{worker_id}.json       # Worker metadata
+│   └── approvals/{approval_id}.json   # Approval metadata
+├── logs/
+│   ├── {session_id}.jsonl             # Per-session redacted event log
+│   └── daemon.jsonl                   # Daemon-level events (no session)
+├── run/
+│   └── cadisd.sock                    # Daemon Unix socket
+├── global-cache/                      # Shared cache (safe to delete)
+├── plugins/                           # Installed plugins/extensions
+└── bin/                               # Managed helper binaries
+```
+
+All directories under `~/.cadis` are created with mode `0700`. All files are
+written with mode `0600`. Writes use atomic rename via temporary files to
+prevent partial reads.
+
+The socket path resolves as: `$CADIS_SOCKET` → `config.toml socket_path` →
+`$XDG_RUNTIME_DIR/cadis/cadisd.sock` → `~/.cadis/run/cadisd.sock`.
+
+## 2. State Metadata Formats
+
+Each state record is a single pretty-printed JSON file under `~/.cadis/state/`.
+File names use redaction-safe IDs: path separators and special characters are
+replaced with `_`. Secret-looking values are replaced with `[REDACTED]` before
+writing.
+
+### Session (`state/sessions/{session_id}.json`)
+
+```json
+{
+  "session_id": "ses_abc123",
+  "title": "User chat session",
+  "cwd": "/home/user/project"
+}
+```
+
+### Agent (`state/agents/{agent_id}.json`)
+
+```json
+{
+  "agent_id": "main",
+  "role": "Orchestrator",
+  "display_name": "CADIS",
+  "parent_agent_id": null,
+  "model": "auto",
+  "status": "ready",
+  "specialist_id": "cadis-main",
+  "specialist_label": "Main Orchestrator",
+  "persona": "..."
+}
+```
+
+### AgentSession (`state/agent-sessions/{id}.json`)
+
+```json
+{
+  "agent_session_id": "ags_xyz789",
+  "session_id": "ses_abc123",
+  "route_id": "route_1",
+  "agent_id": "main",
+  "parent_agent_id": null,
+  "task": "Respond to user message",
+  "status": "running",
+  "timeout_at": "2026-04-29T01:15:00Z",
+  "budget_steps": 8,
+  "steps_used": 2,
+  "result": null,
+  "error_code": null,
+  "error": null,
+  "cancellation_requested_at": null
+}
+```
+
+### Worker (`state/workers/{worker_id}.json`)
+
+```json
+{
+  "worker_id": "worker_1",
+  "session_id": "ses_abc123",
+  "agent_id": "coder",
+  "parent_agent_id": "main",
+  "agent_session_id": "ags_xyz789",
+  "status": "running",
+  "cli": null,
+  "cwd": "/home/user/project/.cadis/worktrees/worker_1",
+  "summary": "Implement auth module",
+  "error_code": null,
+  "error": null,
+  "cancellation_requested_at": null,
+  "worktree": { "workspace_id": "my-project", "branch": "cadis/worker_1/auth" },
+  "artifacts": { "root": "~/.cadis/profiles/default/artifacts/workers/worker_1" },
+  "updated_at": "2026-04-29T01:00:00Z"
+}
+```
+
+### Approval (`state/approvals/{approval_id}.json`)
+
+```json
+{
+  "approval_id": "apr_1",
+  "session_id": "ses_abc123",
+  "tool_call_id": "tool_1",
+  "tool_name": "shell.run",
+  "risk_class": "system_change",
+  "title": "Approval needed",
+  "summary": "Run command in workspace",
+  "command": "make build",
+  "workspace": "/home/user/project",
+  "requested_at": "2026-04-29T01:00:00Z",
+  "expires_at": "2026-04-29T01:05:00Z",
+  "state": "pending",
+  "decision": null,
+  "reason": null,
+  "resolved_at": null
+}
+```
+
+`state` values: `pending`, `resolved`, `expired`.
+`decision` values (when resolved): `approved`, `denied`.
+
+## 3. JSONL Event Log Format
+
+Event logs are append-only JSONL files under `~/.cadis/logs/`. Each line is one
+redacted `EventEnvelope`:
+
+```json
+{"protocol_version":"0.9","event_id":"evt_001","timestamp":"2026-04-29T01:00:00Z","source":"cadisd","session_id":"ses_abc123","event":"message.complete","data":{...}}
+```
+
+Fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `protocol_version` | string | Protocol version (e.g. `"0.9"`) |
+| `event_id` | string | Daemon-generated unique event ID |
+| `timestamp` | string | UTC ISO-8601 timestamp |
+| `source` | string | Source component, usually `"cadisd"` |
+| `session_id` | string? | Session ID when event belongs to a session |
+| `event` | string | Event type (flattened via serde) |
+
+Events without a session ID are written to `daemon.jsonl`. Events with a
+session ID are written to `{session_id}.jsonl`. All secret-looking values are
+redacted before writing.
+
+## 4. Workspace Registry Format
+
+### Registry (`profiles/{id}/workspaces/registry.toml`)
+
+```toml
+[[workspace]]
+id = "my-project"
+kind = "project"
+root = "~/Project/my-project"
+vcs = "git"
+owner = "rama"
+trusted = true
+worktree_root = ".cadis/worktrees"
+artifact_root = ".cadis/artifacts"
+checkpoint_policy = "enabled"
+
+[[workspace.alias]]
+workspace_id = "my-project"
+aliases = ["myproj", "mp"]
+```
+
+`kind` values: `project`, `documents`, `sandbox`, `worktree`.
+`vcs` values: `none`, `git`.
+`checkpoint_policy` values: `enabled`, `disabled`.
+
+### Grants (`profiles/{id}/workspaces/grants.jsonl`)
+
+Append-only JSONL. Each line is one `WorkspaceGrantRecord`:
+
+```json
+{"grant_id":"grant_1","profile_id":"default","agent_id":"main","workspace_id":"my-project","root":"/home/user/Project/my-project","access":["read","write"],"created_at":"2026-04-29T01:00:00Z","expires_at":"2026-04-29T02:00:00Z","source":"user","reason":"User approved workspace access"}
+```
+
+`access` values: `read`, `write`, `exec`, `admin`.
+`source` values: `route`, `user`, `policy`, `worker_spawn`.
+
+## 5. Project `.cadis/` Layout
+
+```text
+<project>/.cadis/
+├── workspace.toml                     # Project-local workspace metadata
+├── .gitignore                         # Ignores worktrees/, artifacts/, tmp/, logs/
+├── worktrees/
+│   ├── {worker_id}/                   # Git worktree checkout
+│   └── .metadata/
+│       └── {worker_id}.toml           # Worktree lifecycle metadata
+├── artifacts/                         # Workspace-local artifacts
+└── media/
+    └── manifest.json                  # Media provenance manifest
+```
+
+### `workspace.toml`
+
+```toml
+workspace_id = "my-project"
+kind = "project"
+vcs = "git"
+worktree_root = ".cadis/worktrees"
+artifact_root = ".cadis/artifacts"
+media_root = ".cadis/media"
+```
+
+### Worker worktree metadata (`.metadata/{worker_id}.toml`)
+
+```toml
+worker_id = "worker_1"
+workspace_id = "my-project"
+worktree_path = ".cadis/worktrees/worker_1"
+branch_name = "cadis/worker_1/auth"
+base_ref = "HEAD"
+state = "ready"
+artifact_root = "/home/user/.cadis/profiles/default/artifacts/workers/worker_1"
+```
+
+`state` values: `planned`, `ready`, `review_pending`, `cleanup_pending`, `removed`.
+
+### Media manifest (`media/manifest.json`)
+
+```json
+{
+  "entries": [
+    {
+      "path": "generated/image.png",
+      "generated_by": "agent/main",
+      "tool": "image.generate",
+      "created_at": "2026-04-29T01:00:00Z",
+      "description": "Generated concept art"
+    }
+  ]
+}
+```
+
+## 6. State Migration Policy
+
+The v1.0 storage format is **stable**. Future v1.x releases will include
+migration scripts if the format changes.
+
+**v0.x → v1.0 migration:** Delete `~/.cadis/state/` and restart the daemon.
+Session and agent-session state is ephemeral and rebuilt on daemon startup.
+Worker and approval state from v0.x is not carried forward.
+
+No migration is needed for profile homes, workspace registries, or agent homes
+— these formats are forward-compatible from v0.9.
+
+## 7. Backup and Restore
+
+To back up a C.A.D.I.S. installation:
+
+```bash
+cp ~/.cadis/config.toml /backup/cadis/config.toml
+cp -a ~/.cadis/profiles/ /backup/cadis/profiles/
+```
+
+To restore:
+
+```bash
+cp /backup/cadis/config.toml ~/.cadis/config.toml
+cp -a /backup/cadis/profiles/ ~/.cadis/profiles/
+```
+
+The `state/` directory is ephemeral and does not need to be backed up. The
+`logs/` directory can optionally be preserved for audit. The `run/` directory
+contains runtime sockets and should not be backed up.


### PR DESCRIPTION
## Summary
v1.0 release candidate preparation: all required documentation and release workflow updates.

## Changes
- **Protocol Freeze** (docs/29_PROTOCOL_FREEZE.md): documents stable protocol subset for v1.0
- **Stable CLI Reference** (docs/30_STABLE_CLI.md): documents all CLI commands with stability status
- **Storage Format** (docs/31_STORAGE_FORMAT.md): documents ~/.cadis layout and migration path
- **HUD Packaging**: adds Tauri build job to release.yml (AppImage + deb artifacts)
- **Security**: updates SECURITY.md with response timeline and supported versions
- **Changelog**: finalizes v0.9.2 section

## Testing
- 296 tests pass, cargo fmt/clippy/build clean

## v1.0 Readiness Checklist
- [x] Protocol freeze documentation
- [x] Stable CLI command documentation
- [x] Storage migration path documentation
- [x] HUD packaging in release workflow
- [x] Security response process verified
- [x] Changelog finalized