### PR TITLE
fix(core): validate workspace boundary for file.list entries and search index

### DIFF
--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -5296,6 +5296,12 @@ impl Runtime {
         for entry in entries {
             let entry = entry.map_err(|e| tool_error("file_list_failed", e.to_string(), false))?;
             let meta = entry.metadata().ok();
+            // Skip entries whose canonical path escapes the workspace (symlink defense).
+            if let Ok(canonical) = entry.path().canonicalize() {
+                if !canonical.starts_with(workspace) {
+                    continue;
+                }
+            }
             let is_dir = meta.as_ref().map(|m| m.is_dir()).unwrap_or(false);
             let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
             let name = entry.file_name().to_string_lossy().to_string();

--- a/crates/cadis-core/src/search_index.rs
+++ b/crates/cadis-core/src/search_index.rs
@@ -53,18 +53,26 @@ impl SearchIndex {
                     continue;
                 }
                 let path = entry.path();
+                // Canonicalize to resolve symlinks and verify the path stays inside the workspace.
+                let canonical = match path.canonicalize() {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+                if !canonical.starts_with(root) {
+                    continue;
+                }
                 let Ok(meta) = entry.metadata() else { continue };
                 if meta.is_dir() {
-                    stack.push(path);
+                    stack.push(canonical);
                 } else if meta.is_file() && meta.len() <= MAX_FILE_SIZE {
-                    let Ok(content) = fs::read(&path) else {
+                    let Ok(content) = fs::read(&canonical) else {
                         continue;
                     };
                     if is_binary(&content) {
                         continue;
                     }
                     let trigrams = extract_trigrams(&content);
-                    entries.push(IndexEntry { path, trigrams });
+                    entries.push(IndexEntry { path: canonical, trigrams });
                 }
             }
         }


### PR DESCRIPTION
## What

file.list and SearchIndex::build could follow symlinks that escape the workspace boundary. A symlink inside the workspace pointing outside would leak file metadata (names, sizes) for paths outside the registered workspace.

## Why

file.read and execute_file_search already canonicalize paths and check starts_with(workspace). file.list and the search index walker didn't do this, creating an inconsistency.

## What changed

- execute_file_list: Added canonicalization + workspace boundary check for each entry. Entries whose resolved path escapes the workspace are skipped.
- SearchIndex::build: Canonicalize each path before following it. Skip entries outside the workspace root. Use canonicalized paths for directory traversal and index entries.

## Testing

- Existing tests should pass (no behavior change for normal files)
- A symlink pointing outside the workspace is now filtered out in file.list results and excluded from the search index