### PR TITLE
docs: update stale file.patch limitation and version ref in KNOWN_LIM…

### DIFF
--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -1,6 +1,6 @@
 # Known Limitations
 
-This document lists known limitations of C.A.D.I.S. v1.1.x.
+This document lists known limitations of C.A.D.I.S. v1.2.x.
 
 ## Platform
 
@@ -46,8 +46,9 @@ This document lists known limitations of C.A.D.I.S. v1.1.x.
   inline logic. Further decomposition is ongoing.
 - **Worker artifact view in HUD is read-only.** Apply/discard actions route
   through daemon approval but the full patch-apply flow needs more work.
-- **`file.patch` lacks atomic writes.** Structured file patching works but does
-  not yet use atomic temp-file writes or concurrent-edit protection.
+- **`file.patch` concurrent-edit detection is basic.** Structured file patching
+  uses atomic temp-file writes with rollback, but concurrent-edit conflict
+  detection remains simple and may not cover all race conditions.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

[KNOWN_LIMITATIONS.md](cci:7://file:///d:/Portfolio%20Data/Learning%20PR/cadis/docs/KNOWN_LIMITATIONS.md:0:0-0:0) contains two pieces of stale information that no longer reflect the current state of the codebase:

1. **`file.patch` limitation is outdated.** The document states that `file.patch` "lacks atomic writes" and "does not yet use atomic temp-file writes or concurrent-edit protection." However, PR #19 (DeryFerd) already implemented transactional file patching with a temp-file write followed by `fs::rename`, plus rollback on failure. The atomic write mechanism is in place; only concurrent-edit conflict detection remains basic.
2. **Version reference is behind.** The document header says "C.A.D.I.S. v1.1.x" but the project is now at v1.2.3.

## Why this matters

- **Misleading documentation erodes trust.** Contributors and users reading the limitations doc would believe atomic writes are missing when they are already implemented. This could lead to duplicate work or incorrect assumptions about reliability.
- **Accurate limitations help reviewers prioritize.** If the doc says something is missing when it's actually done, the remaining real gaps (like concurrent-edit detection) get less visibility than they deserve.
- **Version references should stay current.** The doc is a living document, not a changelog — it should describe the current state.

## Changes

- Updated the `file.patch` entry from "lacks atomic writes" to "concurrent-edit detection is basic" — accurately reflecting that atomic temp-file writes with rollback are implemented, but race-condition handling for simultaneous edits is still simple.
- Updated the document header from "v1.1.x" → "v1.2.x".

## Testing

- Documentation-only change — no code impact.
- Verified in [crates/cadis-core/src/lib.rs](cci:7://file:///d:/Portfolio%20Data/Learning%20PR/cadis/crates/cadis-core/src/lib.rs:0:0-0:0) that `fs::rename(&temp_path, &change.path)` with temp-file cleanup is present (line ~4573).

## Checklist

- [x] Commit follows conventional commit style (`docs:`)
- [x] No code changes
- [x] Accurately reflects current implementation state