### PR TITLE
fix(protocol): add #[serde(deny_unknown_fields)] to all request structs

### DIFF
--- a/crates/cadis-protocol/src/lib.rs
+++ b/crates/cadis-protocol/src/lib.rs
@@ -208,6 +208,7 @@ impl Error for ProtocolError {}
 
 /// Request envelope sent by a client to `cadisd`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RequestEnvelope {
     /// Protocol version used by the client.
     pub protocol_version: ProtocolVersion,
@@ -488,6 +489,7 @@ pub enum ClientRequest {
 
 /// Payload for subscribing to daemon runtime events.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct EventSubscriptionRequest {
     /// Optional event ID. Buffered replay starts after this ID when still retained.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -512,6 +514,7 @@ impl Default for EventSubscriptionRequest {
 
 /// Payload for requesting a one-shot daemon-owned runtime state snapshot.
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct EventsSnapshotRequest {}
 
 fn default_true() -> bool {
@@ -520,6 +523,7 @@ fn default_true() -> bool {
 
 /// Payload for creating a session.
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SessionCreateRequest {
     /// Optional user-facing session title.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -531,6 +535,7 @@ pub struct SessionCreateRequest {
 
 /// Payload that targets one session.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SessionTargetRequest {
     /// Target session ID.
     pub session_id: SessionId,
@@ -538,6 +543,7 @@ pub struct SessionTargetRequest {
 
 /// Payload for subscribing to one session's event stream.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SessionSubscriptionRequest {
     /// Target session ID.
     pub session_id: SessionId,
@@ -554,6 +560,7 @@ pub struct SessionSubscriptionRequest {
 
 /// Payload for a user message.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MessageSendRequest {
     /// Optional existing session ID.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -569,6 +576,7 @@ pub struct MessageSendRequest {
 
 /// Payload for an approval response.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ApprovalResponseRequest {
     /// Target approval ID.
     pub approval_id: ApprovalId,
@@ -581,6 +589,7 @@ pub struct ApprovalResponseRequest {
 
 /// Payload for requesting daemon-owned tool execution.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ToolCallRequest {
     /// Optional session this tool call belongs to.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -597,6 +606,7 @@ pub struct ToolCallRequest {
 
 /// Payload for agent rename.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AgentRenameRequest {
     /// Target agent ID.
     pub agent_id: AgentId,
@@ -606,6 +616,7 @@ pub struct AgentRenameRequest {
 
 /// Payload for selecting an agent model.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AgentModelSetRequest {
     /// Target agent ID.
     pub agent_id: AgentId,
@@ -615,6 +626,7 @@ pub struct AgentModelSetRequest {
 
 /// Payload for selecting an agent specialist persona.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AgentSpecialistSetRequest {
     /// Target agent ID.
     pub agent_id: AgentId,
@@ -628,6 +640,7 @@ pub struct AgentSpecialistSetRequest {
 
 /// Payload for agent spawn.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AgentSpawnRequest {
     /// Agent role identifier.
     pub role: String,
@@ -644,6 +657,7 @@ pub struct AgentSpawnRequest {
 
 /// Payload that targets one agent.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AgentTargetRequest {
     /// Target agent ID.
     pub agent_id: AgentId,
@@ -651,6 +665,7 @@ pub struct AgentTargetRequest {
 
 /// Payload for tailing an agent's recent session events.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AgentTailRequest {
     /// Target agent ID.
     pub agent_id: AgentId,
@@ -661,6 +676,7 @@ pub struct AgentTailRequest {
 
 /// Payload for tailing worker output.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkerTailRequest {
     /// Worker identifier.
     pub worker_id: String,
@@ -671,6 +687,7 @@ pub struct WorkerTailRequest {
 
 /// Payload for collecting a worker terminal result.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkerResultRequest {
     /// Worker identifier.
     pub worker_id: String,
@@ -678,6 +695,7 @@ pub struct WorkerResultRequest {
 
 /// Payload for requesting worker worktree cleanup planning.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkerCleanupRequest {
     /// Worker identifier.
     pub worker_id: String,
@@ -689,6 +707,7 @@ pub struct WorkerCleanupRequest {
 
 /// Payload for requesting approval-gated worker patch application.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkerApplyRequest {
     /// Worker identifier.
     pub worker_id: String,
@@ -700,6 +719,7 @@ pub struct WorkerApplyRequest {
 
 /// Payload for reading a worker artifact file content.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkerArtifactReadRequest {
     /// Worker identifier.
     pub worker_id: String,
@@ -722,6 +742,7 @@ pub struct WorkerArtifactReadResponse {
 
 /// Payload for listing registered workspaces.
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkspaceListRequest {
     /// Include active grants in the response.
     #[serde(default)]
@@ -730,6 +751,7 @@ pub struct WorkspaceListRequest {
 
 /// Payload for registering a project workspace root.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkspaceRegisterRequest {
     /// Stable workspace identifier.
     pub workspace_id: WorkspaceId,
@@ -756,6 +778,7 @@ pub struct WorkspaceRegisterRequest {
 
 /// Payload for granting workspace access.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkspaceGrantRequest {
     /// Agent receiving access. Missing means the default local runtime context.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -775,6 +798,7 @@ pub struct WorkspaceGrantRequest {
 
 /// Payload for revoking workspace grants.
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkspaceRevokeRequest {
     /// Revoke a specific grant.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -789,6 +813,7 @@ pub struct WorkspaceRevokeRequest {
 
 /// Payload for workspace registry health checks.
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WorkspaceDoctorRequest {
     /// Check a registered workspace by ID.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -800,6 +825,7 @@ pub struct WorkspaceDoctorRequest {
 
 /// Payload for patching UI preferences.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct UiPreferencesSetRequest {
     /// Partial preference object owned by `cadisd`.
     pub patch: serde_json::Value,
@@ -807,6 +833,7 @@ pub struct UiPreferencesSetRequest {
 
 /// Voice preview payload.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct VoicePreviewRequest {
     /// Text to preview.
     pub text: String,
@@ -830,6 +857,7 @@ pub struct VoicePreferences {
 
 /// Request payload for daemon-visible voice diagnostics.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct VoiceDoctorRequest {
     /// Include the last local bridge preflight in the result when available.
     #[serde(default = "default_true")]
@@ -846,6 +874,7 @@ impl Default for VoiceDoctorRequest {
 
 /// Request payload used by a local bridge to publish preflight results.
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct VoicePreflightRequest {
     /// Client or bridge that performed the checks, for example `cadis-hud`.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
### Problem

The protocol layer between `cadis` CLI and `cadisd` daemon accepts JSON over TCP, Unix sockets, or stdio. Every deserializable struct uses serde with `#[derive(Deserialize)]`, but none of them reject unknown fields.

This means a client can send arbitrary extra fields in any request, and serde silently ignores them. On its own this is mostly a hygiene issue, but combined with `#[serde(flatten)]` on the envelope structs it creates a real attack surface:

- `RequestEnvelope` flattens `ClientRequest` into the top-level JSON object
- `DaemonResponse` and `EventEnvelope` do the same on the response side
- Unknown fields that happen to shadow or collide with flattened variant fields could cause deserialization confusion

There is also the practical concern: when you add a new field to a request struct, you want to catch stale callers immediately. Without `deny_unknown_fields`, an outdated client silently drops the new field and proceeds with a partial request.

### Scope

I added `#[serde(deny_unknown_fields)]` to every `*Request` struct in `crates/cadis-protocol/src/lib.rs`:

| Category | Structs affected |
|----------|-----------------|
| Session | `SessionCreateRequest`, `SessionTargetRequest`, `SessionSubscriptionRequest` |
| Events | `EventSubscriptionRequest`, `EventsSnapshotRequest` |
| Messages | `MessageSendRequest` |
| Approvals | `ApprovalResponseRequest` |
| Tools | `ToolCallRequest` |
| Agents | `AgentRenameRequest`, `AgentModelSetRequest`, `AgentSpecialistSetRequest`, `AgentSpawnRequest`, `AgentTargetRequest`, `AgentTailRequest` |
| Workers | `WorkerTailRequest`, `WorkerResultRequest`, `WorkerCleanupRequest`, `WorkerApplyRequest`, `WorkerArtifactReadRequest` |
| Workspaces | `WorkspaceListRequest`, `WorkspaceRegisterRequest`, `WorkspaceGrantRequest`, `WorkspaceRevokeRequest`, `WorkspaceDoctorRequest` |
| UI | `UiPreferencesSetRequest` |
| Voice | `VoicePreviewRequest`, `VoiceDoctorRequest`, `VoicePreflightRequest` |
| Envelope | `RequestEnvelope` |

That is 29 structs in total.

### What I did NOT touch

- `ResponseEnvelope`, `EventEnvelope`, and all response/event payload structs (`*Payload`, `*Response`). These are serialized by the daemon and consumed by clients. Adding `deny_unknown_fields` there would break forward compatibility if the daemon adds new fields before the client updates.
- The `string_id!` macro types (`RequestId`, `SessionId`, etc.). These are newtype wrappers with a single field and serde already requires an exact match for newtype structs.
- `VoicePreferences` — this is shared between requests and responses, so I left it off to keep the client compatible.

### Backward Compatibility

This is a strict parsing change. Clients that send extra fields in any request will get a deserialization error instead of silent field dropping. The `cadis` CLI that ships with the same protocol version does not send unknown fields, so normal operation is unaffected.

If you maintain an external client, make sure it only sends the documented fields.

### Validation

- The change is purely additive — 29 `#[serde(deny_unknown_fields)]` attributes inserted between the derive line and the struct definition.
- No logic changes, no new dependencies.
- I couldn't run `cargo test` due to a missing MSVC linker, but the existing protocol tests should pass since they construct valid requests with only the expected fields.

### Risk

Low-medium. The strict parsing could surface latent bugs in the CLI or in tests that accidentally send extra fields. If any test breaks, the fix is to remove the extraneous field from the test data.