### PR TITLE
refactor(protocol): box large enum variants in ServerFrame and DaemonResponse

### DIFF
--- a/crates/cadis-cli/src/main.rs
+++ b/crates/cadis-cli/src/main.rs
@@ -1142,7 +1142,7 @@ fn daemon_status(frames: &[ServerFrame]) -> Option<&cadis_protocol::DaemonStatus
             return None;
         };
         match &response.response {
-            DaemonResponse::DaemonStatus(status) => Some(status),
+            DaemonResponse::DaemonStatus(status) => Some(status.as_ref()),
             _ => None,
         }
     })

--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -777,7 +777,7 @@ impl Runtime {
         RequestOutcome {
             response: ResponseEnvelope::new(
                 request_id,
-                DaemonResponse::DaemonStatus(DaemonStatusPayload {
+                DaemonResponse::DaemonStatus(Box::new(DaemonStatusPayload {
                     status: "ok".to_owned(),
                     version: env!("CARGO_PKG_VERSION").to_owned(),
                     protocol_version: ProtocolVersion::current(),
@@ -791,7 +791,7 @@ impl Runtime {
                     model_provider: self.options.model_provider.clone(),
                     uptime_seconds: self.started_at.elapsed().as_secs(),
                     voice: self.voice_status(),
-                }),
+                })),
             ),
             events: Vec::new(),
         }
@@ -12783,7 +12783,7 @@ mod tests {
         ));
 
         let response_frame = ServerFrame::Response(outcome.response);
-        let event_frame = ServerFrame::Event(outcome.events[0].clone());
+        let event_frame = ServerFrame::Event(Box::new(outcome.events[0].clone()));
 
         serde_json::to_string(&response_frame).expect("response frame should serialize");
         serde_json::to_string(&event_frame).expect("event frame should serialize");

--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -480,19 +480,19 @@ where
                 write_frame(&mut writer, &response)?;
                 if let Some(subscription) = subscription {
                     for event in events {
-                        write_frame(&mut writer, &ServerFrame::Event(event))?;
+                        write_frame(&mut writer, &ServerFrame::Event(Box::new(event)))?;
                     }
                     let (replay, receiver) = event_bus.subscribe(subscription);
                     for event in replay {
-                        write_frame(&mut writer, &ServerFrame::Event(event))?;
+                        write_frame(&mut writer, &ServerFrame::Event(Box::new(event)))?;
                     }
                     for event in receiver {
-                        write_frame(&mut writer, &ServerFrame::Event(event))?;
+                        write_frame(&mut writer, &ServerFrame::Event(Box::new(event)))?;
                     }
                     return Ok(());
                 } else if snapshot_only {
                     for event in events {
-                        write_frame(&mut writer, &ServerFrame::Event(event))?;
+                        write_frame(&mut writer, &ServerFrame::Event(Box::new(event)))?;
                     }
                 } else {
                     for event in events {
@@ -556,19 +556,23 @@ where
                 write_frame_async(&mut writer, &response).await?;
                 if let Some(subscription) = subscription {
                     for event in events {
-                        write_frame_async(&mut writer, &ServerFrame::Event(event)).await?;
+                        write_frame_async(&mut writer, &ServerFrame::Event(Box::new(event)))
+                            .await?;
                     }
                     let (replay, receiver) = event_bus.subscribe(subscription);
                     for event in replay {
-                        write_frame_async(&mut writer, &ServerFrame::Event(event)).await?;
+                        write_frame_async(&mut writer, &ServerFrame::Event(Box::new(event)))
+                            .await?;
                     }
                     for event in receiver {
-                        write_frame_async(&mut writer, &ServerFrame::Event(event)).await?;
+                        write_frame_async(&mut writer, &ServerFrame::Event(Box::new(event)))
+                            .await?;
                     }
                     return Ok(());
                 } else if snapshot_only {
                     for event in events {
-                        write_frame_async(&mut writer, &ServerFrame::Event(event)).await?;
+                        write_frame_async(&mut writer, &ServerFrame::Event(Box::new(event)))
+                            .await?;
                     }
                 } else {
                     for event in events {
@@ -812,7 +816,7 @@ async fn emit_event_async<W: tokio::io::AsyncWrite + Unpin>(
     event: EventEnvelope,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     publish_event(event_log, event_bus, &event);
-    write_frame_async(writer, &ServerFrame::Event(event)).await
+    write_frame_async(writer, &ServerFrame::Event(Box::new(event))).await
 }
 
 async fn write_frame_async<W: tokio::io::AsyncWrite + Unpin>(
@@ -999,7 +1003,7 @@ fn emit_event<W: Write>(
     event: EventEnvelope,
 ) -> Result<(), Box<dyn Error>> {
     publish_event(event_log, event_bus, &event);
-    write_frame(writer, &ServerFrame::Event(event))
+    write_frame(writer, &ServerFrame::Event(Box::new(event)))
 }
 
 fn publish_event(event_log: &EventLog, event_bus: &EventBus, event: &EventEnvelope) {
@@ -1437,10 +1441,10 @@ mod tests {
             })
         ));
         let session_id = match control.read_frame() {
-            ServerFrame::Event(EventEnvelope {
-                event: CadisEvent::SessionStarted(payload),
-                ..
-            }) => payload.session_id,
+            ServerFrame::Event(event) => match event.event {
+                CadisEvent::SessionStarted(payload) => payload.session_id,
+                other => panic!("expected session.started event, got {other:?}"),
+            },
             other => panic!("expected session.started event, got {other:?}"),
         };
 
@@ -1807,7 +1811,7 @@ mod tests {
                 let frame = self.read_frame();
                 if let ServerFrame::Event(event) = frame {
                     if predicate(&event) {
-                        return event;
+                        return *event;
                     }
                 }
                 assert!(

--- a/crates/cadis-hud/src/main.rs
+++ b/crates/cadis-hud/src/main.rs
@@ -220,7 +220,7 @@ impl HudApp {
         match frame {
             ServerFrame::Response(response) => match response.response {
                 DaemonResponse::DaemonStatus(status) => {
-                    self.daemon_status = Some(status);
+                    self.daemon_status = Some(*status);
                 }
                 DaemonResponse::RequestRejected(error) => {
                     self.messages
@@ -231,7 +231,7 @@ impl HudApp {
                     // Not yet implemented in legacy HUD
                 }
             },
-            ServerFrame::Event(event) => self.apply_event(event),
+            ServerFrame::Event(event) => self.apply_event(*event),
         }
     }
 

--- a/crates/cadis-protocol/src/lib.rs
+++ b/crates/cadis-protocol/src/lib.rs
@@ -295,18 +295,16 @@ impl ResponseEnvelope {
 }
 
 /// Newline-delimited JSON frame sent by `cadisd`.
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "frame", content = "payload", rename_all = "snake_case")]
 pub enum ServerFrame {
     /// Immediate response to a request.
     Response(ResponseEnvelope),
     /// Runtime event emitted by the daemon.
-    Event(EventEnvelope),
+    Event(Box<EventEnvelope>),
 }
 
 /// Immediate response returned for request handling failures or acknowledgements.
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "type", content = "payload")]
 pub enum DaemonResponse {
@@ -315,13 +313,13 @@ pub enum DaemonResponse {
     RequestAccepted(RequestAcceptedPayload),
     /// Current daemon status.
     #[serde(rename = "daemon.status.response")]
-    DaemonStatus(DaemonStatusPayload),
+    DaemonStatus(Box<DaemonStatusPayload>),
     /// Request was rejected before execution.
     #[serde(rename = "request.rejected")]
     RequestRejected(ErrorPayload),
     /// Worker artifact file content.
     #[serde(rename = "worker.artifact.read.response")]
-    WorkerArtifactRead(WorkerArtifactReadResponse),
+    WorkerArtifactRead(Box<WorkerArtifactReadResponse>),
 }
 
 /// Acknowledgement payload for accepted requests.
@@ -2605,7 +2603,7 @@ mod tests {
     fn server_response_frame_matches_transport_shape() {
         let frame = ServerFrame::Response(ResponseEnvelope::new(
             RequestId::from("req_1"),
-            DaemonResponse::DaemonStatus(DaemonStatusPayload {
+            DaemonResponse::DaemonStatus(Box::new(DaemonStatusPayload {
                 status: "ok".to_owned(),
                 version: "0.1.0".to_owned(),
                 protocol_version: ProtocolVersion::current(),
@@ -2615,7 +2613,7 @@ mod tests {
                 model_provider: "echo".to_owned(),
                 uptime_seconds: 3,
                 voice: VoiceStatusPayload::default(),
-            }),
+            })),
         ));
 
         let value = serde_json::to_value(&frame).expect("frame should serialize");


### PR DESCRIPTION

### What's going on?

Right now, `ServerFrame` and `DaemonResponse` carry `#[allow(clippy::large_enum_variant)]` annotations to silence a legitimate warning: some variants are *significantly* larger than others, which means every instance of the enum pays the stack cost of the largest variant — even when it's holding a tiny one.

This PR removes those suppressions and properly boxes the large variants instead.

### The Problem

Rust enums are sized to their largest variant. When one variant is 300+ bytes and another is 16, every `ServerFrame` on the stack (or in a `Vec`, channel, etc.) wastes the difference. On hot paths like event publishing and frame serialization, this adds up — both in stack pressure and cache utilization.

Clippy flags this with `clippy::large_enum_variant`, and the current codebase suppresses it rather than fixing it.

### What Changed

**`crates/cadis-protocol/src/lib.rs`**
- `ServerFrame::Event` now wraps `Box<EventEnvelope>` instead of a bare `EventEnvelope`
- `DaemonResponse::DaemonStatus` now wraps `Box<DaemonStatusPayload>`
- `DaemonResponse::WorkerArtifactRead` now wraps `Box<WorkerArtifactReadResponse>`
- Removed both `#[allow(clippy::large_enum_variant)]` annotations

**`crates/cadis-daemon/src/main.rs`**
- All `ServerFrame::Event(...)` construction sites updated to use `Box::new(...)`
- Pattern matches updated where destructuring is needed
- Async and sync `emit_event` paths both adapted

**`crates/cadis-core/src/lib.rs`**
- `DaemonStatusPayload` construction in `status()` and test suites wrapped with `Box::new()`

**`crates/cadis-hud/src/main.rs`**
- `apply_frame` updated to dereference the boxed `DaemonStatus` and `Event` payloads

**`crates/cadis-cli/src/main.rs`**
- `daemon_status()` return adjusted: `Some(status)` → `Some(status.as_ref())` to correctly deref `&Box<T>` into `&T`
- Field access in other pattern matches works transparently via Rust's auto-deref

### Why This Is Safe

`Box<T>` is transparent to serde — `#[derive(Serialize, Deserialize)]` handles it automatically. This means the wire format doesn't change at all. Existing clients, stored events, and serialized frames remain fully compatible.

### How to Verify

```bash
cargo test --workspace
cargo clippy --workspace -- -D warnings
```

The `clippy::large_enum_variant` warning should no longer fire, and no new warnings should appear.
```