### PR TITLE
feat(worker): add approval-gated worker.apply patch flow

### DIFF
--- a/apps/cadis-hud/src/ui/cadisActions.test.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.test.ts
@@ -541,6 +541,10 @@ describe("cadisActions", () => {
     const apply = screen.getByRole("button", { name: "APPLY" });
     expect(apply).toBeDisabled();
     expect(apply.getAttribute("title")).toBe("Pending daemon worker.apply support");
+
+    const discard = screen.getByRole("button", { name: "DISCARD" });
+    expect(discard).toBeDisabled();
+    expect(discard.getAttribute("title")).toBe("Daemon disconnected");
   });
 
   it("routes theme/opacity/avatar preference changes through daemon via ui.preferences.set", async () => {

--- a/apps/cadis-hud/src/ui/cadisActions.test.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.test.ts
@@ -531,7 +531,7 @@ describe("cadisActions", () => {
     expect(screen.getByText("started: Worker Coding: run focused HUD worker tests")).toBeInTheDocument();
   });
 
-  it("apply button is disabled pending daemon worker.apply support", () => {
+  it("apply button is disabled while disconnected", () => {
     for (const frame of mockCadisDaemonWorkerStream) {
       handleCadisFrameForTest(frame);
     }
@@ -540,7 +540,33 @@ describe("cadisActions", () => {
 
     const apply = screen.getByRole("button", { name: "APPLY" });
     expect(apply).toBeDisabled();
-    expect(apply.getAttribute("title")).toBe("Pending daemon worker.apply support");
+    expect(apply.getAttribute("title")).toBe("Daemon disconnected");
+  });
+
+  it("sends worker.apply from code work panel when connected", async () => {
+    connect();
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(4));
+    invokeMock.mockClear();
+
+    for (const frame of mockCadisDaemonWorkerStream) {
+      handleCadisFrameForTest(frame);
+    }
+    useHud.getState().selectWorker("worker_mock_001");
+
+    render(createElement(CodeWorkPanel));
+
+    const apply = screen.getByRole("button", { name: "APPLY" });
+    expect(apply).toBeEnabled();
+    fireEvent.click(apply);
+
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledTimes(1));
+    expect(sentRequest()).toMatchObject({
+      type: "worker.apply",
+      payload: {
+        worker_id: "worker_mock_001",
+        worktree_path: ".cadis/worktrees/worker_mock_001",
+      },
+    });
   });
 
   it("routes theme/opacity/avatar preference changes through daemon via ui.preferences.set", async () => {

--- a/apps/cadis-hud/src/ui/cadisActions.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.ts
@@ -245,21 +245,15 @@ export function sendVoicePreflight(report: VoiceDoctorReport, surface = "cadis-h
   return true;
 }
 
-// TODO: Pending daemon worker.apply support — file.patch needs workspace_id
-// and patch operations, not just worker_id. Re-enable when daemon resolves
-// worker patches via a dedicated worker.apply request.
-// export function sendApplyPatch(workerId: string, _patchPath?: string): boolean {
-//   if (!connected) return false;
-//   void callCadis("tool.call", {
-//     session_id: null,
-//     agent_id: null,
-//     tool_name: "file.patch",
-//     input: { worker_id: workerId },
-//   }).then((ok) => {
-//     if (!ok) scheduleReconnect();
-//   });
-//   return true;
-// }
+export function sendWorkerApply(workerId: string, worktreePath?: string): boolean {
+  if (!connected) return false;
+  const payload: Record<string, unknown> = { worker_id: workerId };
+  if (worktreePath) payload.worktree_path = worktreePath;
+  void callCadis("worker.apply", payload).then((ok) => {
+    if (!ok) scheduleReconnect();
+  });
+  return true;
+}
 
 export function sendWorkerCleanup(workerId: string, worktreePath?: string): boolean {
   if (!connected) return false;

--- a/apps/cadis-hud/src/ui/codework/CodeWorkPanel.tsx
+++ b/apps/cadis-hud/src/ui/codework/CodeWorkPanel.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useHud, type WorkerRecord } from "../hudState.js";
-import { sendWorkerCleanup } from "../cadisActions.js";
+import { sendWorkerApply, sendWorkerCleanup } from "../cadisActions.js";
 
 const EMPTY_VALUE = "not reported by daemon";
 
 export function CodeWorkPanel() {
   const open = useHud((s) => s.codeWorkPanelOpen);
+  const gateway = useHud((s) => s.gateway);
   const selectedWorkerId = useHud((s) => s.selectedWorkerId);
   const workers = useHud((s) => s.workers);
   const agents = useHud((s) => s.agents);
@@ -24,6 +25,10 @@ export function CodeWorkPanel() {
   const isTerminal = worker
     ? ["completed", "failed", "cancelled"].includes(worker.status)
     : false;
+  const canApply = worker
+    ? worker.status === "completed" && Boolean(worker.artifacts?.patch?.trim())
+    : false;
+  const disconnected = gateway !== "connected";
 
   if (!open) return null;
 
@@ -124,15 +129,22 @@ export function CodeWorkPanel() {
         <div>
           <button
             type="button"
-            disabled
-            title="Pending daemon worker.apply support"
+            disabled={!canApply || disconnected}
+            title={
+              disconnected
+                ? "Daemon disconnected"
+                : canApply
+                  ? "Send worker.apply to daemon"
+                  : "Worker must be completed with a patch artifact"
+            }
+            onClick={() => worker && sendWorkerApply(worker.id, worker.worktree?.worktreePath)}
           >
             APPLY
           </button>
           <button
             type="button"
-            disabled={!worker || !isTerminal}
-            title="Send worker.cleanup to daemon"
+            disabled={!worker || !isTerminal || disconnected}
+            title={disconnected ? "Daemon disconnected" : "Send worker.cleanup to daemon"}
             onClick={() => worker && sendWorkerCleanup(worker.id, worker.worktree?.worktreePath)}
           >
             DISCARD

--- a/apps/cadis-hud/src/ui/codework/CodeWorkPanel.tsx
+++ b/apps/cadis-hud/src/ui/codework/CodeWorkPanel.tsx
@@ -7,6 +7,7 @@ const EMPTY_VALUE = "not reported by daemon";
 
 export function CodeWorkPanel() {
   const open = useHud((s) => s.codeWorkPanelOpen);
+  const gateway = useHud((s) => s.gateway);
   const selectedWorkerId = useHud((s) => s.selectedWorkerId);
   const workers = useHud((s) => s.workers);
   const agents = useHud((s) => s.agents);
@@ -24,6 +25,7 @@ export function CodeWorkPanel() {
   const isTerminal = worker
     ? ["completed", "failed", "cancelled"].includes(worker.status)
     : false;
+  const disconnected = gateway !== "connected";
 
   if (!open) return null;
 
@@ -131,8 +133,8 @@ export function CodeWorkPanel() {
           </button>
           <button
             type="button"
-            disabled={!worker || !isTerminal}
-            title="Send worker.cleanup to daemon"
+            disabled={!worker || !isTerminal || disconnected}
+            title={disconnected ? "Daemon disconnected" : "Send worker.cleanup to daemon"}
             onClick={() => worker && sendWorkerCleanup(worker.id, worker.worktree?.worktreePath)}
           >
             DISCARD

--- a/apps/cadis-hud/src/ui/settings/AgentRenameDialog.test.tsx
+++ b/apps/cadis-hud/src/ui/settings/AgentRenameDialog.test.tsx
@@ -18,6 +18,7 @@ beforeEach(() => {
   sendAgentRenameMock.mockClear().mockReturnValue(true);
   sendAgentSpecialistUpdateMock.mockClear().mockReturnValue(true);
   useHud.setState({
+    gateway: "connected",
     agentRenameTarget: "atlas",
     agents: [
       {
@@ -58,5 +59,16 @@ describe("AgentRenameDialog", () => {
 
     const input = screen.getByLabelText(/agent name/i) as HTMLInputElement;
     expect(input.maxLength).toBe(32);
+  });
+
+  it("disables save while disconnected", () => {
+    useHud.setState({ gateway: "disconnected" });
+    render(createElement(AgentRenameDialog));
+
+    const save = screen.getByRole("button", { name: "SAVE" });
+    expect(save).toBeDisabled();
+    fireEvent.click(save);
+    expect(sendAgentRenameMock).not.toHaveBeenCalled();
+    expect(sendAgentSpecialistUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/cadis-hud/src/ui/settings/AgentRenameDialog.tsx
+++ b/apps/cadis-hud/src/ui/settings/AgentRenameDialog.tsx
@@ -12,6 +12,7 @@ import {
 
 export function AgentRenameDialog() {
   const target = useHud((s) => s.agentRenameTarget);
+  const gateway = useHud((s) => s.gateway);
   const agent = useHud((s) => s.agents.find((a) => a.spec.id === s.agentRenameTarget));
   const close = useHud((s) => s.setAgentRenameTarget);
   const [name, setName] = useState("");
@@ -32,6 +33,7 @@ export function AgentRenameDialog() {
   }, [target, agent?.spec.name, agent?.spec.role, agent?.specialist]);
 
   if (!target || !agent) return null;
+  const disconnected = gateway !== "connected";
 
   const selectedSpecialist =
     specialistId === CUSTOM_SPECIALIST_ID
@@ -39,6 +41,10 @@ export function AgentRenameDialog() {
       : specialistOption(specialistId) ?? defaultSpecialistForRole(agent.spec.role);
 
   const submit = () => {
+    if (disconnected) {
+      setWarning("CADIS daemon is disconnected. Reconnect first to save agent settings.");
+      return;
+    }
     const next = normalizeAgentName(name);
     const renameDelivered = sendAgentRename(target, next);
     const specialistDelivered = sendAgentSpecialistUpdate(target, selectedSpecialist);
@@ -80,6 +86,7 @@ export function AgentRenameDialog() {
             value={name}
             maxLength={32}
             autoFocus
+            disabled={disconnected}
             onChange={(e) => setName(e.target.value)}
           />
         </section>
@@ -93,6 +100,7 @@ export function AgentRenameDialog() {
             id="agent-specialist-input"
             className="voice-config__select"
             value={specialistId}
+            disabled={disconnected}
             onChange={(e) => setSpecialistId(e.target.value)}
           >
             {SPECIALIST_OPTIONS.map((option) => (
@@ -113,6 +121,7 @@ export function AgentRenameDialog() {
               className="voice-config__input"
               value={customLabel}
               maxLength={48}
+              disabled={disconnected}
               onChange={(e) => setCustomLabel(e.target.value)}
             />
           </section>
@@ -129,6 +138,7 @@ export function AgentRenameDialog() {
             value={selectedSpecialist.persona}
             rows={5}
             maxLength={1200}
+            disabled={disconnected}
             onChange={(e) => {
               if (specialistId !== CUSTOM_SPECIALIST_ID) return;
               setCustomPersona(e.target.value);
@@ -138,12 +148,22 @@ export function AgentRenameDialog() {
         </section>
 
         {warning && <div className="voice-config__hint">{warning}</div>}
+        {disconnected && !warning && (
+          <div className="voice-config__hint">
+            CADIS daemon disconnected. Reconnect to save agent settings.
+          </div>
+        )}
 
         <footer className="voice-config__foot">
           <button type="button" className="voice-config__btn" onClick={() => close(null)}>
             CANCEL
           </button>
-          <button type="submit" className="voice-config__btn voice-config__btn--primary">
+          <button
+            type="submit"
+            className="voice-config__btn voice-config__btn--primary"
+            disabled={disconnected}
+            title={disconnected ? "Daemon disconnected" : undefined}
+          >
             SAVE
           </button>
         </footer>

--- a/apps/cadis-hud/src/ui/settings/ConfigDialog.test.tsx
+++ b/apps/cadis-hud/src/ui/settings/ConfigDialog.test.tsx
@@ -34,4 +34,36 @@ describe("ConfigDialog", () => {
     const labels = Array.from(buttons).map((b) => b.textContent);
     expect(labels).toEqual(["Voice", "Models", "Appearance", "Window"]);
   });
+
+  it("disables model mutation controls while disconnected", () => {
+    useHud.setState({
+      configOpen: true,
+      configTab: "models",
+      gateway: "disconnected",
+      defaultModel: "openai/gpt-5.5",
+      availableModels: ["openai/gpt-5.5"],
+      agentModels: { main: "openai/gpt-5.5" },
+      chatPreferences: { thinking: false, fast: false },
+      agents: [
+        {
+          spec: { id: "main", name: "CADIS", role: "Core", icon: "C", hue: 180, tasks: [] },
+          status: "idle",
+          currentTask: { verb: "ready", target: "CADIS", detail: "openai/gpt-5.5" },
+          specialist: { id: "core", label: "Core", persona: "" },
+          uptimeSeconds: 0,
+        },
+      ],
+    });
+
+    render(createElement(ConfigDialog));
+    for (const select of screen.getAllByRole("combobox")) {
+      expect(select).toBeDisabled();
+    }
+    for (const checkbox of screen.getAllByRole("checkbox")) {
+      expect(checkbox).toBeDisabled();
+    }
+    expect(
+      screen.getByText(/model and chat preference updates are temporarily disabled/i),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/cadis-hud/src/ui/settings/ConfigDialog.tsx
+++ b/apps/cadis-hud/src/ui/settings/ConfigDialog.tsx
@@ -282,12 +282,14 @@ function VoiceTab() {
 }
 
 function ModelsTab() {
+  const gateway = useHud((s) => s.gateway);
   const models = useHud((s) => s.availableModels);
   const defaultModel = useHud((s) => s.defaultModel);
   const agents = useHud((s) => s.agents);
   const agentModels = useHud((s) => s.agentModels);
   const chatPrefs = useHud((s) => s.chatPreferences);
   const setChatPreferences = useHud((s) => s.setChatPreferences);
+  const disconnected = gateway !== "connected";
   const updateChatPrefs = (patch: Partial<typeof chatPrefs>) => {
     const next = { ...chatPrefs, ...patch };
     setChatPreferences(patch);
@@ -317,6 +319,8 @@ function ModelsTab() {
                 <select
                   className="voice-config__select"
                   value={current}
+                  disabled={disconnected}
+                  title={disconnected ? "Daemon disconnected" : undefined}
                   onChange={(e) => {
                     const nextModel = e.target.value;
                     sendAgentModelUpdate(a.spec.id, nextModel);
@@ -343,6 +347,7 @@ function ModelsTab() {
           <input
             type="checkbox"
             checked={chatPrefs.thinking}
+            disabled={disconnected}
             onChange={(e) => updateChatPrefs({ thinking: e.target.checked })}
           />
           Enable thinking mode
@@ -354,11 +359,19 @@ function ModelsTab() {
           <input
             type="checkbox"
             checked={chatPrefs.fast}
+            disabled={disconnected}
             onChange={(e) => updateChatPrefs({ fast: e.target.checked })}
           />
           Fast responses
         </label>
       </section>
+      {disconnected && (
+        <section className="voice-config__row">
+          <div className="voice-config__hint">
+            CADIS daemon disconnected. Model and chat preference updates are temporarily disabled.
+          </div>
+        </section>
+      )}
     </>
   );
 }

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -719,6 +719,7 @@ impl Runtime {
             ClientRequest::WorkerTail(request) => self.worker_tail(request_id, request),
             ClientRequest::WorkerResult(request) => self.worker_result(request_id, request),
             ClientRequest::WorkerCleanup(request) => self.worker_cleanup(request_id, request),
+            ClientRequest::WorkerApply(request) => self.worker_apply(request_id, request),
             ClientRequest::SessionUnsubscribe(_) => self.accept(request_id, Vec::new()),
         }
     }
@@ -822,6 +823,7 @@ impl Runtime {
 
         let required_access = required_tool_access(&request.tool_name);
         let workspace = match self.resolved_granted_workspace(
+            &request.tool_name,
             &session_id,
             request.agent_id.as_ref(),
             &request.input,
@@ -2072,6 +2074,123 @@ impl Runtime {
             Ok(events) => self.accept(request_id, events),
             Err(error) => self.reject(request_id, error.code, error.message, false),
         }
+    }
+
+    fn worker_apply(
+        &mut self,
+        request_id: RequestId,
+        request: WorkerApplyRequest,
+    ) -> RequestOutcome {
+        let Some(worker) = self.workers.get(&request.worker_id).cloned() else {
+            return self.reject(
+                request_id,
+                "worker_not_found",
+                format!("worker '{}' was not found", request.worker_id),
+                false,
+            );
+        };
+
+        if worker.status != WorkerState::Completed {
+            return self.reject(
+                request_id,
+                "worker_apply_unavailable",
+                format!(
+                    "worker '{}' must be completed before apply",
+                    request.worker_id
+                ),
+                false,
+            );
+        }
+
+        let verified = match self
+            .verify_cadis_worker_worktree(&request.worker_id, request.worktree_path.as_deref())
+        {
+            Ok(verified) => verified,
+            Err(error) => return self.reject(request_id, error.code, error.message, false),
+        };
+
+        let Some(artifacts) = worker.artifacts.as_ref() else {
+            return self.reject(
+                request_id,
+                "worker_patch_missing",
+                format!(
+                    "worker '{}' has no patch artifact metadata",
+                    request.worker_id
+                ),
+                false,
+            );
+        };
+        let patch_path = PathBuf::from(artifacts.patch.trim());
+        let expected_patch = self.profile_home.worker_artifact_paths(&request.worker_id).patch;
+        if patch_path != expected_patch {
+            return self.reject(
+                request_id,
+                "worker_patch_not_owned",
+                format!(
+                    "worker '{}' patch artifact is not CADIS-owned",
+                    request.worker_id
+                ),
+                false,
+            );
+        }
+
+        let patch_path = match fs::canonicalize(&patch_path) {
+            Ok(path) => path,
+            Err(error) => {
+                return self.reject(
+                    request_id,
+                    "worker_patch_missing",
+                    format!(
+                        "worker '{}' patch artifact '{}' is unavailable: {error}",
+                        request.worker_id,
+                        patch_path.display()
+                    ),
+                    false,
+                )
+            }
+        };
+        let patch_content = match fs::read_to_string(&patch_path) {
+            Ok(content) => content,
+            Err(error) => {
+                return self.reject(
+                    request_id,
+                    "worker_patch_unreadable",
+                    format!(
+                        "worker '{}' patch artifact '{}' could not be read: {error}",
+                        request.worker_id,
+                        patch_path.display()
+                    ),
+                    false,
+                )
+            }
+        };
+        if patch_content.trim().is_empty() {
+            return self.reject(
+                request_id,
+                "worker_patch_empty",
+                format!(
+                    "worker '{}' patch artifact '{}' is empty",
+                    request.worker_id,
+                    patch_path.display()
+                ),
+                false,
+            );
+        }
+
+        let tool_request = ToolCallRequest {
+            session_id: Some(worker.session_id),
+            agent_id: worker.agent_id.or(worker.parent_agent_id),
+            tool_name: "worker.apply".to_owned(),
+            input: serde_json::json!({
+                "workspace_id": verified.metadata.workspace_id,
+                "worker_id": request.worker_id,
+                "worktree_path": request
+                    .worktree_path
+                    .unwrap_or_else(|| verified.metadata.worktree_path.display().to_string()),
+            }),
+        };
+
+        self.handle_tool_call(request_id, tool_request)
     }
 
     fn set_agent_specialist(
@@ -4339,6 +4458,7 @@ impl Runtime {
         };
 
         let workspace = match self.resolved_granted_workspace(
+            &request.tool_name,
             &record.session_id,
             request.agent_id.as_ref(),
             &request.input,
@@ -4470,6 +4590,9 @@ impl Runtime {
                 self.try_checkpoint(workspace, &request.input);
                 self.execute_file_patch(workspace, &request.input)
             }
+            "worker.apply" => {
+                self.execute_worker_apply_patch(workspace, &request.input, tool_timeout_secs)
+            }
             "shell.run" => self.execute_shell_run(workspace, &request.input, tool_timeout_secs),
             "git.worktree.create" => self.execute_git_worktree_create(workspace, &request.input),
             "git.worktree.remove" => self.execute_git_worktree_remove(workspace, &request.input),
@@ -4599,6 +4722,148 @@ impl Runtime {
                 "schema": "structured_replace_write_v1",
                 "files": output_files,
                 "truncated": truncated
+            }),
+        })
+    }
+
+    fn execute_worker_apply_patch(
+        &self,
+        workspace: &Path,
+        input: &serde_json::Value,
+        tool_timeout_secs: u64,
+    ) -> Result<ToolExecutionResult, ErrorPayload> {
+        let worker_id = input_string(input, "worker_id")
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                tool_error(
+                    "invalid_tool_input",
+                    "worker.apply requires worker_id",
+                    false,
+                )
+            })?;
+        let requested_worktree = input_string(input, "worktree_path");
+        let _verified = self
+            .verify_cadis_worker_worktree(&worker_id, requested_worktree.as_deref())
+            .map_err(|error| tool_error(error.code, error.message, false))?;
+
+        let worker = self.workers.get(&worker_id).ok_or_else(|| {
+            tool_error(
+                "worker_not_found",
+                format!("worker '{worker_id}' was not found"),
+                false,
+            )
+        })?;
+        if worker.status != WorkerState::Completed {
+            return Err(tool_error(
+                "worker_apply_unavailable",
+                format!("worker '{worker_id}' must be completed before apply"),
+                false,
+            ));
+        }
+
+        let artifacts = worker.artifacts.as_ref().ok_or_else(|| {
+            tool_error(
+                "worker_patch_missing",
+                format!("worker '{worker_id}' has no patch artifact metadata"),
+                false,
+            )
+        })?;
+        let patch_path = PathBuf::from(artifacts.patch.trim());
+        let expected_patch = self.profile_home.worker_artifact_paths(&worker_id).patch;
+        if patch_path != expected_patch {
+            return Err(tool_error(
+                "worker_patch_not_owned",
+                format!("worker '{worker_id}' patch artifact is not CADIS-owned"),
+                false,
+            ));
+        }
+        let patch_path = fs::canonicalize(&patch_path).map_err(|error| {
+            tool_error(
+                "worker_patch_missing",
+                format!(
+                    "worker '{worker_id}' patch artifact '{}' is unavailable: {error}",
+                    patch_path.display()
+                ),
+                false,
+            )
+        })?;
+
+        let patch_content = fs::read_to_string(&patch_path).map_err(|error| {
+            tool_error(
+                "worker_patch_unreadable",
+                format!(
+                    "worker '{worker_id}' patch artifact '{}' could not be read: {error}",
+                    patch_path.display()
+                ),
+                false,
+            )
+        })?;
+        if patch_content.trim().is_empty() {
+            return Err(tool_error(
+                "worker_patch_empty",
+                format!(
+                    "worker '{worker_id}' patch artifact '{}' is empty",
+                    patch_path.display()
+                ),
+                false,
+            ));
+        }
+
+        let mut apply = Command::new("git");
+        apply
+            .arg("-C")
+            .arg(workspace)
+            .arg("apply")
+            .arg("--3way")
+            .arg("--whitespace=nowarn")
+            .arg(&patch_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let result = run_bounded_command(apply, StdDuration::from_secs(tool_timeout_secs))?;
+        let stdout = redact(&String::from_utf8_lossy(&result.stdout.bytes));
+        let stderr = redact(&String::from_utf8_lossy(&result.stderr.bytes));
+
+        if result.timed_out {
+            return Err(tool_error(
+                "tool_timeout",
+                format!(
+                    "worker.apply exceeded timeout of {tool_timeout_secs}s for worker '{worker_id}'"
+                ),
+                false,
+            ));
+        }
+        if !result.status_success {
+            let detail = if !stderr.trim().is_empty() {
+                stderr
+            } else if !stdout.trim().is_empty() {
+                stdout
+            } else {
+                "git apply failed without output".to_owned()
+            };
+            return Err(tool_error(
+                "worker_apply_failed",
+                format!(
+                    "worker '{worker_id}' patch apply failed (exit code {:?}): {}",
+                    result.exit_code, detail
+                ),
+                false,
+            ));
+        }
+
+        Ok(ToolExecutionResult {
+            summary: format!("applied worker patch for {worker_id}"),
+            output: serde_json::json!({
+                "worker_id": worker_id,
+                "patch_path": patch_path.display().to_string(),
+                "workspace": workspace.display().to_string(),
+                "exit_code": result.exit_code,
+                "stdout": stdout,
+                "stderr": stderr,
+                "stdout_truncated": result.stdout.truncated,
+                "stderr_truncated": result.stderr.truncated
             }),
         })
     }
@@ -5243,11 +5508,16 @@ impl Runtime {
 
     fn resolved_granted_workspace(
         &self,
+        tool_name: &str,
         session_id: &SessionId,
         agent_id: Option<&AgentId>,
         input: &serde_json::Value,
         required_access: WorkspaceAccess,
     ) -> Result<ResolvedWorkspace, ErrorPayload> {
+        if tool_name == "worker.apply" {
+            return self.resolve_worker_apply_workspace(input);
+        }
+
         let workspace_ref = tool_workspace_id(input)
             .or_else(|| tool_workspace_summary(input))
             .or_else(|| self.session_workspace(session_id))
@@ -5273,6 +5543,41 @@ impl Runtime {
                 false,
             ))
         }
+    }
+
+    fn resolve_worker_apply_workspace(
+        &self,
+        input: &serde_json::Value,
+    ) -> Result<ResolvedWorkspace, ErrorPayload> {
+        let worker_id = input_string(input, "worker_id")
+            .map(|value| value.trim().to_owned())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                tool_error(
+                    "invalid_tool_input",
+                    "worker.apply requires worker_id",
+                    false,
+                )
+            })?;
+        let requested_worktree = input_string(input, "worktree_path");
+        let verified = self
+            .verify_cadis_worker_worktree(&worker_id, requested_worktree.as_deref())
+            .map_err(|error| tool_error(error.code, error.message, false))?;
+        let workspace_id = WorkspaceId::from(verified.metadata.workspace_id.clone());
+        let workspace = self.workspaces.get(&workspace_id).ok_or_else(|| {
+            tool_error(
+                "workspace_not_found",
+                format!(
+                    "workspace '{}' is not registered for worker '{}'",
+                    workspace_id, worker_id
+                ),
+                false,
+            )
+        })?;
+
+        Ok(ResolvedWorkspace {
+            root: workspace.root.clone(),
+        })
     }
 
     fn resolve_registered_workspace(
@@ -10098,6 +10403,114 @@ mod tests {
             project_metadata.state,
             ProjectWorkerWorktreeState::ReviewPending
         );
+    }
+
+    #[test]
+    fn worker_apply_requests_approval_and_applies_patch_after_approval() {
+        let cadis_home = test_workspace("worker-apply-home");
+        let workspace = test_workspace("worker-apply-workspace");
+        init_git_workspace(&workspace);
+
+        let mut runtime = runtime_with_home(cadis_home);
+        register_workspace(&mut runtime, "worker-apply", &workspace);
+        let (_session_id, worker_id, worktree_path) =
+            complete_worker_in_workspace(&mut runtime, &workspace, "worker_apply");
+
+        let patch_path = runtime
+            .workers
+            .get(&worker_id)
+            .and_then(|worker| worker.artifacts.as_ref())
+            .map(|artifacts| artifacts.patch.clone())
+            .expect("worker patch artifact path should exist");
+
+        let readme = workspace.join("README.md");
+        let original = fs::read_to_string(&readme).expect("README should read");
+        let patched = format!("{original}Applied from worker patch\n");
+        fs::write(&readme, &patched).expect("README patched content should write");
+        let patch = Command::new("git")
+            .arg("-C")
+            .arg(&workspace)
+            .args(["diff", "--binary", "HEAD", "--", "README.md"])
+            .output()
+            .expect("git diff should run");
+        assert!(
+            patch.status.success(),
+            "git diff should succeed: {}",
+            String::from_utf8_lossy(&patch.stderr)
+        );
+        fs::write(&readme, &original).expect("README should reset to original");
+        fs::write(&patch_path, &patch.stdout).expect("worker patch artifact should write");
+
+        let request = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_worker_apply"),
+            ClientId::from("hud_1"),
+            ClientRequest::WorkerApply(WorkerApplyRequest {
+                worker_id: worker_id.clone(),
+                worktree_path: Some(worktree_path),
+            }),
+        ));
+
+        assert!(matches!(
+            request.response.response,
+            DaemonResponse::RequestAccepted(_)
+        ));
+        assert!(request.events.iter().any(|event| {
+            matches!(&event.event, CadisEvent::ApprovalRequested(payload) if payload.summary.contains("worker.apply requires approval"))
+        }));
+        assert!(!request
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ToolStarted(_))));
+
+        let approved = approve(&mut runtime, approval_id_from(&request));
+        assert!(approved
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ToolStarted(_))));
+        assert!(approved.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolCompleted(payload)
+                    if payload.summary.as_deref() == Some(&format!("applied worker patch for {worker_id}"))
+            )
+        }));
+
+        let final_readme = fs::read_to_string(&readme).expect("README should read after apply");
+        assert!(
+            final_readme.contains("Applied from worker patch"),
+            "README should include patch content after apply"
+        );
+    }
+
+    #[test]
+    fn worker_apply_rejects_empty_patch_artifact() {
+        let cadis_home = test_workspace("worker-apply-empty-home");
+        let workspace = test_workspace("worker-apply-empty-workspace");
+        init_git_workspace(&workspace);
+
+        let mut runtime = runtime_with_home(cadis_home);
+        register_workspace(&mut runtime, "worker-apply-empty", &workspace);
+        let (_session_id, worker_id, worktree_path) =
+            complete_worker_in_workspace(&mut runtime, &workspace, "worker_apply_empty");
+
+        let patch_path = runtime
+            .workers
+            .get(&worker_id)
+            .and_then(|worker| worker.artifacts.as_ref())
+            .map(|artifacts| artifacts.patch.clone())
+            .expect("worker patch artifact path should exist");
+        fs::write(&patch_path, "\n").expect("empty worker patch should write");
+
+        let request = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_worker_apply_empty"),
+            ClientId::from("hud_1"),
+            ClientRequest::WorkerApply(WorkerApplyRequest {
+                worker_id,
+                worktree_path: Some(worktree_path),
+            }),
+        ));
+
+        assert_rejected(request, "worker_patch_empty");
     }
 
     #[test]

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -4815,44 +4815,70 @@ impl Runtime {
             ));
         }
 
-        let mut apply = Command::new("git");
-        apply
-            .arg("-C")
-            .arg(workspace)
-            .arg("apply")
-            .arg("--3way")
-            .arg("--whitespace=nowarn")
-            .arg(&patch_path)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+        let affected_paths = worker_apply_patch_paths(workspace, &patch_path, tool_timeout_secs)?;
+        ensure_worker_apply_paths_clean(workspace, &affected_paths, tool_timeout_secs)?;
 
-        let result = run_bounded_command(apply, StdDuration::from_secs(tool_timeout_secs))?;
+        let preflight = run_worker_apply_git(
+            workspace,
+            &patch_path,
+            &["--check", "--whitespace=nowarn"],
+            tool_timeout_secs,
+        )?;
+        if preflight.timed_out {
+            return Err(tool_error(
+                "tool_timeout",
+                format!(
+                    "worker.apply preflight exceeded timeout of {tool_timeout_secs}s for worker '{worker_id}'"
+                ),
+                false,
+            ));
+        }
+        if !preflight.status_success {
+            return Err(tool_error(
+                "worker_apply_preflight_failed",
+                format!(
+                    "worker '{worker_id}' patch preflight failed; no changes were applied: {}",
+                    worker_apply_command_detail(
+                        &preflight,
+                        "git apply --check failed without output"
+                    )
+                ),
+                false,
+            ));
+        }
+
+        let checkpoint =
+            capture_worker_apply_checkpoint(workspace, &affected_paths, tool_timeout_secs)?;
+        let result = run_worker_apply_git(
+            workspace,
+            &patch_path,
+            &["--3way", "--whitespace=nowarn"],
+            tool_timeout_secs,
+        )?;
         let stdout = redact(&String::from_utf8_lossy(&result.stdout.bytes));
         let stderr = redact(&String::from_utf8_lossy(&result.stderr.bytes));
 
         if result.timed_out {
+            let rollback =
+                rollback_worker_apply(workspace, &patch_path, &checkpoint, tool_timeout_secs);
             return Err(tool_error(
                 "tool_timeout",
                 format!(
-                    "worker.apply exceeded timeout of {tool_timeout_secs}s for worker '{worker_id}'"
+                    "worker.apply exceeded timeout of {tool_timeout_secs}s for worker '{worker_id}'; rollback {}",
+                    rollback.message
                 ),
                 false,
             ));
         }
         if !result.status_success {
-            let detail = if !stderr.trim().is_empty() {
-                stderr
-            } else if !stdout.trim().is_empty() {
-                stdout
-            } else {
-                "git apply failed without output".to_owned()
-            };
+            let rollback =
+                rollback_worker_apply(workspace, &patch_path, &checkpoint, tool_timeout_secs);
+            let detail = worker_apply_command_detail(&result, "git apply failed without output");
             return Err(tool_error(
                 "worker_apply_failed",
                 format!(
-                    "worker '{worker_id}' patch apply failed (exit code {:?}): {}",
-                    result.exit_code, detail
+                    "worker '{worker_id}' patch apply failed (exit code {:?}): {}; rollback {}",
+                    result.exit_code, detail, rollback.message
                 ),
                 false,
             ));
@@ -5520,7 +5546,7 @@ impl Runtime {
         required_access: WorkspaceAccess,
     ) -> Result<ResolvedWorkspace, ErrorPayload> {
         if tool_name == "worker.apply" {
-            return self.resolve_worker_apply_workspace(input);
+            return self.resolve_worker_apply_workspace(input, agent_id, required_access);
         }
 
         let workspace_ref = tool_workspace_id(input)
@@ -5553,6 +5579,8 @@ impl Runtime {
     fn resolve_worker_apply_workspace(
         &self,
         input: &serde_json::Value,
+        request_agent_id: Option<&AgentId>,
+        required_access: WorkspaceAccess,
     ) -> Result<ResolvedWorkspace, ErrorPayload> {
         let worker_id = input_string(input, "worker_id")
             .map(|value| value.trim().to_owned())
@@ -5569,6 +5597,13 @@ impl Runtime {
             .verify_cadis_worker_worktree(&worker_id, requested_worktree.as_deref())
             .map_err(|error| tool_error(error.code, error.message, false))?;
         let workspace_id = WorkspaceId::from(verified.metadata.workspace_id.clone());
+        let worker = self.workers.get(&worker_id).ok_or_else(|| {
+            tool_error(
+                "worker_not_found",
+                format!("worker '{worker_id}' was not found"),
+                false,
+            )
+        })?;
         let workspace = self.workspaces.get(&workspace_id).ok_or_else(|| {
             tool_error(
                 "workspace_not_found",
@@ -5580,9 +5615,25 @@ impl Runtime {
             )
         })?;
 
-        Ok(ResolvedWorkspace {
-            root: workspace.root.clone(),
-        })
+        let grant_agent_id = worker
+            .agent_id
+            .as_ref()
+            .or(worker.parent_agent_id.as_ref())
+            .or(request_agent_id);
+        if self.has_workspace_grant(&workspace.id, grant_agent_id, required_access) {
+            Ok(ResolvedWorkspace {
+                root: workspace.root.clone(),
+            })
+        } else {
+            Err(tool_error(
+                "workspace_grant_required",
+                format!(
+                    "no active {:?} grant for workspace '{}' and worker '{}'",
+                    required_access, workspace.id, worker_id
+                ),
+                false,
+            ))
+        }
     }
 
     fn resolve_registered_workspace(
@@ -7500,6 +7551,504 @@ fn run_worker_validation_command(
     run_bounded_command(command, StdDuration::from_millis(WORKER_COMMAND_TIMEOUT_MS))
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WorkerApplyCheckpoint {
+    pre_status: Vec<u8>,
+    paths: Vec<WorkerApplyPathSnapshot>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WorkerApplyPathSnapshot {
+    relative_path: String,
+    state: WorkerApplyPathState,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum WorkerApplyPathState {
+    Missing,
+    File(Vec<u8>),
+    Directory,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WorkerApplyRollback {
+    restored: bool,
+    message: String,
+}
+
+fn worker_apply_patch_paths(
+    workspace: &Path,
+    patch_path: &Path,
+    timeout_secs: u64,
+) -> Result<Vec<String>, ErrorPayload> {
+    let result = run_worker_apply_git(
+        workspace,
+        patch_path,
+        &["--numstat", "-z", "--whitespace=nowarn"],
+        timeout_secs,
+    )?;
+    if result.timed_out {
+        return Err(tool_error(
+            "tool_timeout",
+            format!("worker.apply patch inspection exceeded timeout of {timeout_secs}s"),
+            false,
+        ));
+    }
+    if result.stdout.truncated {
+        return Err(tool_error(
+            "worker_apply_patch_too_large",
+            "worker.apply patch path list exceeded bounded output",
+            false,
+        ));
+    }
+    if !result.status_success {
+        return Err(tool_error(
+            "worker_apply_preflight_failed",
+            format!(
+                "worker.apply could not inspect patch paths; no changes were applied: {}",
+                worker_apply_command_detail(&result, "git apply --numstat failed without output")
+            ),
+            false,
+        ));
+    }
+
+    let mut paths = Vec::new();
+    for record in result.stdout.bytes.split(|byte| *byte == 0) {
+        if record.is_empty() {
+            continue;
+        }
+        let record = String::from_utf8_lossy(record);
+        let mut fields = record.splitn(3, '\t');
+        let _added = fields.next();
+        let _deleted = fields.next();
+        let Some(path) = fields.next() else {
+            return Err(tool_error(
+                "worker_apply_preflight_failed",
+                "worker.apply patch path inspection returned malformed numstat output",
+                false,
+            ));
+        };
+        push_worker_apply_path(&mut paths, path)?;
+    }
+
+    if paths.is_empty() {
+        return Err(tool_error(
+            "worker_patch_empty",
+            "worker.apply patch does not contain file changes",
+            false,
+        ));
+    }
+
+    Ok(paths)
+}
+
+fn push_worker_apply_path(paths: &mut Vec<String>, path: &str) -> Result<(), ErrorPayload> {
+    let path = validate_worker_apply_repo_path(path)?;
+    if !paths.iter().any(|existing| existing == &path) {
+        paths.push(path);
+    }
+    Ok(())
+}
+
+fn validate_worker_apply_repo_path(path: &str) -> Result<String, ErrorPayload> {
+    if path.is_empty() || path == "/dev/null" {
+        return Err(tool_error(
+            "worker_apply_preflight_failed",
+            "worker.apply patch contains an invalid path",
+            false,
+        ));
+    }
+    let repo_path = Path::new(path);
+    if repo_path.is_absolute()
+        || repo_path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(tool_error(
+            "outside_workspace",
+            format!("worker.apply patch path '{path}' is outside the workspace"),
+            false,
+        ));
+    }
+    if file_patch_path_is_protected(repo_path) {
+        return Err(tool_error(
+            "protected_path",
+            "worker.apply refuses to modify protected workspace metadata paths",
+            false,
+        ));
+    }
+    if file_patch_path_is_secret_like(repo_path) {
+        return Err(tool_error(
+            "secret_path_rejected",
+            "worker.apply refuses to modify secret-like paths",
+            false,
+        ));
+    }
+    Ok(path.to_owned())
+}
+
+fn ensure_worker_apply_paths_clean(
+    workspace: &Path,
+    paths: &[String],
+    timeout_secs: u64,
+) -> Result<(), ErrorPayload> {
+    let status = worker_apply_git_status(workspace, paths, timeout_secs)?;
+    if status.is_empty() {
+        return Ok(());
+    }
+
+    Err(tool_error(
+        "worker_apply_dirty_paths",
+        format!(
+            "worker.apply refuses to apply over pre-existing changes in affected paths: {}",
+            worker_apply_status_summary(&status)
+        ),
+        false,
+    ))
+}
+
+fn capture_worker_apply_checkpoint(
+    workspace: &Path,
+    paths: &[String],
+    timeout_secs: u64,
+) -> Result<WorkerApplyCheckpoint, ErrorPayload> {
+    let pre_status = worker_apply_git_status(workspace, &[], timeout_secs)?;
+    let mut snapshots = Vec::with_capacity(paths.len());
+    for relative_path in paths {
+        snapshots.push(snapshot_worker_apply_path(workspace, relative_path)?);
+    }
+    Ok(WorkerApplyCheckpoint {
+        pre_status,
+        paths: snapshots,
+    })
+}
+
+fn snapshot_worker_apply_path(
+    workspace: &Path,
+    relative_path: &str,
+) -> Result<WorkerApplyPathSnapshot, ErrorPayload> {
+    let relative_path = validate_worker_apply_repo_path(relative_path)?;
+    let path = workspace.join(&relative_path);
+    ensure_worker_apply_snapshot_path(workspace, &path)?;
+
+    let state = match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(tool_error(
+                "worker_apply_checkpoint_failed",
+                format!(
+                    "worker.apply refuses to checkpoint symlink path '{}'",
+                    relative_path
+                ),
+                false,
+            ))
+        }
+        Ok(metadata) if metadata.is_file() => {
+            let bytes = fs::read(&path).map_err(|error| {
+                tool_error(
+                    "worker_apply_checkpoint_failed",
+                    format!("could not checkpoint '{}': {error}", relative_path),
+                    false,
+                )
+            })?;
+            WorkerApplyPathState::File(bytes)
+        }
+        Ok(metadata) if metadata.is_dir() => WorkerApplyPathState::Directory,
+        Ok(_) => {
+            return Err(tool_error(
+                "worker_apply_checkpoint_failed",
+                format!(
+                    "worker.apply refuses to checkpoint unsupported path '{}'",
+                    relative_path
+                ),
+                false,
+            ))
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => WorkerApplyPathState::Missing,
+        Err(error) => {
+            return Err(tool_error(
+                "worker_apply_checkpoint_failed",
+                format!("could not inspect '{}': {error}", relative_path),
+                false,
+            ))
+        }
+    };
+
+    Ok(WorkerApplyPathSnapshot {
+        relative_path,
+        state,
+    })
+}
+
+fn ensure_worker_apply_snapshot_path(workspace: &Path, path: &Path) -> Result<(), ErrorPayload> {
+    let workspace = workspace.canonicalize().map_err(|error| {
+        tool_error(
+            "workspace_unavailable",
+            format!("workspace {} is unavailable: {error}", workspace.display()),
+            false,
+        )
+    })?;
+
+    let candidate = path
+        .ancestors()
+        .find(|ancestor| ancestor.exists())
+        .and_then(|ancestor| ancestor.canonicalize().ok());
+    if candidate
+        .as_ref()
+        .is_some_and(|candidate| !candidate.starts_with(&workspace))
+    {
+        return Err(tool_error(
+            "outside_workspace",
+            format!(
+                "worker.apply patch path '{}' resolves outside the workspace",
+                path.display()
+            ),
+            false,
+        ));
+    }
+    Ok(())
+}
+
+fn rollback_worker_apply(
+    workspace: &Path,
+    patch_path: &Path,
+    checkpoint: &WorkerApplyCheckpoint,
+    timeout_secs: u64,
+) -> WorkerApplyRollback {
+    let mut notes = Vec::new();
+    match run_worker_apply_git(
+        workspace,
+        patch_path,
+        &["--reverse", "--whitespace=nowarn"],
+        timeout_secs,
+    ) {
+        Ok(result) if result.status_success => notes.push("reverse patch applied".to_owned()),
+        Ok(result) => notes.push(format!(
+            "reverse patch failed: {}",
+            worker_apply_command_detail(&result, "git apply --reverse failed without output")
+        )),
+        Err(error) => notes.push(format!("reverse patch failed: {}", error.message)),
+    }
+
+    if let Err(error) = worker_apply_restore_index(workspace, &checkpoint.paths, timeout_secs) {
+        notes.push(format!("index restore failed: {error}"));
+    }
+    for snapshot in &checkpoint.paths {
+        if let Err(error) = restore_worker_apply_path(workspace, snapshot) {
+            notes.push(format!(
+                "path restore failed for '{}': {error}",
+                snapshot.relative_path
+            ));
+        }
+    }
+
+    match worker_apply_git_status(workspace, &[], timeout_secs) {
+        Ok(status) if status == checkpoint.pre_status => WorkerApplyRollback {
+            restored: true,
+            message: format!("restored pre-apply status ({})", notes.join("; ")),
+        },
+        Ok(status) => WorkerApplyRollback {
+            restored: false,
+            message: format!(
+                "attempted but workspace status changed from [{}] to [{}] ({})",
+                worker_apply_status_summary(&checkpoint.pre_status),
+                worker_apply_status_summary(&status),
+                notes.join("; ")
+            ),
+        },
+        Err(error) => WorkerApplyRollback {
+            restored: false,
+            message: format!(
+                "attempted but status verification failed: {} ({})",
+                error.message,
+                notes.join("; ")
+            ),
+        },
+    }
+}
+
+fn worker_apply_restore_index(
+    workspace: &Path,
+    snapshots: &[WorkerApplyPathSnapshot],
+    timeout_secs: u64,
+) -> Result<(), String> {
+    if snapshots.is_empty() {
+        return Ok(());
+    }
+    let paths = snapshots
+        .iter()
+        .map(|snapshot| snapshot.relative_path.clone())
+        .collect::<Vec<_>>();
+    let result = run_worker_apply_git_command(
+        workspace,
+        &["restore", "--staged", "--source=HEAD", "--"],
+        &paths,
+        timeout_secs,
+    )
+    .map_err(|error| error.message)?;
+    if result.timed_out {
+        return Err(format!(
+            "git restore --staged exceeded timeout of {timeout_secs}s"
+        ));
+    }
+    if result.status_success {
+        Ok(())
+    } else {
+        Err(worker_apply_command_detail(
+            &result,
+            "git restore --staged failed without output",
+        ))
+    }
+}
+
+fn restore_worker_apply_path(
+    workspace: &Path,
+    snapshot: &WorkerApplyPathSnapshot,
+) -> Result<(), String> {
+    let path = workspace.join(&snapshot.relative_path);
+    match &snapshot.state {
+        WorkerApplyPathState::Missing => remove_worker_apply_path(&path),
+        WorkerApplyPathState::File(bytes) => {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+            }
+            fs::write(&path, bytes).map_err(|error| error.to_string())
+        }
+        WorkerApplyPathState::Directory => {
+            if path.exists() && !path.is_dir() {
+                remove_worker_apply_path(&path)?;
+            }
+            fs::create_dir_all(&path).map_err(|error| error.to_string())
+        }
+    }
+}
+
+fn remove_worker_apply_path(path: &Path) -> Result<(), String> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() => {
+            fs::remove_dir_all(path).map_err(|error| error.to_string())
+        }
+        Ok(_) => fs::remove_file(path).map_err(|error| error.to_string()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn worker_apply_git_status(
+    workspace: &Path,
+    paths: &[String],
+    timeout_secs: u64,
+) -> Result<Vec<u8>, ErrorPayload> {
+    let mut args = vec!["status", "--porcelain=v1", "-z", "--untracked-files=all"];
+    if !paths.is_empty() {
+        args.push("--");
+    }
+    let result = if paths.is_empty() {
+        run_worker_apply_git_command(workspace, &args, &[], timeout_secs)?
+    } else {
+        run_worker_apply_git_command(workspace, &args, paths, timeout_secs)?
+    };
+    if result.timed_out {
+        return Err(tool_error(
+            "tool_timeout",
+            format!("worker.apply status snapshot exceeded timeout of {timeout_secs}s"),
+            false,
+        ));
+    }
+    if result.stdout.truncated {
+        return Err(tool_error(
+            "worker_apply_status_truncated",
+            "worker.apply status snapshot exceeded bounded output",
+            false,
+        ));
+    }
+    if result.status_success {
+        Ok(result.stdout.bytes)
+    } else {
+        Err(tool_error(
+            "worker_apply_status_failed",
+            worker_apply_command_detail(&result, "git status failed without output"),
+            false,
+        ))
+    }
+}
+
+fn run_worker_apply_git(
+    workspace: &Path,
+    patch_path: &Path,
+    args: &[&str],
+    timeout_secs: u64,
+) -> Result<ShellRunResult, ErrorPayload> {
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(workspace)
+        .arg("apply")
+        .args(args)
+        .arg(patch_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    run_bounded_command(command, StdDuration::from_secs(timeout_secs))
+}
+
+fn run_worker_apply_git_command(
+    workspace: &Path,
+    args: &[&str],
+    paths: &[String],
+    timeout_secs: u64,
+) -> Result<ShellRunResult, ErrorPayload> {
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(workspace)
+        .args(args)
+        .args(paths)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    run_bounded_command(command, StdDuration::from_secs(timeout_secs))
+}
+
+fn worker_apply_command_detail(result: &ShellRunResult, fallback: &str) -> String {
+    let stdout = redact(&String::from_utf8_lossy(&result.stdout.bytes));
+    let stderr = redact(&String::from_utf8_lossy(&result.stderr.bytes));
+    let mut detail = if !stderr.trim().is_empty() {
+        stderr
+    } else if !stdout.trim().is_empty() {
+        stdout
+    } else {
+        fallback.to_owned()
+    };
+    if result.stderr.truncated || result.stdout.truncated {
+        detail.push_str(" [output truncated]");
+    }
+    detail
+}
+
+fn worker_apply_status_summary(status: &[u8]) -> String {
+    let mut entries = status
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty())
+        .take(8)
+        .map(|entry| redact(&String::from_utf8_lossy(entry)).replace('\n', " "))
+        .collect::<Vec<_>>();
+    let truncated = status
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty())
+        .count()
+        > 8;
+    if entries.is_empty() {
+        return "clean".to_owned();
+    }
+    if truncated {
+        entries.push("...".to_owned());
+    }
+    entries.join(", ")
+}
+
 fn worker_command_report(
     worker_command: &str,
     cwd: &str,
@@ -8381,6 +8930,47 @@ mod tests {
         (session_id, completed.worker_id.clone(), worktree_path)
     }
 
+    fn write_worker_readme_append_patch(
+        runtime: &Runtime,
+        worker_id: &str,
+        workspace: &Path,
+        line: &str,
+    ) -> String {
+        let patch_path = runtime
+            .workers
+            .get(worker_id)
+            .and_then(|worker| worker.artifacts.as_ref())
+            .map(|artifacts| artifacts.patch.clone())
+            .expect("worker patch artifact path should exist");
+
+        let readme = workspace.join("README.md");
+        let original = fs::read_to_string(&readme).expect("README should read");
+        let patched = format!("{original}{line}\n");
+        fs::write(&readme, &patched).expect("README patched content should write");
+        let patch = Command::new("git")
+            .arg("-C")
+            .arg(workspace)
+            .args(["diff", "--binary", "HEAD", "--", "README.md"])
+            .output()
+            .expect("git diff should run");
+        assert!(
+            patch.status.success(),
+            "git diff should succeed: {}",
+            String::from_utf8_lossy(&patch.stderr)
+        );
+        fs::write(&readme, &original).expect("README should reset to original");
+        fs::write(&patch_path, &patch.stdout).expect("worker patch artifact should write");
+        original
+    }
+
+    fn worker_owner_agent(runtime: &Runtime, worker_id: &str) -> AgentId {
+        runtime
+            .workers
+            .get(worker_id)
+            .and_then(|worker| worker.agent_id.clone().or(worker.parent_agent_id.clone()))
+            .expect("worker should have an owner agent")
+    }
+
     fn grant_workspace(runtime: &mut Runtime, workspace_id: &str, access: Vec<WorkspaceAccess>) {
         grant_workspace_for_agent(runtime, workspace_id, access, None)
     }
@@ -8406,6 +8996,15 @@ mod tests {
             outcome.response.response,
             DaemonResponse::RequestAccepted(_)
         ));
+    }
+
+    fn assert_tool_failed_code(outcome: &RequestOutcome, code: &str) {
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolFailed(payload) if payload.error.code == code
+            )
+        }));
     }
 
     fn approval_id_from(outcome: &RequestOutcome) -> ApprovalId {
@@ -10421,30 +11020,14 @@ mod tests {
         let (_session_id, worker_id, worktree_path) =
             complete_worker_in_workspace(&mut runtime, &workspace, "worker_apply");
 
-        let patch_path = runtime
-            .workers
-            .get(&worker_id)
-            .and_then(|worker| worker.artifacts.as_ref())
-            .map(|artifacts| artifacts.patch.clone())
-            .expect("worker patch artifact path should exist");
-
         let readme = workspace.join("README.md");
-        let original = fs::read_to_string(&readme).expect("README should read");
-        let patched = format!("{original}Applied from worker patch\n");
-        fs::write(&readme, &patched).expect("README patched content should write");
-        let patch = Command::new("git")
-            .arg("-C")
-            .arg(&workspace)
-            .args(["diff", "--binary", "HEAD", "--", "README.md"])
-            .output()
-            .expect("git diff should run");
-        assert!(
-            patch.status.success(),
-            "git diff should succeed: {}",
-            String::from_utf8_lossy(&patch.stderr)
+        let original = write_worker_readme_append_patch(
+            &runtime,
+            &worker_id,
+            &workspace,
+            "Applied from worker patch",
         );
-        fs::write(&readme, &original).expect("README should reset to original");
-        fs::write(&patch_path, &patch.stdout).expect("worker patch artifact should write");
+        grant_workspace(&mut runtime, "worker-apply", vec![WorkspaceAccess::Write]);
 
         let request = runtime.handle_request(RequestEnvelope::new(
             RequestId::from("req_worker_apply"),
@@ -10466,6 +11049,11 @@ mod tests {
             .events
             .iter()
             .any(|event| matches!(event.event, CadisEvent::ToolStarted(_))));
+        assert_eq!(
+            fs::read_to_string(&readme).expect("README should still read"),
+            original,
+            "worker.apply must not mutate before approval"
+        );
 
         let approved = approve(&mut runtime, approval_id_from(&request));
         assert!(approved
@@ -10484,6 +11072,253 @@ mod tests {
         assert!(
             final_readme.contains("Applied from worker patch"),
             "README should include patch content after apply"
+        );
+    }
+
+    #[test]
+    fn worker_apply_requires_active_write_grant_for_worker_owner() {
+        let cadis_home = test_workspace("worker-apply-grant-home");
+        let workspace = test_workspace("worker-apply-grant-workspace");
+        init_git_workspace(&workspace);
+
+        let mut runtime = runtime_with_home(cadis_home);
+        register_workspace(&mut runtime, "worker-apply-grant", &workspace);
+        let (_session_id, worker_id, worktree_path) =
+            complete_worker_in_workspace(&mut runtime, &workspace, "worker_apply_grant");
+        let original = write_worker_readme_append_patch(
+            &runtime,
+            &worker_id,
+            &workspace,
+            "Grant-gated worker patch",
+        );
+        let readme = workspace.join("README.md");
+        let owner_agent = worker_owner_agent(&runtime, &worker_id);
+
+        grant_workspace(
+            &mut runtime,
+            "worker-apply-grant",
+            vec![WorkspaceAccess::Read],
+        );
+        let read_only = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_worker_apply_read_only_grant"),
+            ClientId::from("hud_1"),
+            ClientRequest::WorkerApply(WorkerApplyRequest {
+                worker_id: worker_id.clone(),
+                worktree_path: Some(worktree_path.clone()),
+            }),
+        ));
+        assert_tool_failed_code(&read_only, "workspace_grant_required");
+        assert!(!read_only
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ApprovalRequested(_))));
+        assert_eq!(
+            fs::read_to_string(&readme).expect("README should read"),
+            original
+        );
+
+        grant_workspace_for_agent(
+            &mut runtime,
+            "worker-apply-grant",
+            vec![WorkspaceAccess::Write],
+            Some(AgentId::from("other-agent")),
+        );
+        let wrong_agent = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_worker_apply_wrong_agent_grant"),
+            ClientId::from("hud_1"),
+            ClientRequest::WorkerApply(WorkerApplyRequest {
+                worker_id: worker_id.clone(),
+                worktree_path: Some(worktree_path.clone()),
+            }),
+        ));
+        assert_tool_failed_code(&wrong_agent, "workspace_grant_required");
+        assert!(!wrong_agent
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ApprovalRequested(_))));
+
+        grant_workspace_for_agent(
+            &mut runtime,
+            "worker-apply-grant",
+            vec![WorkspaceAccess::Write],
+            Some(owner_agent),
+        );
+        let allowed = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_worker_apply_owner_write_grant"),
+            ClientId::from("hud_1"),
+            ClientRequest::WorkerApply(WorkerApplyRequest {
+                worker_id,
+                worktree_path: Some(worktree_path),
+            }),
+        ));
+        assert!(allowed.events.iter().any(|event| {
+            matches!(&event.event, CadisEvent::ApprovalRequested(payload) if payload.summary.contains("worker.apply requires approval"))
+        }));
+        assert!(!allowed
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ToolStarted(_))));
+        assert_eq!(
+            fs::read_to_string(&readme).expect("README should read"),
+            original
+        );
+    }
+
+    #[test]
+    fn worker_apply_preflight_failure_does_not_mutate_workspace() {
+        let cadis_home = test_workspace("worker-apply-preflight-home");
+        let workspace = test_workspace("worker-apply-preflight-workspace");
+        init_git_workspace(&workspace);
+
+        let mut runtime = runtime_with_home(cadis_home);
+        register_workspace(&mut runtime, "worker-apply-preflight", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "worker-apply-preflight",
+            vec![WorkspaceAccess::Write],
+        );
+        let (_session_id, worker_id, worktree_path) =
+            complete_worker_in_workspace(&mut runtime, &workspace, "worker_apply_preflight");
+        let patch_path = runtime
+            .workers
+            .get(&worker_id)
+            .and_then(|worker| worker.artifacts.as_ref())
+            .map(|artifacts| artifacts.patch.clone())
+            .expect("worker patch artifact path should exist");
+        fs::write(
+            patch_path,
+            "diff --git a/README.md b/README.md\n\
+             --- a/README.md\n\
+             +++ b/README.md\n\
+             @@ -20,1 +20,1 @@\n\
+             -missing preflight context\n\
+             +should not apply\n",
+        )
+        .expect("invalid-context worker patch should write");
+        let readme = workspace.join("README.md");
+        let original = fs::read_to_string(&readme).expect("README should read");
+
+        let request = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_worker_apply_preflight"),
+            ClientId::from("hud_1"),
+            ClientRequest::WorkerApply(WorkerApplyRequest {
+                worker_id,
+                worktree_path: Some(worktree_path),
+            }),
+        ));
+        assert!(request
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ApprovalRequested(_))));
+
+        let approved = approve(&mut runtime, approval_id_from(&request));
+        assert_tool_failed_code(&approved, "worker_apply_preflight_failed");
+        assert_eq!(
+            fs::read_to_string(&readme).expect("README should read after preflight failure"),
+            original
+        );
+    }
+
+    #[test]
+    fn worker_apply_rejects_dirty_affected_paths_without_mutating() {
+        let cadis_home = test_workspace("worker-apply-dirty-home");
+        let workspace = test_workspace("worker-apply-dirty-workspace");
+        init_git_workspace(&workspace);
+
+        let mut runtime = runtime_with_home(cadis_home);
+        register_workspace(&mut runtime, "worker-apply-dirty", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "worker-apply-dirty",
+            vec![WorkspaceAccess::Write],
+        );
+        let (_session_id, worker_id, worktree_path) =
+            complete_worker_in_workspace(&mut runtime, &workspace, "worker_apply_dirty");
+        let patch_original =
+            write_worker_readme_append_patch(&runtime, &worker_id, &workspace, "Worker patch");
+        let readme = workspace.join("README.md");
+        let dirty_content = format!("{patch_original}local dirty change\n");
+        fs::write(&readme, &dirty_content).expect("dirty README should write");
+
+        let request = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_worker_apply_dirty"),
+            ClientId::from("hud_1"),
+            ClientRequest::WorkerApply(WorkerApplyRequest {
+                worker_id,
+                worktree_path: Some(worktree_path),
+            }),
+        ));
+        assert!(request
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ApprovalRequested(_))));
+
+        let approved = approve(&mut runtime, approval_id_from(&request));
+        assert_tool_failed_code(&approved, "worker_apply_dirty_paths");
+        assert_eq!(
+            fs::read_to_string(&readme).expect("README should read after dirty reject"),
+            dirty_content,
+            "worker.apply must not apply over dirty affected paths"
+        );
+    }
+
+    #[test]
+    fn worker_apply_rejects_protected_and_secret_patch_paths() {
+        let protected = validate_worker_apply_repo_path(".cadis/workspace.toml")
+            .expect_err("protected metadata path should be rejected");
+        assert_eq!(protected.code, "protected_path");
+
+        let secret = validate_worker_apply_repo_path("nested/.env.production")
+            .expect_err("secret-like path should be rejected");
+        assert_eq!(secret.code, "secret_path_rejected");
+    }
+
+    #[test]
+    fn worker_apply_rollback_restores_checkpoint_snapshot() {
+        let workspace = test_workspace("worker-apply-rollback-workspace");
+        let patch_workspace = test_workspace("worker-apply-rollback-patch");
+        init_git_workspace(&workspace);
+        let patch_path = patch_workspace.join("not-a-reverse.patch");
+        fs::write(&patch_path, "not a patch\n").expect("rollback patch fixture should write");
+
+        let readme = workspace.join("README.md");
+        let original = fs::read_to_string(&readme).expect("README should read");
+        let generated = workspace.join("generated.txt");
+        let affected_paths = vec!["README.md".to_owned(), "generated.txt".to_owned()];
+        let checkpoint = capture_worker_apply_checkpoint(&workspace, &affected_paths, 30)
+            .expect("worker.apply checkpoint should capture");
+
+        fs::write(&readme, "partial worker apply\n").expect("partial README write should work");
+        fs::write(&generated, "partial generated file\n")
+            .expect("partial generated write should work");
+        run_git(&workspace, &["add", "generated.txt"]);
+
+        let rollback = rollback_worker_apply(&workspace, &patch_path, &checkpoint, 30);
+        assert!(
+            rollback.restored,
+            "rollback should restore checkpoint: {}",
+            rollback.message
+        );
+        assert_eq!(
+            fs::read_to_string(&readme).expect("README should read after rollback"),
+            original
+        );
+        assert!(!generated.exists(), "rollback should remove created path");
+        let status = Command::new("git")
+            .arg("-C")
+            .arg(&workspace)
+            .args(["status", "--porcelain=v1", "--untracked-files=all"])
+            .output()
+            .expect("git status should run");
+        assert!(
+            status.status.success(),
+            "git status should succeed: {}",
+            String::from_utf8_lossy(&status.stderr)
+        );
+        assert!(
+            status.stdout.is_empty(),
+            "workspace should return to pre-apply status: {}",
+            String::from_utf8_lossy(&status.stdout)
         );
     }
 

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -31,12 +31,13 @@ use cadis_protocol::{
     SessionEventPayload, SessionId, Timestamp, ToolCallId, ToolCallRequest, ToolEventPayload,
     ToolFailedPayload, UiPreferencesPayload, VoiceDoctorCheck, VoiceDoctorPayload,
     VoicePreferences, VoicePreflightRequest, VoicePreflightSummary, VoicePreviewRequest,
-    VoiceRuntimeState, VoiceStatusPayload, WorkerArtifactLocations, WorkerCleanupRequest,
-    WorkerEventPayload, WorkerLogDeltaPayload, WorkerResultRequest, WorkerState, WorkerTailRequest,
-    WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent, WorkerWorktreeState, WorkspaceAccess,
-    WorkspaceDoctorCheck, WorkspaceDoctorPayload, WorkspaceDoctorRequest, WorkspaceGrantId,
-    WorkspaceGrantPayload, WorkspaceGrantRequest, WorkspaceId, WorkspaceKind, WorkspaceListPayload,
-    WorkspaceListRequest, WorkspaceRecordPayload, WorkspaceRegisterRequest, WorkspaceRevokeRequest,
+    VoiceRuntimeState, VoiceStatusPayload, WorkerApplyRequest, WorkerArtifactLocations,
+    WorkerCleanupRequest, WorkerEventPayload, WorkerLogDeltaPayload, WorkerResultRequest,
+    WorkerState, WorkerTailRequest, WorkerWorktreeCleanupPolicy, WorkerWorktreeIntent,
+    WorkerWorktreeState, WorkspaceAccess, WorkspaceDoctorCheck, WorkspaceDoctorPayload,
+    WorkspaceDoctorRequest, WorkspaceGrantId, WorkspaceGrantPayload, WorkspaceGrantRequest,
+    WorkspaceId, WorkspaceKind, WorkspaceListPayload, WorkspaceListRequest, WorkspaceRecordPayload,
+    WorkspaceRegisterRequest, WorkspaceRevokeRequest,
 };
 use cadis_store::{
     redact, AgentHomeDiagnostic, AgentHomeDoctorOptions, AgentHomeTemplate, ApprovalRecord,
@@ -1436,6 +1437,7 @@ impl Runtime {
 
         let required_access = required_tool_access(&directive.tool_name);
         let workspace = match self.resolved_granted_workspace(
+            &directive.tool_name,
             session_id,
             Some(agent_id),
             &directive.input,

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -2121,7 +2121,10 @@ impl Runtime {
             );
         };
         let patch_path = PathBuf::from(artifacts.patch.trim());
-        let expected_patch = self.profile_home.worker_artifact_paths(&request.worker_id).patch;
+        let expected_patch = self
+            .profile_home
+            .worker_artifact_paths(&request.worker_id)
+            .patch;
         if patch_path != expected_patch {
             return self.reject(
                 request_id,

--- a/crates/cadis-core/src/tools.rs
+++ b/crates/cadis-core/src/tools.rs
@@ -494,8 +494,9 @@ pub(crate) fn tool_command_summary(tool_name: &str, input: &serde_json::Value) -
             })
         }),
         "file.patch" => file_patch_path_summary(input),
-        "worker.apply" => input_string(input, "worker_id")
-            .map(|worker_id| format!("worker {worker_id} patch")),
+        "worker.apply" => {
+            input_string(input, "worker_id").map(|worker_id| format!("worker {worker_id} patch"))
+        }
         _ => input_string(input, "path"),
     }
     .map(|value| redact(&value))

--- a/crates/cadis-core/src/tools.rs
+++ b/crates/cadis-core/src/tools.rs
@@ -111,6 +111,18 @@ impl ToolRegistry {
                 false,
                 false,
             ),
+            ToolDefinition::approval_placeholder(
+                "worker.apply",
+                "Apply a daemon-owned worker patch to a registered workspace",
+                cadis_protocol::RiskClass::WorkspaceEdit,
+                ToolInputSchema::WorkspaceMutation,
+                &[ToolSideEffect::EditWorkspace],
+                60,
+                ToolCancellationBehavior::Cooperative,
+                ToolWorkspaceBehavior::PathScoped,
+                false,
+                false,
+            ),
             ToolDefinition::safe_read(
                 "git.diff",
                 "Read git diff output for an approved workspace",
@@ -463,7 +475,7 @@ pub(crate) fn tool_workspace_id(input: &serde_json::Value) -> Option<String> {
 pub(crate) fn required_tool_access(tool_name: &str) -> WorkspaceAccess {
     match tool_name {
         "shell.run" => WorkspaceAccess::Exec,
-        "file.write" | "file.patch" => WorkspaceAccess::Write,
+        "file.write" | "file.patch" | "worker.apply" => WorkspaceAccess::Write,
         _ => WorkspaceAccess::Read,
     }
 }
@@ -482,6 +494,8 @@ pub(crate) fn tool_command_summary(tool_name: &str, input: &serde_json::Value) -
             })
         }),
         "file.patch" => file_patch_path_summary(input),
+        "worker.apply" => input_string(input, "worker_id")
+            .map(|worker_id| format!("worker {worker_id} patch")),
         _ => input_string(input, "path"),
     }
     .map(|value| redact(&value))

--- a/crates/cadis-protocol/src/lib.rs
+++ b/crates/cadis-protocol/src/lib.rs
@@ -447,6 +447,9 @@ pub enum ClientRequest {
     /// Request daemon-owned worker worktree cleanup planning.
     #[serde(rename = "worker.cleanup")]
     WorkerCleanup(WorkerCleanupRequest),
+    /// Request approval-gated patch application for a daemon-owned worker.
+    #[serde(rename = "worker.apply")]
+    WorkerApply(WorkerApplyRequest),
     /// List available model descriptors.
     #[serde(rename = "models.list")]
     ModelsList(EmptyPayload),
@@ -672,6 +675,17 @@ pub struct WorkerResultRequest {
 /// Payload for requesting worker worktree cleanup planning.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct WorkerCleanupRequest {
+    /// Worker identifier.
+    pub worker_id: String,
+    /// Optional caller-observed worktree path. When supplied, it must match the
+    /// daemon-owned worker metadata exactly.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
+}
+
+/// Payload for requesting approval-gated worker patch application.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct WorkerApplyRequest {
     /// Worker identifier.
     pub worker_id: String,
     /// Optional caller-observed worktree path. When supplied, it must match the
@@ -2004,6 +2018,34 @@ mod tests {
                 "request_id": "req_1",
                 "client_id": "cli_1",
                 "type": "worker.cleanup",
+                "payload": {
+                    "worker_id": "worker_000001",
+                    "worktree_path": ".cadis/worktrees/worker_000001"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn worker_apply_request_matches_documented_shape() {
+        let envelope = RequestEnvelope::new(
+            RequestId::from("req_1"),
+            ClientId::from("cli_1"),
+            ClientRequest::WorkerApply(WorkerApplyRequest {
+                worker_id: "worker_000001".to_owned(),
+                worktree_path: Some(".cadis/worktrees/worker_000001".to_owned()),
+            }),
+        );
+
+        let value = serde_json::to_value(&envelope).expect("request should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "protocol_version": CURRENT_PROTOCOL_VERSION,
+                "request_id": "req_1",
+                "client_id": "cli_1",
+                "type": "worker.apply",
                 "payload": {
                     "worker_id": "worker_000001",
                     "worktree_path": ".cadis/worktrees/worker_000001"

--- a/docs/15_PROTOCOL_DRAFT.md
+++ b/docs/15_PROTOCOL_DRAFT.md
@@ -244,10 +244,10 @@ a registered workspace and an active workspace grant before execution or
 approval flow proceeds. `agent_id` is optional; when present, it lets daemon tool
 execution satisfy agent-scoped workspace grants. The current baseline supports
 safe read-only execution for `file.read`, `file.search`, `git.status`, and
-`git.diff`. `shell.run` and `file.patch` create an approval request after the
-workspace grant check, then execute only after approval and daemon-side
-revalidation. Other risky placeholders such as `file.write` still fail closed
-after approval until a later runtime implements the gated action.
+`git.diff`. `shell.run`, `file.patch`, and `worker.apply` create an approval
+request after the workspace grant check, then execute only after approval and
+daemon-side revalidation. Other risky placeholders such as `file.write` still
+fail closed after approval until a later runtime implements the gated action.
 
 Example:
 
@@ -340,11 +340,15 @@ Worker integration uses the same protocol flow. The current worker command
 baseline runs only the daemon-owned validation command inside the active worker
 worktree and records bounded redacted output in events/artifacts. Future
 configurable worker commands/tests must use daemon-owned policy and cwd inside
-the worker worktree. Applying a worker artifact to the parent workspace is a
-separate `file.patch` or future patch-apply tool call with its own approval;
-`worker.completed` alone does not authorize parent-checkout mutation.
-Cleanup/removal of a worker worktree is also a separate approval-gated flow and
-must require a CADIS-owned worker/worktree record.
+the worker worktree. Applying a worker artifact to the parent workspace uses
+`worker.apply`, which must resolve a CADIS-owned worker/worktree record, require
+an active write grant for the worker owner on the parent workspace, emit approval
+events before mutation, preflight the patch, reject protected metadata,
+secret-like paths, and dirty affected paths, and fail closed with rollback
+reporting if apply fails. `worker.completed` alone does not authorize
+parent-checkout mutation. Cleanup/removal of a worker worktree is also a
+separate approval-gated flow and must require a CADIS-owned worker/worktree
+record.
 
 `patch.created` and `test.result` are summary events for code-work presentation.
 They do not carry authority to mutate the parent checkout. `patch.created`
@@ -734,6 +738,8 @@ tool outputs are:
 - `shell.run`: `cwd`, `exit_code`, `stdout`, `stderr`, truncation flags,
   `timeout_ms`
 - `file.patch`: `schema`, `files[]`, `truncated`
+- `worker.apply`: `worker_id`, `patch_path`, `workspace`, `exit_code`,
+  `stdout`, `stderr`, truncation flags
 
 ## 8. Compatibility Rules
 


### PR DESCRIPTION
## Summary

This PR introduces a first-class `worker.apply` flow so patches produced by daemon-owned workers can be applied in a safer, reviewable, and approval-gated way.

Instead of keeping APPLY as a disabled UI placeholder, we now support an end-to-end path from HUD → protocol → runtime approval pipeline → patch application backend.

## Why this change

Until now, worker patches were generated and visible as artifacts, but there was no dedicated daemon request to apply them safely. The UI had an APPLY button, but it was intentionally disabled because the backend contract did not exist yet.

This PR closes that gap and keeps the same safety posture as other mutation tools:
- explicit approval required
- fail-closed validation
- bounded execution
- ownership checks for worker/worktree/artifact paths

## What changed

- Added protocol request type:
  - `worker.apply` with `worker_id` and optional `worktree_path`
- Added runtime handling for `ClientRequest::WorkerApply(...)`
- Added strict preflight checks before creating the internal tool request:
  - worker must exist
  - worker must be `completed`
  - worker worktree must be verified as CADIS-owned
  - patch artifact metadata must exist
  - patch artifact path must match CADIS-owned expected location
  - patch file must exist and be non-empty
- Registered a new approval-placeholder tool:
  - `worker.apply`
  - risk class: `WorkspaceEdit`
  - access: write
- Added approved backend execution for `worker.apply`:
  - runs `git apply --3way --whitespace=nowarn <patch>`
  - bounded with timeout
  - fail-closed error reporting with contextual messages
- Updated workspace resolution path for `worker.apply` so it resolves from verified worker metadata instead of fragile caller context
- Re-enabled HUD apply wiring:
  - added `sendWorkerApply(...)`
  - APPLY button now dispatches `worker.apply` when worker state/artifacts are valid
- Added protocol/runtime/HUD tests for the new request path and failure scenarios

## Reviewer notes

- This PR intentionally keeps approval as the gate before mutation.
- It does not auto-create PRs, auto-commit, or auto-cleanup after apply.
- It focuses on making patch apply explicit, auditable, and safe by default.
- The behavior for invalid ownership/path conditions is fail-closed.

## Validation

I added request-shape and runtime behavior tests for:
- successful approval-gated apply path
- empty patch rejection path

Please rely on CI to run the full matrix in your environment.
