### PR TITLE
fix(core): validate workspace boundary for git.worktree tools

### DIFF
--- a/crates/cadis-core/src/lib.rs
+++ b/crates/cadis-core/src/lib.rs
@@ -5168,7 +5168,7 @@ impl Runtime {
             ));
         }
 
-        let resolved = workspace.join(&path);
+        let resolved = resolve_git_worktree_path(workspace, &path)?;
 
         // Try with -b first (new branch); fall back to existing branch.
         let output = Command::new("git")
@@ -5246,7 +5246,7 @@ impl Runtime {
             )
         })?;
 
-        let resolved = workspace.join(&path);
+        let resolved = resolve_git_worktree_path(workspace, &path)?;
 
         let output = Command::new("git")
             .args(["worktree", "remove", &resolved.to_string_lossy(), "--force"])
@@ -9899,6 +9899,87 @@ mod tests {
                 CadisEvent::ToolFailed(payload)
                     if payload.tool_name == "file.patch"
                         && payload.error.code == "workspace_grant_required"
+            )
+        }));
+        assert!(!outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ApprovalRequested(_))));
+    }
+
+    #[test]
+    fn git_worktree_create_rejects_outside_workspace_path() {
+        let workspace = test_workspace("git-worktree-create-outside");
+        fs::write(workspace.join("README.md"), "hello\n").expect("test file should write");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "git-worktree-create-outside", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "git-worktree-create-outside",
+            vec![WorkspaceAccess::Write],
+        );
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_git_worktree_create_outside"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "git.worktree.create".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "git-worktree-create-outside",
+                    "branch": "feature/escape",
+                    "path": "../outside-worktree"
+                }),
+            }),
+        ));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolFailed(payload)
+                    if payload.tool_name == "git.worktree.create"
+                        && payload.error.code == "outside_workspace"
+            )
+        }));
+        assert!(!outcome
+            .events
+            .iter()
+            .any(|event| matches!(event.event, CadisEvent::ApprovalRequested(_))));
+    }
+
+    #[test]
+    fn git_worktree_remove_rejects_outside_workspace_path() {
+        let workspace = test_workspace("git-worktree-remove-outside");
+        fs::write(workspace.join("README.md"), "hello\n").expect("test file should write");
+        let mut runtime = runtime();
+        register_workspace(&mut runtime, "git-worktree-remove-outside", &workspace);
+        grant_workspace(
+            &mut runtime,
+            "git-worktree-remove-outside",
+            vec![WorkspaceAccess::Write],
+        );
+
+        let outcome = runtime.handle_request(RequestEnvelope::new(
+            RequestId::from("req_git_worktree_remove_outside"),
+            ClientId::from("cli_1"),
+            ClientRequest::ToolCall(ToolCallRequest {
+                session_id: None,
+                agent_id: None,
+                tool_name: "git.worktree.remove".to_owned(),
+                input: serde_json::json!({
+                    "workspace_id": "git-worktree-remove-outside",
+                    "path": "../outside-worktree"
+                }),
+            }),
+        ));
+
+        assert!(outcome.events.iter().any(|event| {
+            matches!(
+                &event.event,
+                CadisEvent::ToolFailed(payload)
+                    if payload.tool_name == "git.worktree.remove"
+                        && payload.error.code == "outside_workspace"
             )
         }));
         assert!(!outcome

--- a/crates/cadis-core/src/tools.rs
+++ b/crates/cadis-core/src/tools.rs
@@ -957,6 +957,72 @@ pub(crate) fn is_secret_config_value(value: &str) -> bool {
         || lower.contains("private_key=")
 }
 
+pub(crate) fn resolve_git_worktree_path(
+    workspace: &Path,
+    user_path: &str,
+) -> Result<PathBuf, ErrorPayload> {
+    let trimmed = user_path.trim();
+    if trimmed.is_empty() {
+        return Err(tool_error(
+            "invalid_tool_input",
+            "git worktree path cannot be empty",
+            false,
+        ));
+    }
+
+    let relative = Path::new(trimmed);
+    if relative.is_absolute() || path_has_parent_or_root(relative) {
+        return Err(tool_error(
+            "outside_workspace",
+            "git worktree path must be relative to the workspace",
+            false,
+        ));
+    }
+
+    let workspace = workspace.canonicalize().map_err(|error| {
+        tool_error(
+            "path_resolution_failed",
+            format!("could not resolve workspace: {error}"),
+            false,
+        )
+    })?;
+    let candidate = workspace.join(relative);
+    if let Ok(resolved) = candidate.canonicalize() {
+        if !resolved.starts_with(&workspace) {
+            return Err(tool_error(
+                "outside_workspace",
+                "git worktree path resolves outside the workspace",
+                false,
+            ));
+        }
+        return Ok(resolved);
+    }
+
+    let parent = candidate.parent().ok_or_else(|| {
+        tool_error(
+            "invalid_tool_input",
+            "git worktree path must have a parent directory",
+            false,
+        )
+    })?;
+    let parent = parent.canonicalize().map_err(|error| {
+        tool_error(
+            "path_resolution_failed",
+            format!("could not resolve git worktree parent: {error}"),
+            false,
+        )
+    })?;
+    if !parent.starts_with(&workspace) {
+        return Err(tool_error(
+            "outside_workspace",
+            "git worktree parent resolves outside the workspace",
+            false,
+        ));
+    }
+
+    Ok(candidate)
+}
+
 pub(crate) fn validate_git_pathspec(pathspec: &str) -> Result<String, ErrorPayload> {
     let trimmed = pathspec.trim();
     if trimmed.is_empty() {
@@ -1106,5 +1172,37 @@ pub(crate) fn tool_error(
         code: code.into(),
         message: redact(&message.into()),
         retryable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn resolve_git_worktree_path_rejects_parent_dir_escape() {
+        let workspace = std::env::temp_dir().join(format!(
+            "cadis-worktree-path-test-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&workspace).expect("workspace dir should exist");
+        let error = resolve_git_worktree_path(&workspace, "../outside")
+            .expect_err("parent dir path should be rejected");
+        assert_eq!(error.code, "outside_workspace");
+        let _ = fs::remove_dir_all(&workspace);
+    }
+
+    #[test]
+    fn resolve_git_worktree_path_accepts_relative_child() {
+        let workspace = std::env::temp_dir().join(format!(
+            "cadis-worktree-path-test-child-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&workspace).expect("workspace dir should exist");
+        let resolved =
+            resolve_git_worktree_path(&workspace, "worktrees/feature").expect("valid child path");
+        assert!(resolved.starts_with(workspace.canonicalize().expect("workspace canonical")));
+        let _ = fs::remove_dir_all(&workspace);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds workspace boundary validation to `git.worktree.create` and `git.worktree.remove` before either tool shells out to `git worktree`.

Right now both tools take a user-supplied `path`, join it against the registered workspace root, and pass the result straight to git. There is no check that the resolved location stays inside the workspace. A relative path like `../../outside-worktree` can therefore reach filesystem locations outside the caller's granted workspace. For `git.worktree.remove`, the hardcoded `--force` flag makes that worse because git's own safety checks for dirty worktrees are bypassed.

Other workspace tools already enforce containment. `file.read`, `file.patch`, and `git.diff` path handling reject parent-dir escapes and verify resolved paths against the workspace root. Worker apply flows use `validate_worker_apply_repo_path` for the same reason. The worktree tools were the odd ones out.

## Motivation

This came out of a repository-wide security review of CADIS. Path traversal in git worktree operations was flagged as a high-priority finding because:

- The daemon exposes these tools to protocol clients with workspace grants.
- Both operations are approval-gated, but path traversal is invisible to whoever approves the action.
- `git.worktree.remove --force` can delete worktrees the caller should not be able to touch.

The goal here is a small, behavior-preserving hardening change: block escapes early, fail closed, and keep the fix consistent with how the rest of the tool runtime handles workspace-relative paths.

## What changed

### New helper: `resolve_git_worktree_path`

Added in `crates/cadis-core/src/tools.rs`.

The helper:

1. Rejects empty paths.
2. Rejects absolute paths and any path containing `..`, root, or Windows prefix components.
3. Canonicalizes the workspace root.
4. Joins the relative path and checks containment:
   - If the target already exists, canonicalizes it and verifies `starts_with(workspace)`.
   - If the target does not exist yet (common for `git.worktree.create`), canonicalizes the parent directory and verifies the parent stays inside the workspace.

This mirrors the containment model used by `resolve_file_patch_target`, adapted for worktree directory paths instead of single files.

### Tool execution updates

`execute_git_worktree_create` and `execute_git_worktree_remove` in `crates/cadis-core/src/lib.rs` now call `resolve_git_worktree_path(workspace, &path)?` instead of doing a raw `workspace.join(&path)`.

No changes to branch-name validation, git command arguments, approval flow, or protocol surface.

## Behavior notes

- Valid relative paths inside the workspace behave the same as before.
- Traversal attempts fail with `outside_workspace` before git is invoked.
- The error surfaces through the existing `ToolFailed` event path, same as `file.patch` and `git.diff` rejections.
- No new protocol fields, config knobs, or migration steps.

## Testing

Added coverage at two levels:

**Unit tests** (`tools.rs`):
- `resolve_git_worktree_path_rejects_parent_dir_escape`
- `resolve_git_worktree_path_accepts_relative_child`

**Integration tests** (`lib.rs`):
- `git_worktree_create_rejects_outside_workspace_path`
- `git_worktree_remove_rejects_outside_workspace_path`

Both integration tests register a workspace, grant write access, send a tool call with `path: "../outside-worktree"`, and assert:
- `ToolFailed` with code `outside_workspace`
- No `ApprovalRequested` event (failure happens before approval)

I was not able to run `cargo test` locally on Windows because the MSVC linker (`link.exe`) is not installed in my environment. CI on Linux should be the authoritative check for this branch.

## Risk / compatibility

**Risk level:** Low to medium.

- Low for normal in-workspace worktree usage.
- Medium only in the sense that previously accepted malicious paths will now be rejected. That is intentional.

No breaking change for legitimate callers that already pass workspace-relative paths like `worktrees/feature-a` or `.cadis/worktrees/...`.

## Related issues

- Closes #65 (`git.worktree.remove` path validation)
- Closes #66 (`git.worktree.create` path validation)

## Checklist

- [x] Fails closed on path traversal before git execution
- [x] Matches existing workspace containment patterns
- [x] Adds unit and integration tests
- [ ] CI green (pending PR creation)