### PR TITLE
ci: resolve npm publish version from release metadata

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,12 +27,20 @@ jobs:
       - name: Resolve version
         id: version
         run: |
+          VERSION=""
           if [ -n "${{ github.event.inputs.version }}" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+            VERSION="${{ github.event.inputs.version }}"
+          elif [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
           else
-            TAG="${GITHUB_REF#refs/tags/v}"
-            echo "version=$TAG" >> "$GITHUB_OUTPUT"
+            VERSION="${GITHUB_REF#refs/tags/}"
           fi
+          VERSION="${VERSION#v}"
+          if [ -z "$VERSION" ]; then
+            echo "Could not resolve publish version from workflow context." >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Sync version
         run: |

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -616,12 +616,12 @@ mod tests {
         CadisEvent, EmptyPayload, EventId, SessionEventPayload, SessionId, Timestamp,
     };
     #[cfg(unix)]
-    use cadis_protocol::{DaemonResponse, RequestId};
-    #[cfg(unix)]
     use cadis_protocol::{
         ClientId, ContentKind, MessageSendRequest, RequestEnvelope, ServerFrame,
         SessionCreateRequest, SessionTargetRequest,
     };
+    #[cfg(unix)]
+    use cadis_protocol::{DaemonResponse, RequestId};
     #[cfg(unix)]
     use std::sync::Condvar;
     #[cfg(unix)]

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -613,9 +613,10 @@ mod tests {
     #[cfg(unix)]
     use cadis_models::{ModelInvocation, ModelProvider, ModelResponse};
     use cadis_protocol::{
-        CadisEvent, DaemonResponse, EmptyPayload, EventId, RequestId, SessionEventPayload,
-        SessionId, Timestamp,
+        CadisEvent, EmptyPayload, EventId, SessionEventPayload, SessionId, Timestamp,
     };
+    #[cfg(unix)]
+    use cadis_protocol::{DaemonResponse, RequestId};
     #[cfg(unix)]
     use cadis_protocol::{
         ClientId, ContentKind, MessageSendRequest, RequestEnvelope, ServerFrame,
@@ -623,6 +624,7 @@ mod tests {
     };
     #[cfg(unix)]
     use std::sync::Condvar;
+    #[cfg(unix)]
     use std::time::{Duration, Instant};
 
     #[test]

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -3,12 +3,15 @@
 use std::env;
 use std::error::Error;
 use std::fmt;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(unix)]
+use std::fs::File;
 
 use cadis_protocol::{
     AgentId, AgentSessionId, ApprovalDecision, ApprovalId, EventEnvelope, RiskClass, SessionId,

--- a/crates/cadis-store/src/lib.rs
+++ b/crates/cadis-store/src/lib.rs
@@ -2597,9 +2597,15 @@ fn set_private_file_permissions(_path: &Path) -> Result<(), StoreError> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn sync_parent_dir(path: &Path) -> Result<(), StoreError> {
     let dir = File::open(path)?;
     dir.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_path: &Path) -> Result<(), StoreError> {
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- update 
pm-publish.yml to resolve version from github.event.release.tag_name for release-triggered runs
- keep manual workflow_dispatch input support unchanged
- add validation so workflow fails fast if version cannot be resolved

## Why
Release-triggered workflows are safest when they use release payload metadata directly. This makes version resolution clearer and avoids publishing with an empty or malformed version string.