### PR TITLE
fix: preserve non-socket files at daemon socket path

### DIFF
--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::error::Error;
 use std::fs;
 use std::io::{self, BufRead, BufReader, BufWriter, Write};
+use std::os::unix::fs::FileTypeExt;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::process;
@@ -632,6 +633,30 @@ mod tests {
             .try_recv()
             .expect("subscriber should remain attached until a matching event");
         assert_eq!(received.event_id.as_str(), "evt_000002");
+    }
+
+    #[test]
+    fn prepare_socket_path_rejects_existing_regular_file_without_deleting_it() {
+        let cadis_home = test_workspace("cadis-daemon-socket-regular-file");
+        let socket_path = cadis_home.join("run").join("cadisd-test.sock");
+        fs::create_dir_all(
+            socket_path
+                .parent()
+                .expect("socket path should have a parent"),
+        )
+        .expect("socket parent should be created");
+        fs::write(&socket_path, "not a socket").expect("regular file should write");
+
+        let error = prepare_socket_path(&socket_path).expect_err("regular file should be rejected");
+        let io_error = error
+            .downcast_ref::<io::Error>()
+            .expect("prepare_socket_path should return an io error");
+
+        assert_eq!(io_error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            fs::read_to_string(&socket_path).expect("regular file should remain readable"),
+            "not a socket"
+        );
     }
 
     #[test]
@@ -1273,18 +1298,34 @@ fn prepare_socket_path(socket_path: &Path) -> Result<(), Box<dyn Error>> {
         }
     }
 
-    if socket_path.exists() {
-        if UnixStream::connect(socket_path).is_ok() {
-            return Err(io::Error::new(
-                io::ErrorKind::AlreadyExists,
-                format!(
-                    "daemon already appears to be running at {}",
-                    socket_path.display()
-                ),
-            )
-            .into());
+    match fs::symlink_metadata(socket_path) {
+        Ok(metadata) => {
+            if UnixStream::connect(socket_path).is_ok() {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!(
+                        "daemon already appears to be running at {}",
+                        socket_path.display()
+                    ),
+                )
+                .into());
+            }
+
+            if metadata.file_type().is_socket() {
+                fs::remove_file(socket_path)?;
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!(
+                        "socket path {} already exists and is not a Unix socket",
+                        socket_path.display()
+                    ),
+                )
+                .into());
+            }
         }
-        fs::remove_file(socket_path)?;
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.into()),
     }
 
     Ok(())


### PR DESCRIPTION
Cherry-pick of #30 by @DeryFerd, rebased on current main with fmt fix.

When a regular file exists at the socket path, the daemon now returns an error instead of deleting it. Only stale Unix sockets are removed.

Co-authored-by: DeryFerd

Supersedes #30