### PR TITLE
ci: avoid duplicate npm publish on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,22 +153,3 @@ jobs:
         with:
           generate_release_notes: true
           files: artifacts/*
-
-  npm-publish:
-    name: Publish to npm
-    needs: [release]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
-      - name: Sync version and publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
-          cd npm/cadis
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
-          npm publish --access public

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -616,12 +616,12 @@ mod tests {
         CadisEvent, EmptyPayload, EventId, SessionEventPayload, SessionId, Timestamp,
     };
     #[cfg(unix)]
-    use cadis_protocol::{DaemonResponse, RequestId};
-    #[cfg(unix)]
     use cadis_protocol::{
         ClientId, ContentKind, MessageSendRequest, RequestEnvelope, ServerFrame,
         SessionCreateRequest, SessionTargetRequest,
     };
+    #[cfg(unix)]
+    use cadis_protocol::{DaemonResponse, RequestId};
     #[cfg(unix)]
     use std::sync::Condvar;
     #[cfg(unix)]

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -613,9 +613,10 @@ mod tests {
     #[cfg(unix)]
     use cadis_models::{ModelInvocation, ModelProvider, ModelResponse};
     use cadis_protocol::{
-        CadisEvent, DaemonResponse, EmptyPayload, EventId, RequestId, SessionEventPayload,
-        SessionId, Timestamp,
+        CadisEvent, EmptyPayload, EventId, SessionEventPayload, SessionId, Timestamp,
     };
+    #[cfg(unix)]
+    use cadis_protocol::{DaemonResponse, RequestId};
     #[cfg(unix)]
     use cadis_protocol::{
         ClientId, ContentKind, MessageSendRequest, RequestEnvelope, ServerFrame,
@@ -623,6 +624,7 @@ mod tests {
     };
     #[cfg(unix)]
     use std::sync::Condvar;
+    #[cfg(unix)]
     use std::time::{Duration, Instant};
 
     #[test]

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -3,12 +3,15 @@
 use std::env;
 use std::error::Error;
 use std::fmt;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::fs::File;
 
 use cadis_protocol::{
     AgentId, AgentSessionId, ApprovalDecision, ApprovalId, EventEnvelope, RiskClass, SessionId,

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -2597,9 +2597,15 @@ fn set_private_file_permissions(_path: &Path) -> Result<(), StoreError> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn sync_parent_dir(path: &Path) -> Result<(), StoreError> {
     let dir = File::open(path)?;
     dir.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_path: &Path) -> Result<(), StoreError> {
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- remove the npm publish job from .github/workflows/release.yml
- keep npm publishing in the dedicated .github/workflows/npm-publish.yml workflow
- prevent duplicate publish attempts for the same release tag

## Why
Both workflows can publish the same version on release, which can fail with \ersion already exists\ and create noisy release runs.