### PR TITLE
core: harden workspace path guards on Windows

### DIFF
--- a/crates/cadis-core/src/workspace.rs
+++ b/crates/cadis-core/src/workspace.rs
@@ -323,12 +323,65 @@ pub(crate) fn normalize_aliases(aliases: Vec<String>) -> Vec<String> {
     aliases
 }
 
-pub(crate) fn canonical_workspace_root(root: &str) -> Result<PathBuf, std::io::Error> {
-    let path = if let Some(rest) = root.strip_prefix("~/") {
-        std::env::var_os("HOME")
+fn canonical_home_dir() -> Option<PathBuf> {
+    let mut candidates = vec![
+        std::env::var_os("HOME").map(PathBuf::from),
+        std::env::var_os("USERPROFILE").map(PathBuf::from),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
+
+    if let (Some(home_drive), Some(home_path)) =
+        (std::env::var_os("HOMEDRIVE"), std::env::var_os("HOMEPATH"))
+    {
+        let mut joined = PathBuf::from(home_drive);
+        joined.push(PathBuf::from(home_path));
+        candidates.push(joined);
+    }
+
+    candidates
+        .into_iter()
+        .find_map(|candidate| candidate.canonicalize().ok())
+}
+
+fn protected_system_paths() -> Vec<PathBuf> {
+    let mut protected = vec![
+        PathBuf::from("/etc"),
+        PathBuf::from("/dev"),
+        PathBuf::from("/proc"),
+        PathBuf::from("/sys"),
+        PathBuf::from("/run"),
+    ];
+
+    if cfg!(windows) {
+        let drive = std::env::var_os("SystemDrive")
             .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from("~"))
-            .join(rest)
+            .unwrap_or_else(|| PathBuf::from("C:"));
+        for segment in ["Windows", "Program Files", "Program Files (x86)", "ProgramData"] {
+            let mut path = drive.clone();
+            path.push(segment);
+            protected.push(path);
+        }
+    }
+
+    protected
+        .into_iter()
+        .map(|path| path.canonicalize().unwrap_or(path))
+        .collect()
+}
+
+fn is_protected_system_path(path: &Path) -> bool {
+    protected_system_paths()
+        .iter()
+        .any(|denied| path == denied || path.starts_with(denied))
+}
+
+pub(crate) fn canonical_workspace_root(root: &str) -> Result<PathBuf, std::io::Error> {
+    let path = if let Some(rest) = root.strip_prefix("~/").or_else(|| root.strip_prefix("~\\")) {
+        canonical_home_dir()
+            .map(|home| home.join(rest))
+            .unwrap_or_else(|| PathBuf::from(root))
     } else {
         PathBuf::from(root)
     };
@@ -344,10 +397,7 @@ pub(crate) fn validate_workspace_root(root: &Path, cadis_home: &Path) -> Result<
         ));
     }
 
