### PR TITLE
fix(models): redact openai_api_key in ModelRouterConfig Debug output

### DIFF
--- a/crates/cadis-models/src/lib.rs
+++ b/crates/cadis-models/src/lib.rs
@@ -1656,7 +1656,7 @@ impl ModelProvider for RoutingModelProvider {
 }
 
 /// Configuration used by the provider router.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct ModelRouterConfig {
     /// Default provider from `[model].provider`.
     pub default_provider: String,
@@ -1670,6 +1670,19 @@ pub struct ModelRouterConfig {
     pub openai_model: String,
     /// Optional OpenAI API key from the environment.
     pub openai_api_key: Option<String>,
+}
+
+impl std::fmt::Debug for ModelRouterConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModelRouterConfig")
+            .field("default_provider", &self.default_provider)
+            .field("ollama_endpoint", &self.ollama_endpoint)
+            .field("ollama_model", &self.ollama_model)
+            .field("openai_base_url", &self.openai_base_url)
+            .field("openai_model", &self.openai_model)
+            .field("openai_api_key", &self.openai_api_key.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## What

ModelRouterConfig derives Debug, which prints openai_api_key in plaintext. RoutingModelProvider contains ModelRouterConfig and also derives Debug, so the key leaks transitively too.

## Why

OpenAiProvider already has a manual Debug impl that redacts its key (line 766-775). ModelRouterConfig is the struct where the key originates, and it doesn't follow the same pattern.

## What changed

- Removed Debug from ModelRouterConfig derive macro
- Added manual Debug impl that redacts openai_api_key as [REDACTED]

## Testing

No runtime behavior changes.