### PR TITLE
fix(hud): add robust open_in_editor fallback chain

### DIFF
--- a/apps/cadis-hud/src-tauri/src/lib.rs
+++ b/apps/cadis-hud/src-tauri/src/lib.rs
@@ -227,12 +227,110 @@ fn open_in_editor(path: String) -> Result<(), String> {
     if !canonical_str.contains("/.cadis/worktrees/") && !canonical_str.contains("\\.cadis\\worktrees\\") {
         return Err("path is not inside a CADIS-owned worktree".to_owned());
     }
-    let editor = std::env::var("EDITOR").unwrap_or_else(|_| "code".to_owned());
-    std::process::Command::new(&editor)
-        .arg(&canonical)
-        .spawn()
-        .map_err(|e| format!("failed to open editor: {e}"))?;
-    Ok(())
+    launch_editor_with_fallback(&canonical)
+}
+
+fn launch_editor_with_fallback(path: &Path) -> Result<(), String> {
+    let editor_env = env::var("EDITOR").ok();
+    let mut errors = Vec::new();
+
+    for (program, args) in editor_launch_plan(editor_env.as_deref()) {
+        let mut command = Command::new(&program);
+        command.args(&args).arg(path);
+        match command.spawn() {
+            Ok(_) => return Ok(()),
+            Err(error) => {
+                errors.push(format!(
+                    "{} ({error})",
+                    format_editor_command(&program, &args)
+                ));
+            }
+        }
+    }
+
+    match open_with_system_default(path) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            errors.push(format!("system default opener ({error})"));
+            Err(format!(
+                "failed to open editor for '{}': {}",
+                path.display(),
+                errors.join("; ")
+            ))
+        }
+    }
+}
+
+fn editor_launch_plan(editor_env: Option<&str>) -> Vec<(String, Vec<String>)> {
+    let mut plan: Vec<(String, Vec<String>)> = Vec::new();
+    if let Some((program, args)) = parse_editor_command(editor_env) {
+        push_editor_candidate(&mut plan, program, args);
+    }
+    for program in default_editor_candidates() {
+        push_editor_candidate(&mut plan, (*program).to_owned(), Vec::new());
+    }
+    plan
+}
+
+fn parse_editor_command(editor_env: Option<&str>) -> Option<(String, Vec<String>)> {
+    let value = editor_env?.trim();
+    if value.is_empty() {
+        return None;
+    }
+    let mut parts = value.split_whitespace();
+    let program = parts.next()?.trim();
+    if program.is_empty() {
+        return None;
+    }
+    let args = parts.map(|value| value.to_owned()).collect::<Vec<_>>();
+    Some((program.to_owned(), args))
+}
+
+fn push_editor_candidate(plan: &mut Vec<(String, Vec<String>)>, program: String, args: Vec<String>) {
+    if plan
+        .iter()
+        .any(|(existing_program, existing_args)| existing_program == &program && existing_args == &args)
+    {
+        return;
+    }
+    plan.push((program, args));
+}
+
+fn format_editor_command(program: &str, args: &[String]) -> String {
+    if args.is_empty() {
+        return program.to_owned();
+    }
+    format!("{} {}", program, args.join(" "))
+}
+
+fn default_editor_candidates() -> &'static [&'static str] {
+    #[cfg(target_os = "windows")]
+    {
+        &["code", "cursor", "codium", "notepad++"]
+    }
+    #[cfg(target_os = "macos")]
+    {
+        &["code", "cursor", "codium"]
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        &["code", "cursor", "codium"]
+    }
+}
+
+fn open_with_system_default(path: &Path) -> io::Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        Command::new("explorer").arg(path).spawn().map(|_| ())
+    }
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("open").arg(path).spawn().map(|_| ())
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        Command::new("xdg-open").arg(path).spawn().map(|_| ())
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -1475,6 +1573,35 @@ mod tests {
         assert_eq!(frames.len(), 2);
         assert_eq!(frames[0]["frame"], "response");
         assert_eq!(frames[1]["payload"]["event_id"], "evt_1");
+    }
+
+    #[test]
+    fn parse_editor_command_handles_empty_and_args() {
+        assert_eq!(parse_editor_command(None), None);
+        assert_eq!(parse_editor_command(Some("   ")), None);
+        assert_eq!(
+            parse_editor_command(Some("code --reuse-window --wait")),
+            Some((
+                "code".to_owned(),
+                vec!["--reuse-window".to_owned(), "--wait".to_owned()]
+            ))
+        );
+    }
+
+    #[test]
+    fn editor_launch_plan_prefers_editor_env_and_deduplicates() {
+        let plan = editor_launch_plan(Some("code --reuse-window"));
+        assert_eq!(plan.first().map(|item| item.0.as_str()), Some("code"));
+        assert_eq!(
+            plan.first().map(|item| item.1.clone()),
+            Some(vec!["--reuse-window".to_owned()])
+        );
+
+        let duplicates = plan
+            .iter()
+            .filter(|(program, args)| program == "code" && args.is_empty())
+            .count();
+        assert_eq!(duplicates, 1);
     }
 
     fn unique_temp_dir() -> PathBuf {

--- a/apps/cadis-hud/src-tauri/src/lib.rs
+++ b/apps/cadis-hud/src-tauri/src/lib.rs
@@ -221,10 +221,12 @@ fn voice_stt_stop() -> Result<(), String> {
 fn open_in_editor(path: String) -> Result<(), String> {
     // Desktop convenience: open a CADIS-owned worktree in the user's editor.
     // Validate the canonical path contains a .cadis/worktrees/ segment.
-    let canonical = std::fs::canonicalize(&path)
-        .map_err(|e| format!("cannot resolve path: {e}"))?;
+    let canonical =
+        std::fs::canonicalize(&path).map_err(|e| format!("cannot resolve path: {e}"))?;
     let canonical_str = canonical.to_string_lossy();
-    if !canonical_str.contains("/.cadis/worktrees/") && !canonical_str.contains("\\.cadis\\worktrees\\") {
+    if !canonical_str.contains("/.cadis/worktrees/")
+        && !canonical_str.contains("\\.cadis\\worktrees\\")
+    {
         return Err("path is not inside a CADIS-owned worktree".to_owned());
     }
     launch_editor_with_fallback(&canonical)
@@ -277,20 +279,89 @@ fn parse_editor_command(editor_env: Option<&str>) -> Option<(String, Vec<String>
     if value.is_empty() {
         return None;
     }
-    let mut parts = value.split_whitespace();
-    let program = parts.next()?.trim();
-    if program.is_empty() {
+    let mut parts = split_editor_command(value).into_iter();
+    let program = parts.next()?;
+    if program.trim().is_empty() {
         return None;
     }
-    let args = parts.map(|value| value.to_owned()).collect::<Vec<_>>();
-    Some((program.to_owned(), args))
+    let args = parts.collect::<Vec<_>>();
+    Some((program, args))
 }
 
-fn push_editor_candidate(plan: &mut Vec<(String, Vec<String>)>, program: String, args: Vec<String>) {
-    if plan
-        .iter()
-        .any(|(existing_program, existing_args)| existing_program == &program && existing_args == &args)
-    {
+fn split_editor_command(value: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut chars = value.chars().peekable();
+    let mut quote = None;
+    let mut in_token = false;
+
+    while let Some(ch) = chars.next() {
+        match quote {
+            Some(active_quote) if ch == active_quote => {
+                quote = None;
+                in_token = true;
+            }
+            Some(_) if ch == '\\' => {
+                if should_escape_editor_char(chars.peek().copied(), true) {
+                    let next = chars.next().unwrap_or(ch);
+                    current.push(next);
+                } else {
+                    current.push(ch);
+                }
+                in_token = true;
+            }
+            Some(_) => {
+                current.push(ch);
+                in_token = true;
+            }
+            None if ch == '\'' || ch == '"' => {
+                quote = Some(ch);
+                in_token = true;
+            }
+            None if ch == '\\' => {
+                if should_escape_editor_char(chars.peek().copied(), false) {
+                    let next = chars.next().unwrap_or(ch);
+                    current.push(next);
+                } else {
+                    current.push(ch);
+                }
+                in_token = true;
+            }
+            None if ch.is_whitespace() => {
+                if in_token {
+                    parts.push(std::mem::take(&mut current));
+                    in_token = false;
+                }
+            }
+            None => {
+                current.push(ch);
+                in_token = true;
+            }
+        }
+    }
+
+    if in_token {
+        parts.push(current);
+    }
+    parts
+}
+
+fn should_escape_editor_char(next: Option<char>, in_quote: bool) -> bool {
+    match next {
+        Some('\\' | '\'' | '"') => true,
+        Some(ch) if !in_quote && ch.is_whitespace() => true,
+        _ => false,
+    }
+}
+
+fn push_editor_candidate(
+    plan: &mut Vec<(String, Vec<String>)>,
+    program: String,
+    args: Vec<String>,
+) {
+    if plan.iter().any(|(existing_program, existing_args)| {
+        existing_program == &program && existing_args == &args
+    }) {
         return;
     }
     plan.push((program, args));
@@ -1136,7 +1207,8 @@ where
 }
 
 fn send_cadis_request(transport: &DaemonTransport, request: Value) -> io::Result<Vec<Value>> {
-    let mut stream = connect_daemon(transport).map_err(|msg| io::Error::new(io::ErrorKind::ConnectionRefused, msg))?;
+    let mut stream = connect_daemon(transport)
+        .map_err(|msg| io::Error::new(io::ErrorKind::ConnectionRefused, msg))?;
 
     serde_json::to_writer(&mut stream, &request)?;
     stream.write_all(b"\n")?;
@@ -1584,6 +1656,43 @@ mod tests {
             Some((
                 "code".to_owned(),
                 vec!["--reuse-window".to_owned(), "--wait".to_owned()]
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_editor_command_handles_quoted_program_path() {
+        assert_eq!(
+            parse_editor_command(Some("\"/opt/Visual Studio Code/code\" --reuse-window")),
+            Some((
+                "/opt/Visual Studio Code/code".to_owned(),
+                vec!["--reuse-window".to_owned()]
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_editor_command_handles_quoted_and_escaped_args() {
+        assert_eq!(
+            parse_editor_command(Some("code '--profile CADIS Work' --goto src\\ main.rs:10")),
+            Some((
+                "code".to_owned(),
+                vec![
+                    "--profile CADIS Work".to_owned(),
+                    "--goto".to_owned(),
+                    "src main.rs:10".to_owned()
+                ]
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_editor_command_preserves_unescaped_windows_backslashes() {
+        assert_eq!(
+            parse_editor_command(Some(r#"C:\Tools\editor.exe --reuse-window"#)),
+            Some((
+                r#"C:\Tools\editor.exe"#.to_owned(),
+                vec!["--reuse-window".to_owned()]
             ))
         );
     }


### PR DESCRIPTION
## Summary

This PR hardens `open_in_editor` so it no longer depends on a single editor command (`code`) being installed.

If `EDITOR` is missing or points to an unavailable executable, the command now falls back through a safe candidate chain and finally to the OS default opener.

## Why

The previous implementation assumed VS Code CLI availability (`code`). On machines without that binary in PATH, the button failed even though opening the folder was still possible through other editors or system tools.

This change makes the behavior resilient and cross-environment friendly.

## What changed

- Kept existing safety boundary:
  - still validates target path is inside a CADIS-owned `.cadis/worktrees` location
- Added `launch_editor_with_fallback(...)` flow:
  - try `EDITOR` first (including argument parsing)
  - then try default editor candidates by platform
  - then fallback to system opener:
    - Windows: `explorer`
    - macOS: `open`
    - Linux: `xdg-open`
- Added dedup logic so candidate attempts are clean and deterministic
- Improved error reporting by aggregating attempted command failures
- Added tests for:
  - parsing `EDITOR` command variants
  - launch plan ordering and dedup behavior

## Reviewer notes

- This change prioritizes compatibility and graceful fallback.
- It does not loosen worktree path validation.
- It minimizes assumptions about developer tooling installed on host systems.

## Validation

I added focused unit tests for parser/plan behavior.
Full platform behavior should be exercised by CI and real host environments.