-    if ["/etc", "/dev", "/proc", "/sys", "/run"]
-        .iter()
-        .any(|path| root == Path::new(path))
-    {
+    if is_protected_system_path(root) {
         return Err(tool_error(
             "workspace_root_denied",
             format!(
@@ -358,10 +408,7 @@ pub(crate) fn validate_workspace_root(root: &Path, cadis_home: &Path) -> Result<
         ));
     }
 
-    if let Some(home) = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .and_then(|path| path.canonicalize().ok())
-    {
+    if let Some(home) = canonical_home_dir() {
         if root == home || home.starts_with(root) {
             return Err(tool_error(
                 "workspace_root_too_broad",
@@ -407,21 +454,15 @@ pub(crate) fn validate_shell_cwd(cwd: &Path, cadis_home: &Path) -> Result<(), Er
         ));
     }
 
-    for denied in ["/etc", "/dev", "/proc", "/sys", "/run"] {
-        let denied = Path::new(denied);
-        if cwd == denied || cwd.starts_with(denied) {
-            return Err(tool_error(
-                "shell_cwd_denied",
-                format!("shell.run cwd {} is a protected system path", cwd.display()),
-                false,
-            ));
-        }
+    if is_protected_system_path(cwd) {
+        return Err(tool_error(
+            "shell_cwd_denied",
+            format!("shell.run cwd {} is a protected system path", cwd.display()),
+            false,
+        ));
     }
 
-    if let Some(home) = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .and_then(|path| path.canonicalize().ok())
-    {
+    if let Some(home) = canonical_home_dir() {
         if cwd == home || home.starts_with(cwd) {
             return Err(tool_error(
                 "shell_cwd_denied",

--- a/crates/cadis-core/src/workspace.rs
+++ b/crates/cadis-core/src/workspace.rs
@@ -356,10 +356,21 @@ fn protected_system_paths() -> Vec<PathBuf> {
 
     if cfg!(windows) {
         let drive = std::env::var_os("SystemDrive")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from("C:"));
-        for segment in ["Windows", "Program Files", "Program Files (x86)", "ProgramData"] {
-            let mut path = drive.clone();
+            .and_then(|value| value.to_str().map(str::to_owned))
+            .unwrap_or_else(|| "C:".to_owned());
+        let drive_root = if drive.ends_with('\\') || drive.ends_with('/') {
+            drive
+        } else {
+            format!("{drive}\\")
+        };
+        let drive_root = PathBuf::from(drive_root);
+        for segment in [
+            "Windows",
+            "Program Files",
+            "Program Files (x86)",
+            "ProgramData",
+        ] {
+            let mut path = drive_root.clone();
             path.push(segment);
             protected.push(path);
         }

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -616,12 +616,12 @@ mod tests {
         CadisEvent, EmptyPayload, EventId, SessionEventPayload, SessionId, Timestamp,
     };
     #[cfg(unix)]
-    use cadis_protocol::{DaemonResponse, RequestId};
-    #[cfg(unix)]
     use cadis_protocol::{
         ClientId, ContentKind, MessageSendRequest, RequestEnvelope, ServerFrame,
         SessionCreateRequest, SessionTargetRequest,
     };
+    #[cfg(unix)]
+    use cadis_protocol::{DaemonResponse, RequestId};
     #[cfg(unix)]
     use std::sync::Condvar;
     #[cfg(unix)]

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -613,9 +613,10 @@ mod tests {
     #[cfg(unix)]
     use cadis_models::{ModelInvocation, ModelProvider, ModelResponse};
     use cadis_protocol::{
-        CadisEvent, DaemonResponse, EmptyPayload, EventId, RequestId, SessionEventPayload,
-        SessionId, Timestamp,
+        CadisEvent, EmptyPayload, EventId, SessionEventPayload, SessionId, Timestamp,
     };
+    #[cfg(unix)]
+    use cadis_protocol::{DaemonResponse, RequestId};
     #[cfg(unix)]
     use cadis_protocol::{
         ClientId, ContentKind, MessageSendRequest, RequestEnvelope, ServerFrame,
@@ -623,6 +624,7 @@ mod tests {
     };
     #[cfg(unix)]
     use std::sync::Condvar;
+    #[cfg(unix)]
     use std::time::{Duration, Instant};
 
     #[test]

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -3,12 +3,15 @@
 use std::env;
 use std::error::Error;
 use std::fmt;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::fs::File;
 
 use cadis_protocol::{
     AgentId, AgentSessionId, ApprovalDecision, ApprovalId, EventEnvelope, RiskClass, SessionId,

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -2597,9 +2597,15 @@ fn set_private_file_permissions(_path: &Path) -> Result<(), StoreError> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn sync_parent_dir(path: &Path) -> Result<(), StoreError> {
     let dir = File::open(path)?;
     dir.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_path: &Path) -> Result<(), StoreError> {
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- add home directory resolution fallbacks (USERPROFILE, HOMEDRIVE + HOMEPATH) in addition to HOME
- support both ~/... and ~\\... for workspace root expansion
- extend protected system path checks so they also cover common Windows system roots

## Why
Workspace/root safety checks were mostly Unix-oriented. On Windows, this could miss protected locations and weaken the same guardrails we already enforce on Unix.