### PR TITLE
fix(hud): disable unsafe actions while daemon is disconnected

### DIFF
--- a/apps/cadis-hud/src/ui/cadisActions.test.ts
+++ b/apps/cadis-hud/src/ui/cadisActions.test.ts
@@ -541,6 +541,10 @@ describe("cadisActions", () => {
     const apply = screen.getByRole("button", { name: "APPLY" });
     expect(apply).toBeDisabled();
     expect(apply.getAttribute("title")).toBe("Pending daemon worker.apply support");
+
+    const discard = screen.getByRole("button", { name: "DISCARD" });
+    expect(discard).toBeDisabled();
+    expect(discard.getAttribute("title")).toBe("Daemon disconnected");
   });
 
   it("routes theme/opacity/avatar preference changes through daemon via ui.preferences.set", async () => {

--- a/apps/cadis-hud/src/ui/codework/CodeWorkPanel.tsx
+++ b/apps/cadis-hud/src/ui/codework/CodeWorkPanel.tsx
@@ -7,6 +7,7 @@ const EMPTY_VALUE = "not reported by daemon";
 
 export function CodeWorkPanel() {
   const open = useHud((s) => s.codeWorkPanelOpen);
+  const gateway = useHud((s) => s.gateway);
   const selectedWorkerId = useHud((s) => s.selectedWorkerId);
   const workers = useHud((s) => s.workers);
   const agents = useHud((s) => s.agents);
@@ -24,6 +25,7 @@ export function CodeWorkPanel() {
   const isTerminal = worker
     ? ["completed", "failed", "cancelled"].includes(worker.status)
     : false;
+  const disconnected = gateway !== "connected";
 
   if (!open) return null;
 
@@ -131,8 +133,8 @@ export function CodeWorkPanel() {
           </button>
           <button
             type="button"
-            disabled={!worker || !isTerminal}
-            title="Send worker.cleanup to daemon"
+            disabled={!worker || !isTerminal || disconnected}
+            title={disconnected ? "Daemon disconnected" : "Send worker.cleanup to daemon"}
             onClick={() => worker && sendWorkerCleanup(worker.id, worker.worktree?.worktreePath)}
           >
             DISCARD

--- a/apps/cadis-hud/src/ui/settings/AgentRenameDialog.test.tsx
+++ b/apps/cadis-hud/src/ui/settings/AgentRenameDialog.test.tsx
@@ -18,6 +18,7 @@ beforeEach(() => {
   sendAgentRenameMock.mockClear().mockReturnValue(true);
   sendAgentSpecialistUpdateMock.mockClear().mockReturnValue(true);
   useHud.setState({
+    gateway: "connected",
     agentRenameTarget: "atlas",
     agents: [
       {
@@ -58,5 +59,16 @@ describe("AgentRenameDialog", () => {
 
     const input = screen.getByLabelText(/agent name/i) as HTMLInputElement;
     expect(input.maxLength).toBe(32);
+  });
+
+  it("disables save while disconnected", () => {
+    useHud.setState({ gateway: "disconnected" });
+    render(createElement(AgentRenameDialog));
+
+    const save = screen.getByRole("button", { name: "SAVE" });
+    expect(save).toBeDisabled();
+    fireEvent.click(save);
+    expect(sendAgentRenameMock).not.toHaveBeenCalled();
+    expect(sendAgentSpecialistUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/cadis-hud/src/ui/settings/AgentRenameDialog.tsx
+++ b/apps/cadis-hud/src/ui/settings/AgentRenameDialog.tsx
@@ -12,6 +12,7 @@ import {
 
 export function AgentRenameDialog() {
   const target = useHud((s) => s.agentRenameTarget);
+  const gateway = useHud((s) => s.gateway);
   const agent = useHud((s) => s.agents.find((a) => a.spec.id === s.agentRenameTarget));
   const close = useHud((s) => s.setAgentRenameTarget);
   const [name, setName] = useState("");
@@ -32,6 +33,7 @@ export function AgentRenameDialog() {
   }, [target, agent?.spec.name, agent?.spec.role, agent?.specialist]);
 
   if (!target || !agent) return null;
+  const disconnected = gateway !== "connected";
 
   const selectedSpecialist =
     specialistId === CUSTOM_SPECIALIST_ID
@@ -39,6 +41,10 @@ export function AgentRenameDialog() {
       : specialistOption(specialistId) ?? defaultSpecialistForRole(agent.spec.role);
 
   const submit = () => {
+    if (disconnected) {
+      setWarning("CADIS daemon is disconnected. Reconnect first to save agent settings.");
+      return;
+    }
     const next = normalizeAgentName(name);
     const renameDelivered = sendAgentRename(target, next);
     const specialistDelivered = sendAgentSpecialistUpdate(target, selectedSpecialist);
@@ -80,6 +86,7 @@ export function AgentRenameDialog() {
             value={name}
             maxLength={32}
             autoFocus
+            disabled={disconnected}
             onChange={(e) => setName(e.target.value)}
           />
         </section>
@@ -93,6 +100,7 @@ export function AgentRenameDialog() {
             id="agent-specialist-input"
             className="voice-config__select"
             value={specialistId}
+            disabled={disconnected}
             onChange={(e) => setSpecialistId(e.target.value)}
           >
             {SPECIALIST_OPTIONS.map((option) => (
@@ -113,6 +121,7 @@ export function AgentRenameDialog() {
               className="voice-config__input"
               value={customLabel}
               maxLength={48}
+              disabled={disconnected}
               onChange={(e) => setCustomLabel(e.target.value)}
             />
           </section>
@@ -129,6 +138,7 @@ export function AgentRenameDialog() {
             value={selectedSpecialist.persona}
             rows={5}
             maxLength={1200}
+            disabled={disconnected}
             onChange={(e) => {
               if (specialistId !== CUSTOM_SPECIALIST_ID) return;
               setCustomPersona(e.target.value);
@@ -138,12 +148,22 @@ export function AgentRenameDialog() {
         </section>
 
         {warning && <div className="voice-config__hint">{warning}</div>}
+        {disconnected && !warning && (
+          <div className="voice-config__hint">
+            CADIS daemon disconnected. Reconnect to save agent settings.
+          </div>
+        )}
 
         <footer className="voice-config__foot">
           <button type="button" className="voice-config__btn" onClick={() => close(null)}>
             CANCEL
           </button>
-          <button type="submit" className="voice-config__btn voice-config__btn--primary">
+          <button
+            type="submit"
+            className="voice-config__btn voice-config__btn--primary"
+            disabled={disconnected}
+            title={disconnected ? "Daemon disconnected" : undefined}
+          >
             SAVE
           </button>
         </footer>

--- a/apps/cadis-hud/src/ui/settings/ConfigDialog.test.tsx
+++ b/apps/cadis-hud/src/ui/settings/ConfigDialog.test.tsx
@@ -34,4 +34,36 @@ describe("ConfigDialog", () => {
     const labels = Array.from(buttons).map((b) => b.textContent);
     expect(labels).toEqual(["Voice", "Models", "Appearance", "Window"]);
   });
+
+  it("disables model mutation controls while disconnected", () => {
+    useHud.setState({
+      configOpen: true,
+      configTab: "models",
+      gateway: "disconnected",
+      defaultModel: "openai/gpt-5.5",
+      availableModels: ["openai/gpt-5.5"],
+      agentModels: { main: "openai/gpt-5.5" },
+      chatPreferences: { thinking: false, fast: false },
+      agents: [
+        {
+          spec: { id: "main", name: "CADIS", role: "Core", icon: "C", hue: 180, tasks: [] },
+          status: "idle",
+          currentTask: { verb: "ready", target: "CADIS", detail: "openai/gpt-5.5" },
+          specialist: { id: "core", label: "Core", persona: "" },
+          uptimeSeconds: 0,
+        },
+      ],
+    });
+
+    render(createElement(ConfigDialog));
+    for (const select of screen.getAllByRole("combobox")) {
+      expect(select).toBeDisabled();
+    }
+    for (const checkbox of screen.getAllByRole("checkbox")) {
+      expect(checkbox).toBeDisabled();
+    }
+    expect(
+      screen.getByText(/model and chat preference updates are temporarily disabled/i),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/cadis-hud/src/ui/settings/ConfigDialog.tsx
+++ b/apps/cadis-hud/src/ui/settings/ConfigDialog.tsx
@@ -282,12 +282,14 @@ function VoiceTab() {
 }
 
 function ModelsTab() {
+  const gateway = useHud((s) => s.gateway);
   const models = useHud((s) => s.availableModels);
   const defaultModel = useHud((s) => s.defaultModel);
   const agents = useHud((s) => s.agents);
   const agentModels = useHud((s) => s.agentModels);
   const chatPrefs = useHud((s) => s.chatPreferences);
   const setChatPreferences = useHud((s) => s.setChatPreferences);
+  const disconnected = gateway !== "connected";
   const updateChatPrefs = (patch: Partial<typeof chatPrefs>) => {
     const next = { ...chatPrefs, ...patch };
     setChatPreferences(patch);
@@ -317,6 +319,8 @@ function ModelsTab() {
                 <select
                   className="voice-config__select"
                   value={current}
+                  disabled={disconnected}
+                  title={disconnected ? "Daemon disconnected" : undefined}
                   onChange={(e) => {
                     const nextModel = e.target.value;
                     sendAgentModelUpdate(a.spec.id, nextModel);
@@ -343,6 +347,7 @@ function ModelsTab() {
           <input
             type="checkbox"
             checked={chatPrefs.thinking}
+            disabled={disconnected}
             onChange={(e) => updateChatPrefs({ thinking: e.target.checked })}
           />
           Enable thinking mode
@@ -354,11 +359,19 @@ function ModelsTab() {
           <input
             type="checkbox"
             checked={chatPrefs.fast}
+            disabled={disconnected}
             onChange={(e) => updateChatPrefs({ fast: e.target.checked })}
           />
           Fast responses
         </label>
       </section>
+      {disconnected && (
+        <section className="voice-config__row">
+          <div className="voice-config__hint">
+            CADIS daemon disconnected. Model and chat preference updates are temporarily disabled.
+          </div>
+        </section>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary

This PR improves disconnected-state UX by disabling mutation actions that would otherwise fail immediately when the daemon is not connected.

The goal is to prevent “click and fail” behavior and make the UI state clearer when CADIS is offline.

## Why this change

Several controls were still interactable while disconnected, even though their underlying requests require an active daemon. That produced avoidable failed requests and a confusing user experience.

This PR adds straightforward guardrails in the HUD so unsafe mutations are unavailable during disconnect windows.

## What changed

- Code Work panel:
  - `DISCARD` is now disabled when daemon is disconnected
  - tooltip reflects disconnected state
- Agent settings dialog:
  - save action is blocked while disconnected
  - relevant form controls are disabled
  - user gets a clear hint that reconnection is needed before saving
- Models tab in settings:
  - per-agent model selectors disabled while disconnected
  - chat preference mutation toggles in that tab disabled while disconnected
  - explicit hint text added for temporary disablement
- Added/updated tests to cover disconnected behavior so this UX does not regress

## Reviewer notes

- This change is intentionally scoped to mutation actions.
- Read-only display behavior is unchanged.
- Existing connected-path behavior is preserved.
- The UX uses explicit tooltips/hints to reduce ambiguity for users.

## Validation

I added targeted UI tests around disconnected controls and save guards.

Please let CI run the full frontend test pipeline.
