### PR TITLE
fix: progress workflow branch protection

### DIFF
--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   progress:
@@ -16,9 +17,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Calculate progress
         run: bash scripts/update-progress.sh
-      - name: Commit if changed
+      - name: Create PR if changed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/progress.json
-          git diff --cached --quiet || git commit -m "chore: update progress [skip ci]" && git push
+          if git diff --cached --quiet; then
+            echo "No changes to progress.json"
+            exit 0
+          fi
+          BRANCH="chore/update-progress-$(date +%s)"
+          git checkout -b "$BRANCH"
+          git commit -m "chore: update progress.json [skip ci]"
+          git push origin "$BRANCH"
+          gh pr create --title "chore: update progress.json" --body "Automated progress update from checklist change." --base main --head "$BRANCH"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The progress.yml workflow was failing because it tried to push directly to main, which is blocked by the branch protection ruleset. Changed to create a PR instead.