### PR TITLE
scripts: harden update-progress checklist parsing

### DIFF
--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -616,12 +616,12 @@ mod tests {
         CadisEvent, EmptyPayload, EventId, SessionEventPayload, SessionId, Timestamp,
     };
     #[cfg(unix)]
-    use cadis_protocol::{DaemonResponse, RequestId};
-    #[cfg(unix)]
     use cadis_protocol::{
         ClientId, ContentKind, MessageSendRequest, RequestEnvelope, ServerFrame,
         SessionCreateRequest, SessionTargetRequest,
     };
+    #[cfg(unix)]
+    use cadis_protocol::{DaemonResponse, RequestId};
     #[cfg(unix)]
     use std::sync::Condvar;
     #[cfg(unix)]

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -613,9 +613,10 @@ mod tests {
     #[cfg(unix)]
     use cadis_models::{ModelInvocation, ModelProvider, ModelResponse};
     use cadis_protocol::{
-        CadisEvent, DaemonResponse, EmptyPayload, EventId, RequestId, SessionEventPayload,
-        SessionId, Timestamp,
+        CadisEvent, EmptyPayload, EventId, SessionEventPayload, SessionId, Timestamp,
     };
+    #[cfg(unix)]
+    use cadis_protocol::{DaemonResponse, RequestId};
     #[cfg(unix)]
     use cadis_protocol::{
         ClientId, ContentKind, MessageSendRequest, RequestEnvelope, ServerFrame,
@@ -623,6 +624,7 @@ mod tests {
     };
     #[cfg(unix)]
     use std::sync::Condvar;
+    #[cfg(unix)]
     use std::time::{Duration, Instant};
 
     #[test]

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -3,12 +3,15 @@
 use std::env;
 use std::error::Error;
 use std::fmt;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::fs::File;
 
 use cadis_protocol::{
     AgentId, AgentSessionId, ApprovalDecision, ApprovalId, EventEnvelope, RiskClass, SessionId,

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -2597,9 +2597,15 @@ fn set_private_file_permissions(_path: &Path) -> Result<(), StoreError> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn sync_parent_dir(path: &Path) -> Result<(), StoreError> {
     let dir = File::open(path)?;
     dir.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_path: &Path) -> Result<(), StoreError> {
     Ok(())
 }
 

--- a/scripts/update-progress.sh
+++ b/scripts/update-progress.sh
@@ -6,10 +6,19 @@ set -euo pipefail
 CHECKLIST="docs/07_MASTER_CHECKLIST.md"
 OUTPUT="docs/progress.json"
 
-done=$(grep -c '^\- \[x\]' "$CHECKLIST" || true)
+if [ ! -f "$CHECKLIST" ]; then
+  echo "ERROR: checklist file not found: $CHECKLIST" >&2
+  exit 1
+fi
+
+done=$(grep -c '^\- \[[xX]\]' "$CHECKLIST" || true)
 todo=$(grep -c '^\- \[ \]' "$CHECKLIST" || true)
 total=$((done + todo))
-pct=$((done * 100 / total))
+if [ "$total" -eq 0 ]; then
+  pct=0
+else
+  pct=$((done * 100 / total))
+fi
 
 # Determine current milestone and next target
 if [ "$pct" -lt 80 ]; then
@@ -45,4 +54,4 @@ cat > "$OUTPUT" <<EOF
 }
 EOF
 
-echo "Progress: $done/$total ($pct%) — $milestone → $next at ${target}%"
+echo "Progress: $done/$total ($pct%) -- $milestone -> $next at ${target}%"


### PR DESCRIPTION
## Summary
- guard against missing docs/07_MASTER_CHECKLIST.md
- count both - [x] and - [X] checklist markers
- prevent divide-by-zero when no checklist items are present
- normalize status log output to plain ASCII for shell compatibility

## Why
update-progress.sh could fail on edge cases (missing file or empty checklist) and silently ignore uppercase completed markers, which can produce inaccurate progress values.