### PR TITLE
docs: sync crates README and KNOWN_LIMITATIONS

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -1,15 +1,26 @@
 # Crates
 
-Rust workspace crates will live here.
+Rust workspace crates for C.A.D.I.S.
 
-Planned first crates:
+## Core runtime
 
-- `cadis-protocol` - typed requests, responses, events, versioning, serialization
-- `cadis-avatar` - renderer-independent Wulan avatar state engine, gesture model, face-tracking privacy config, wgpu-first renderer contract, and feature-gated adapter-ready wgpu render-plan spike
-- `cadis-core`
-- `cadis-daemon`
-- `cadis-cli`
-- `cadis-store`
-- `cadis-policy`
+- `cadis-protocol` — typed requests, responses, events, versioning, and serialization
+- `cadis-core` — daemon runtime: agents, tools, orchestration, voice, and workspace logic
+- `cadis-daemon` — `cadisd` binary and transport listeners
+- `cadis-cli` — `cadis` command-line client
+- `cadis-store` — local config, state layout, redaction, and JSONL logs
+- `cadis-policy` — risk classification, approvals policy, and path guards
+- `cadis-models` — model provider adapters and routing helpers
 
-Crates should be added only when implementation starts and each crate has a clear responsibility.
+## Clients and surfaces
+
+- `cadis-hud` — legacy eframe HUD prototype (canonical desktop HUD is `apps/cadis-hud`)
+- `cadis-telegram` — Telegram adapter and daemon bridge
+- `cadis-avatar` — Wulan avatar state engine and renderer contracts
+
+## Supporting crates
+
+- `cadis-memory` — memory subsystem helpers
+- `cadis-output-filter` — output filtering and redaction utilities
+
+Each crate should keep a single clear responsibility. Add new crates only when a boundary is stable enough to justify a separate package.

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -1,6 +1,6 @@
 # Known Limitations
 
-This document lists known limitations of C.A.D.I.S. v1.1.x.
+This document lists known limitations of C.A.D.I.S. v1.2.x.
 
 ## Platform
 
@@ -49,8 +49,9 @@ This document lists known limitations of C.A.D.I.S. v1.1.x.
   inline logic. Further decomposition is ongoing.
 - **Worker artifact view in HUD is read-only.** Apply/discard actions route
   through daemon approval but the full patch-apply flow needs more work.
-- **`file.patch` lacks atomic writes.** Structured file patching works but does
-  not yet use atomic temp-file writes or concurrent-edit protection.
+- **`file.patch` concurrent-edit detection is basic.** Structured file patching
+  uses atomic temp-file writes, but concurrent-edit conflict detection remains
+  simple and may not cover all race conditions.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Two documentation cleanups that do not change runtime behavior.

1. `crates/README.md` still describes workspace crates as "planned" even though all 12 crates already exist and are part of the workspace.
2. `docs/KNOWN_LIMITATIONS.md` still references `v1.1.x` and claims `file.patch` lacks atomic writes, which is no longer accurate on `main`.

This PR brings both docs in line with the current repository state.

## Motivation

### `crates/README.md`

New contributors landing in `crates/` get the wrong picture. The README says crates "will live here" and lists only the original skeleton set as planned work. In reality the workspace already contains:

- Core runtime crates (`cadis-protocol`, `cadis-core`, `cadis-daemon`, `cadis-cli`, `cadis-store`, `cadis-policy`, `cadis-models`)
- Client/surface crates (`cadis-hud`, `cadis-telegram`, `cadis-avatar`)
- Supporting crates (`cadis-memory`, `cadis-output-filter`)

Accurate crate docs at the workspace root make it easier to understand boundaries before diving into `cadis-core`.

### `docs/KNOWN_LIMITATIONS.md`

The limitations doc is meant to reflect what users and contributors should still expect from the product. Two entries had drifted:

**Version header**
- Said `v1.1.x`
- Current crate version on `main` is `1.2.3`

**`file.patch` limitation**
- Said patching "does not yet use atomic temp-file writes or concurrent-edit protection"
- Current implementation in `cadis-core` already writes through a temp file and renames into place, with basic mtime-based concurrent-edit detection

Leaving that text in place misleads reviewers and makes it harder to spot what is actually still missing.

## What changed

### `crates/README.md`

Replaced the placeholder text with a grouped inventory of all 12 workspace crates, each with a one-line responsibility summary:

- **Core runtime** — protocol, core, daemon, cli, store, policy, models
- **Clients and surfaces** — legacy HUD crate, telegram adapter, avatar engine
- **Supporting crates** — memory and output-filter helpers

Also noted that the canonical desktop HUD lives under `apps/cadis-hud`, not the legacy `crates/cadis-hud` eframe prototype.

### `docs/KNOWN_LIMITATIONS.md`

- Updated the version reference from `v1.1.x` to `v1.2.x`
- Replaced the outdated `file.patch` bullet with wording that matches current behavior:
  - Atomic temp-file writes are in place
  - Concurrent-edit detection exists but remains basic and may not cover every race

No other limitation sections were rewritten in this PR. Voice, Telegram, cancellation, and platform caveats were left as-is because they still reflect real gaps.

## What this PR does not do

- No code changes
- No protocol or config changes
- No wiki updates (`wiki/Home.md` version drift is tracked separately in #82)
- No attempt to rewrite the entire limitations document

## Testing

Docs-only change. Verified by reading the updated files against current `main` source:

- `crates/*/Cargo.toml` workspace membership
- `execute_file_patch` in `crates/cadis-core/src/lib.rs` (temp write + rename path)

No `cargo test` run required for this PR.

## Risk / compatibility

**Risk level:** None.

Pure documentation. Safe to merge anytime.

## Related issues

- Closes #84 (`crates/README.md` says crates are planned despite all 12 existing)
- Also addresses stale `file.patch` wording in `KNOWN_LIMITATIONS.md` (no dedicated issue filed for that bullet)

## Checklist

- [x] `crates/README.md` lists all current workspace crates
- [x] `KNOWN_LIMITATIONS.md` version header updated
- [x] `file.patch` limitation text matches implementation
- [x] No runtime files modified