### PR TITLE
npm: verify SHA-256 for downloaded native binaries

### DIFF
--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -616,12 +616,12 @@ mod tests {
         CadisEvent, EmptyPayload, EventId, SessionEventPayload, SessionId, Timestamp,
     };
     #[cfg(unix)]
-    use cadis_protocol::{DaemonResponse, RequestId};
-    #[cfg(unix)]
     use cadis_protocol::{
         ClientId, ContentKind, MessageSendRequest, RequestEnvelope, ServerFrame,
         SessionCreateRequest, SessionTargetRequest,
     };
+    #[cfg(unix)]
+    use cadis_protocol::{DaemonResponse, RequestId};
     #[cfg(unix)]
     use std::sync::Condvar;
     #[cfg(unix)]

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -613,9 +613,10 @@ mod tests {
     #[cfg(unix)]
     use cadis_models::{ModelInvocation, ModelProvider, ModelResponse};
     use cadis_protocol::{
-        CadisEvent, DaemonResponse, EmptyPayload, EventId, RequestId, SessionEventPayload,
-        SessionId, Timestamp,
+        CadisEvent, EmptyPayload, EventId, SessionEventPayload, SessionId, Timestamp,
     };
+    #[cfg(unix)]
+    use cadis_protocol::{DaemonResponse, RequestId};
     #[cfg(unix)]
     use cadis_protocol::{
         ClientId, ContentKind, MessageSendRequest, RequestEnvelope, ServerFrame,
@@ -623,6 +624,7 @@ mod tests {
     };
     #[cfg(unix)]
     use std::sync::Condvar;
+    #[cfg(unix)]
     use std::time::{Duration, Instant};
 
     #[test]

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -3,12 +3,15 @@
 use std::env;
 use std::error::Error;
 use std::fmt;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::fs::File;
 
 use cadis_protocol::{
     AgentId, AgentSessionId, ApprovalDecision, ApprovalId, EventEnvelope, RiskClass, SessionId,

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -2597,9 +2597,15 @@ fn set_private_file_permissions(_path: &Path) -> Result<(), StoreError> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn sync_parent_dir(path: &Path) -> Result<(), StoreError> {
     let dir = File::open(path)?;
     dir.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_path: &Path) -> Result<(), StoreError> {
     Ok(())
 }
 

--- a/npm/cadis/scripts/install.js
+++ b/npm/cadis/scripts/install.js
@@ -3,6 +3,7 @@
 "use strict";
 
 const { execSync } = require("child_process");
+const crypto = require("crypto");
 const fs = require("fs");
 const https = require("https");
 const os = require("os");
@@ -59,6 +60,23 @@ function download(url) {
   });
 }
 
+function checksumSha256(buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+function parseSha256File(text, expectedFileName) {
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const [hash, ...rest] = line.split(/\s+/);
+    if (!hash || !/^[a-f0-9]{64}$/i.test(hash)) continue;
+    if (rest.length === 0) return hash.toLowerCase();
+    const fileToken = rest.join(" ").replace(/^\*/, "");
+    if (fileToken === expectedFileName) return hash.toLowerCase();
+  }
+  throw new Error(`Could not parse SHA256 for ${expectedFileName}`);
+}
+
 async function main() {
   const target = getTarget();
   const version = getVersion();
@@ -81,10 +99,17 @@ async function main() {
   fs.mkdirSync(dir, { recursive: true });
 
   for (const name of BINARIES) {
-    const url = `${base}/${name}-${target}${ext}`;
+    const artifactName = `${name}-${target}${ext}`;
+    const url = `${base}/${artifactName}`;
+    const checksumUrl = `${url}.sha256`;
     process.stdout.write(`Downloading ${name} v${version} for ${target}...`);
     try {
-      const buf = await download(url);
+      const [buf, checksumBuf] = await Promise.all([download(url), download(checksumUrl)]);
+      const expected = parseSha256File(checksumBuf.toString("utf8"), artifactName);
+      const actual = checksumSha256(buf);
+      if (actual !== expected) {
+        throw new Error(`Checksum mismatch for ${artifactName} (expected ${expected}, got ${actual})`);
+      }
       const dest = path.join(dir, `${name}${ext}`);
       fs.writeFileSync(dest, buf, { mode: 0o755 });
       console.log(" ok");
@@ -92,6 +117,7 @@ async function main() {
       console.log(" failed");
       console.error(`  ${err.message}`);
       console.error(`  You can download manually from: ${url}`);
+      console.error(`  Checksum file: ${checksumUrl}`);
       process.exit(0); // don't break npm install
     }
   }


### PR DESCRIPTION
## Summary
- add SHA-256 verification for cadis and cadisd binaries in the npm install script
- fetch matching .sha256 release assets and parse expected hashes
- abort local install step (without failing npm install) when checksum validation fails

## Why
The installer currently trusts downloaded binaries without integrity checks. This change validates release assets against published checksums before writing executables to disk.