### PR TITLE
fix(event-bus): restrict EventFilter::All to non-session events only

### DIFF
--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -1067,7 +1067,7 @@ enum EventFilter {
 impl EventFilter {
     fn matches(&self, event: &EventEnvelope) -> bool {
         match self {
-            Self::All => true,
+            Self::All => event.session_id.is_none(),
             Self::Session(session_id) => event.session_id.as_ref() == Some(session_id),
         }
     }


### PR DESCRIPTION
### Problem

The daemon's EventBus lets clients subscribe to runtime events. Two subscription paths exist:

1. `EventsSubscribe` — uses `EventFilter::All`, intended for daemon-level monitoring
2. `SessionSubscribe` — uses `EventFilter::Session(session_id)`, scoped to one session

The problem: `EventFilter::All` matches every single event, including those tagged with a `session_id`. A client that calls `EventsSubscribe` receives message deltas, tool output, approval requests, and orchestrator routing events from all active sessions, not just daemon-level events.

There is no authentication between clients, and the server does not enforce any session boundary on `All` subscribers.

### Root Cause

`EventFilter::matches()` in `crates/cadis-daemon/src/main.rs:1068`:

```rust
Self::All => true,  // matches everything, including session-scoped events
```

### Fix

Changed the `All` match arm to only match events where `session_id` is `None`:

```rust
Self::All => event.session_id.is_none(),
```

Runtime events like `daemon.started`, `daemon.status`, and approval broadcasts don't carry a `session_id`, so they still reach `All` subscribers. Session-scoped events (message deltas, agent routing, tool events) are now only delivered to subscribers that explicitly asked for that session.

### Backward Compatibility

- `EventsSubscribe` still works for its intended purpose: daemon-level monitoring.
- `SessionSubscribe` is unaffected — it always used `EventFilter::Session`.
- Any client that legitimately needs cross-session event visibility must switch to subscribing per-session.

### Validation

- Existing EventBus unit tests cover both `EventFilter::All` (used for runtime events without `session_id`) and `EventFilter::Session` paths.
- Integration tests using `SessionSubscribe` at the socket level continue to work — they explicitly pass `session_id` and use `EventFilter::Session`.
- I couldn't run `cargo test` due to a missing MSVC linker on this machine, but the change is a single expression swap with no new codepaths.

### Risk

Low. The change narrows existing behavior. Test coverage for both filter paths exists in the same file. No new dependencies or configuration.