### PR TITLE
fix(daemon): register SIGTERM/SIGINT handlers for graceful shutdown

### DIFF
--- a/crates/cadis-daemon/src/main.rs
+++ b/crates/cadis-daemon/src/main.rs
@@ -133,6 +133,38 @@ async fn run() -> Result<(), Box<dyn Error>> {
     let event_log = EventLog::new(&config);
     let event_bus = EventBus::new(EVENT_REPLAY_LIMIT);
 
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let sig_shutdown = Arc::clone(&shutdown);
+
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        tokio::spawn(async move {
+            let mut term =
+                signal(SignalKind::terminate()).expect("failed to register SIGTERM handler");
+            let mut int =
+                signal(SignalKind::interrupt()).expect("failed to register SIGINT handler");
+            tokio::select! {
+                _ = term.recv() => {
+                    eprintln!("cadisd received SIGTERM, shutting down");
+                }
+                _ = int.recv() => {
+                    eprintln!("cadisd received SIGINT, shutting down");
+                }
+            }
+            sig_shutdown.store(true, Ordering::SeqCst);
+        });
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::spawn(async move {
+            let _ = tokio::signal::ctrl_c().await;
+            eprintln!("cadisd received Ctrl+C, shutting down");
+            sig_shutdown.store(true, Ordering::SeqCst);
+        });
+    }
+
     if use_tcp {
         let addr = config.effective_tcp_address();
         let addr = tcp_port.map(|p| format!("127.0.0.1:{p}")).unwrap_or(addr);
@@ -142,6 +174,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
             event_log,
             event_bus,
             config.tcp_auth_token.clone(),
+            shutdown,
         )
         .await;
     }
@@ -150,7 +183,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
     {
         let socket_path = socket_path
             .ok_or_else(|| invalid_input("socket path required (use --tcp-port on Windows)"))?;
-        run_socket(socket_path, runtime, event_log, event_bus).await
+        run_socket(socket_path, runtime, event_log, event_bus, shutdown).await
     }
 
     #[cfg(not(unix))]
@@ -164,6 +197,7 @@ async fn run() -> Result<(), Box<dyn Error>> {
             event_log,
             event_bus,
             config.tcp_auth_token.clone(),
+            shutdown,
         )
         .await
     }
@@ -201,11 +235,11 @@ async fn run_tcp(
     event_log: EventLog,
     event_bus: EventBus,
     tcp_auth_token: Option<String>,
+    shutdown: Arc<AtomicBool>,
 ) -> Result<(), Box<dyn Error>> {
     let listener = TokioTcpListener::bind(addr).await?;
     eprintln!("cadisd listening on tcp://{addr}");
 
-    let shutdown = Arc::new(AtomicBool::new(false));
     let tcp_auth_token = tcp_auth_token.map(Arc::new);
 
     loop {
@@ -270,12 +304,11 @@ async fn run_socket(
     runtime: Arc<Mutex<Runtime>>,
     event_log: EventLog,
     event_bus: EventBus,
+    shutdown: Arc<AtomicBool>,
 ) -> Result<(), Box<dyn Error>> {
     prepare_socket_path(&socket_path)?;
     let listener = TokioUnixListener::bind(&socket_path)?;
     eprintln!("cadisd listening on {}", socket_path.display());
-
-    let shutdown = Arc::new(AtomicBool::new(false));
 
     loop {
         if shutdown.load(Ordering::SeqCst) {


### PR DESCRIPTION
### Problem

The daemon has exactly one shutdown path: a `daemon.shutdown` protocol message. Kill it with SIGTERM (systemd stop, service manager, docker stop) or SIGINT (Ctrl+C in terminal), and the process dies immediately. No cleanup, no drain, nothing.

This matters because:

1. **Temp file leaks.** `atomic_write_private_file` writes to `.cadis_patch_<pid>.tmp` then renames. Kill the process between write and rename, and the temp file stays on disk. The next run won't clean it up — it's tied to a stale PID.

2. **Event bus drops.** `EventBus::publish()` pushes to subscriber channels. An abrupt kill drops unprocessed events. Subscribers — especially the HUD and streaming CLI clients — lose the tail of their event stream.

3. **In-flight requests.** The daemon may be mid-conversation with a model provider or mid-tool-execution when killed. No cancellation, no cleanup.

4. **Socket file residue.** On Unix, the socket path is only removed in `run_socket`'s shutdown path (line 312). A SIGKILL leaves the socket file behind, causing "address already in use" on restart.

### What Changed

- Moved the `shutdown: Arc<AtomicBool>` creation from inside `run_tcp` and `run_socket` up to the `run()` function so both transport paths share the same flag.
- Added a `tokio::spawn` task in `run()` that listens for OS signals:
  - **Unix**: registers `SIGTERM` and `SIGINT` via `tokio::signal::unix`, sets `shutdown = true` on either signal
  - **Windows**: registers `ctrl_c()` via `tokio::signal`, sets `shutdown = true`
- Both `run_tcp` and `run_socket` already checked `shutdown.load()` in their accept loop and broke out when true. The signal handler just sets that flag; the existing teardown path handles the rest.

### What I Did NOT Do

- SIGKILL cannot be caught. That's a kernel-level kill and the `.tmp` files from atomic writes are a known trade-off documented elsewhere.
- SIGHUP for config reload. That's a separate feature and needs a mutex dance around the config loader. Not mixing it into this fix.

### File Layout

```
crates/cadis-daemon/src/main.rs
├── run()                  # shutdown creation + signal handler spawn (new)
├── run_tcp()              # accepts shutdown as parameter (was: created internally)
├── run_socket()           # accepts shutdown as parameter (was: created internally)
└── verify_tcp_auth()      # unchanged
```

### Risk

Low. The signal handler is a one-shot tokio task that sets an `AtomicBool`. The accept loop already reads this flag. No locking, no new state, no config changes. The only risk is on platforms where `tokio::signal::unix` is unavailable — but that code is behind `#[cfg(unix)]`, and Windows has its own `#[cfg(not(unix))]` path with `ctrl_c()`.